### PR TITLE
Turn frameType profile into a static

### DIFF
--- a/src/trufflesom/interpreter/nodes/ContextualNode.java
+++ b/src/trufflesom/interpreter/nodes/ContextualNode.java
@@ -32,12 +32,12 @@ import trufflesom.vmobjects.SBlock;
 
 public abstract class ContextualNode extends ExpressionNode {
 
-  protected final int        contextLevel;
-  private final ValueProfile frameType;
+  private static final ValueProfile frameType = ValueProfile.createClassProfile();
+
+  protected final int contextLevel;
 
   public ContextualNode(final int contextLevel) {
     this.contextLevel = contextLevel;
-    this.frameType = ValueProfile.createClassProfile();
   }
 
   public final int getContextLevel() {


### PR DESCRIPTION
This avoids having more profiles than necessary. It should be a single type for the materialized frames, and thus, a static profile is sufficient.

Relates to https://github.com/smarr/SOMns/issues/361

@fniephaus thanks for the hint!