### PR TITLE
Report benchmark completion to ReBenchDB

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,3 +25,4 @@ benchmark_job:
   script:
     - ${ANT} compile
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf TruffleSOM
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/rebench.conf
+++ b/rebench.conf
@@ -7,7 +7,7 @@ reporting:
     # Benchmark results will be reported to ReBenchDB
     rebenchdb:
         # this url needs to point to the API endpoint
-        db_url: https://rebench.stefan-marr.de/rebenchdb/results
+        db_url: https://rebench.stefan-marr.de/rebenchdb
         repo_url: https://github.com/smarr/TruffleSOM
         record_all: true # make sure everything is recorded
         project_name: TruffleSOM


### PR DESCRIPTION
Enable reporting of results to ReBenchDB, which reports it to GitHub.