### PR TITLE
Remove redundant call to frameNoLongerOnStack and fix build order in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -284,7 +284,7 @@
     <target name="compile-for-jar" depends="truffle-libs,libs,som-compile" description="Compile TruffleSOM without LibGraal">
     </target>
     
-    <target name="compile" depends="libs,libgraal-jdk,som-compile" description="Compile TruffleSOM with LibGraal">
+    <target name="compile" depends="libgraal-jdk,libs,som-compile" description="Compile TruffleSOM with LibGraal">
     </target>
 
     <target name="jar" depends="compile-for-jar" description="Package as JAR">

--- a/src/trufflesom/interpreter/nodes/ReturnNonLocalNode.java
+++ b/src/trufflesom/interpreter/nodes/ReturnNonLocalNode.java
@@ -191,7 +191,6 @@ public final class ReturnNonLocalNode extends ContextualNode {
         nonLocalReturnHandler.enter();
         if (!e.reachedTarget(marker)) {
           doPropagate.enter();
-          marker.frameNoLongerOnStack();
           throw e;
         } else {
           doCatch.enter();


### PR DESCRIPTION
The build order needs Truffle to be compiled first, which is now done by the libgraal-jdk target.

And, the finally already calls frameNoLongerOnStack, so we should not need the additional call.