### PR TITLE
Make sure TruffleSOM-interp is actually the interpreter

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -97,6 +97,7 @@ executors:
     TruffleSOM-interp:
         path: .
         executable: som
+        args: " -G "
     TruffleSOM-graal:
         path: .
         executable: som


### PR DESCRIPTION
The missing `-G` was a mistake.

The results on [ReBenchDB](https://rebench.stefan-marr.de/compare/SOMns/ab38ad697262d4b96c61567d7e4e1ca83dc226c0/9adf0650b60f9b1a6a2fee61bc03177387763833) clearly shows the impact of that change for `TruffleSOM-interp`.

Most micro benchmarks benefit from avoiding interference from compilation.
The macro startup benchmarks can suffer, because they run long enough that they reach some compiled code.

/cc @sophie-kaleba