### PR TITLE
Use libgraal as standard compiler

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,5 +23,5 @@ benchmark_job:
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ${ANT} jar
+    - ${ANT} compile
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf TruffleSOM

--- a/build.xml
+++ b/build.xml
@@ -47,6 +47,7 @@
     <property name="sdk.build"   location="${sdk.dir}/mxbuild/dists/jdk1.8" />
     <property name="truffle.dir"   location="${lib.dir}/truffle/truffle" />
     <property name="truffle.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
+    <property name="vm.dir"        location="${lib.dir}/truffle/vm" />
     <property name="compiler.dir"   location="${lib.dir}/truffle/compiler" />
     <property name="compiler.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
     <property name="junit.version" value="4.12" />
@@ -170,6 +171,20 @@
         </exec>
         <travis target="truffle-libs" />
     </target>
+    
+    <target name="libgraal-jdk" depends="jvmci-libs,core-lib">
+        <travis target="libgraal-jdk" start="Build LibGraal-enabled JDK" />
+        <exec executable="${mx.cmd}" dir="${vm.dir}" failonerror="true">
+            <env key="JAVA_HOME" value="${jvmci.home}" />
+            <!-- REM: This needs to match ./som -->
+            <env key="DYNAMIC_IMPORTS" value="/substratevm,/tools,/truffle,/sdk,/compiler" />
+            <env key="FORCE_BASH_LAUNCHERS" value="true" />
+            <env key="DISABLE_LIBPOLYGLOT" value="true" />
+            <env key="EXCLUDE_COMPONENTS" value="svmag,nju,nic,ni,nil" />
+            <arg line="build"/>
+        </exec>
+        <travis target="libgraal-jdk" />
+    </target>
 
     <target name="bd-libs"> <!-- implicit dependency on truffle-libs -->
         <travis target="bd-libs" start="Build Black Diamonds" />
@@ -218,7 +233,7 @@
         <echo>${jvmci.home}</echo>
     </target>
 
-    <target name="libs" depends="core-lib,truffle-libs,bd-libs">
+    <target name="libs" depends="core-lib,bd-libs">
         <get src="https://repo1.maven.org/maven2/junit/junit/${junit.version}/junit-${junit.version}.jar"
             usetimestamp="true"
             dest="${lib.dir}/junit-${junit.version}.jar" />
@@ -266,14 +281,17 @@
         <travis target="compile" />
     </target>
 
-    <target name="compile" depends="libs,som-compile" description="Compile TruffleSOM">
+    <target name="compile-for-jar" depends="truffle-libs,libs,som-compile" description="Compile TruffleSOM without LibGraal">
+    </target>
+    
+    <target name="compile" depends="libs,libgraal-jdk,som-compile" description="Compile TruffleSOM with LibGraal">
     </target>
 
-    <target name="jar" depends="compile" description="Package as JAR">
+    <target name="jar" depends="compile-for-jar" description="Package as JAR">
         <jar destfile="${build.dir}/som.jar" basedir="${classes.dir}"></jar>
     </target>
 
-    <target name="test" depends="compile" description="Execute tests">
+    <target name="test" depends="compile-for-jar" description="Execute tests">
         <travis target="test" start="test" />
 
         <junit haltonerror="false" haltonfailure="false" failureproperty="test.failed"
@@ -300,11 +318,12 @@
         <travis target="test" />
     </target>
 
-    <target name="som-test" depends="compile" description="Test som script">
+    <target name="som-test" depends="compile-for-jar" description="Test som script">
         <travis target="som-test" start="SOM Test" />
 
         <exec executable="./som" failonerror="true">
             <arg value="-G" />
+            <arg value="--no-libgraal" />
             <arg value="-cp" />
             <arg value="Smalltalk" />
             <arg value="TestSuite/TestHarness.com" />

--- a/som
+++ b/som
@@ -65,6 +65,8 @@ parser.add_argument('-G', '--interpreter', help='run without Graal',
                     dest='interpreter', action='store_true', default=False)
 parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal',
                     dest='embedded_graal', action='store_false', default=True)
+parser.add_argument('-LG', '--no-libgraal', help='run without using the embedded libgraal. Settings like JVMCI_BIN and GRAAL_HOME are ignored as long as libgraal is not disabled.',
+                    dest='use_libgraal', action='store_false', default=True)
 parser.add_argument('-X', '--java-interpreter', help='run without Graal, and only the Java interpreter',
                     dest='java_interpreter', action='store_true', default=False)
 parser.add_argument('-T', '--no-trace', help='do not print truffle compilation info',
@@ -94,13 +96,17 @@ args, unknown_args = parser.parse_known_args()
 if args.java_interpreter:
     args.interpreter = True
 
+if args.interpreter:
+    args.use_libgraal = False
+
 # Determine JVM to be used
 java_bin = None
 
-if JVMCI_BIN:
-  java_bin = JVMCI_BIN
-if not java_bin and GRAAL_HOME and os.path.isfile(GRAAL_HOME + '/bin/java'):
-  java_bin = GRAAL_HOME + '/bin/java'
+if not args.use_libgraal:
+    if JVMCI_BIN:
+      java_bin = JVMCI_BIN
+    if not java_bin and GRAAL_HOME and os.path.isfile(GRAAL_HOME + '/bin/java'):
+      java_bin = GRAAL_HOME + '/bin/java'
 
 if not java_bin:
     # use local JVMCI, which ant already needed
@@ -132,6 +138,26 @@ if not args.interpreter and not java_bin.startswith(BASE_DIR + '/libs/jvmci') an
   print "No compatible JDK found. Please set the GRAAL_HOME or JVMCI_BIN environment variables."
   sys.exit(1)
 
+if args.use_libgraal:
+  from subprocess import check_output, STDOUT, CalledProcessError
+  try:
+    libgraal_jdk_home = check_output(
+      [BASE_DIR + '/libs/mx/mx', '--primary-suite-path', BASE_DIR + '/libs/truffle/vm', 'graalvm-home'],
+      stderr=STDOUT,
+      env = {
+        'JAVA_HOME':            java_bin.replace('/bin/java', ''),
+        # REM: This needs to match build.xml:libgraal-jdk
+        'DYNAMIC_IMPORTS':      '/substratevm,/tools,/truffle,/sdk,/compiler',
+        'FORCE_BASH_LAUNCHERS': 'true',
+        'DISABLE_LIBPOLYGLOT':  'true',
+        'EXCLUDE_COMPONENTS':   'svmag,nju,nic,ni,nil'
+      })
+    java_bin = libgraal_jdk_home.strip() + '/bin/java'
+  except CalledProcessError as e:
+    print "Failed to determine location of libgraal"
+    print e.output
+    sys.exit(1)
+
 ##
 ## Defining Necessary Parameter Bits
 ##
@@ -143,8 +169,15 @@ BOOT_CLASSPATH = ('-Xbootclasspath/a:'
              + TRUFFLE_DIR + '/sdk/mxbuild/dists/jdk1.8/graal-sdk.jar:'
              + TRUFFLE_DIR + '/truffle/mxbuild/dists/jdk1.8/truffle-api.jar')
 
-GRAAL_JAVA_8_FLAGS = ['-Djvmci.Compiler=graal',
-  '-Djvmci.class.path.append=' + TRUFFLE_DIR + '/compiler/mxbuild/dists/jdk1.8/graal.jar']
+if args.use_libgraal:
+  GRAAL_JAVA_8_FLAGS = ['-XX:+UseJVMCICompiler', '-XX:+UseJVMCINativeLibrary',
+    '-XX:-UseJVMCIClassLoader', '-Dgraalvm.locatorDisabled=true']
+  GRAAL_JVMCI_FLAGS = []
+else:
+  GRAAL_JAVA_8_FLAGS = ['-Djvmci.Compiler=graal',
+    '-Djvmci.class.path.append=' + TRUFFLE_DIR + '/compiler/mxbuild/dists/jdk1.8/graal.jar']
+  GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:-UseJVMCICompiler']
+
 
 GRAAL_JAVA_9_FLAGS = [
   '--module-path=' + TRUFFLE_DIR + '/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:' +
@@ -157,8 +190,6 @@ SOM_ARGS = ['trufflesom.vm.Universe']
 TWEAK_INLINING = ['-Dpolyglot.engine.CompilationThreshold=191',
                   '-Dpolyglot.engine.InliningMaxCallerSize=10000',
                   '-Dpolyglot.engine.SplittingMaxCalleeSize=100000']
-
-GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:-UseJVMCICompiler']
 
 JAVA_ARGS = ['-server']
 


### PR DESCRIPTION
- added --no-libgraal flag to disable use of libgraal
- only compile libgraal-jdk for the compile target
- use of interpreter-only implies we don’t need libgraal
- the jar target doesn’t use libgraal-jdk, but truffle-libs, which makes it better for use in CI
- for ci and testing, truffle-lib is just fine. So, on Travis, we are avoid compiling libgraal