### PR TITLE
revert Dpolyglot.engine.Dump option to Dgraal.Dump

### DIFF
--- a/som
+++ b/som
@@ -231,7 +231,7 @@ if args.debug:
     flags += ['-Xdebug',
               '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000']
 if not args.interpreter and (args.igv or args.igv_to_file):
-    flags += ['-Dpolyglot.engine.Dump=Truffle,TruffleTree:2']
+    flags += ['-Dgraal.Dump=Truffle,TruffleTree:2']
 if  not args.interpreter and args.only_igv:
     flags += ['-Dpolyglot.engine.MethodFilter=' + args.only_igv]
 if not args.interpreter and args.igv_to_file:


### PR DESCRIPTION
Using the `--igv` option currently throws an exception: `Exception in thread "main" java.lang.IllegalArgumentException: Could not find option with name engine.Dump.`

The `Dump` option was not concerned by the new engine flags. Reverting to the `-Dgraal.` flag solves the issue.