### PR TITLE
Add support for Native Image and Update Truffle to latest 20.x

### DIFF
--- a/.checkstyle_checks.xml
+++ b/.checkstyle_checks.xml
@@ -33,9 +33,6 @@
       <property name="format" value="^[A-Z][_a-zA-Z0-9]*$"/>
     </module>
     <module name="RedundantImport"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -154,6 +151,9 @@
       <property name="onCommentFormat" value="Checkstyle: resume"/>
       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="SuppressionFilter">
     <property name="file" value="${basedir}/.checkstyle_suppressions.xml"/>

--- a/.classpath
+++ b/.classpath
@@ -19,5 +19,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/com.oracle.truffle.object"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/com.oracle.truffle.api.profiles"/>
 	<classpathentry kind="src" path="/BlackDiamonds"/>
+	<classpathentry kind="src" path="/org.graalvm.polyglot"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/.factorypath
+++ b/.factorypath
@@ -1,7 +1,3 @@
 <factorypath>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_API/truffle-api.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR/truffle-dsl-processor.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/GRAAL_SDK/graal-sdk.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTEROP_INTERNAL/truffle-dsl-processor-interop-internal.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTERNAL/truffle-dsl-processor-internal.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,14 +17,13 @@ build_and_test_job:
   stage: build-and-test
   tags: [benchmarks, infinity]
   script:
-    - ${ANT} tests
-    - ${ANT} native-obj-storage-test
+    - ${ANT} tests native-obj-storage-test native-tests
 
 benchmark_job:
   stage: benchmark
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ${ANT} compile
+    - ${ANT} compile native
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf TruffleSOM
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ build_and_test_job:
   tags: [benchmarks, infinity]
   script:
     - ${ANT} tests
+    - ${ANT} native-obj-storage-test
 
 benchmark_job:
   stage: benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
   - $ANT tests
   - $ANT eclipseformat
   - $ANT checkstyle
+  - $ANT native-obj-storage-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
       printf "travis_fold:end:downloads\n"
 
 script:
-  - $ANT tests
+  - $ANT tests native-obj-storage-test
   - $ANT eclipseformat
   - $ANT checkstyle
-  - $ANT native-obj-storage-test

--- a/build.xml
+++ b/build.xml
@@ -409,4 +409,25 @@
 
       <travis target="native" />
     </target>
+    
+    <target name="native-obj-storage-test" depends="truffle-libs,libs,jvmci-libs,compile-som,compile-native-obj-storage-test"></target>
+
+    <target name="compile-native-obj-storage-test">
+      <travis target="native" start="Build Native Image" />
+
+      <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
+        <env key="JAVA_HOME" value="${jvmci.home}" />
+        <arg line="native-image" />
+        <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
+        <arg line="-cp ${ant.refid:common.cp}" />
+        <arg line="trufflesom.intepreter.objectstorage.BasicStorageTester" />
+        <arg line="som-obj-storage-tester" />
+      </exec>
+
+      <move file="${svm.dir}/som-obj-storage-tester" todir="${src.dir}/../" />
+            
+      <exec executable="${src.dir}/../som-obj-storage-tester" failonerror="true" />
+
+      <travis target="native" />
+    </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -3,8 +3,8 @@
     xmlns:if="ant:if"
     xmlns:jacoco="antlib:org.jacoco.ant">
 
-    <property name="jvmci.version" value="jvmci-20.2-b03" />
-    <property name="jdk8.version"  value="262+10" />
+    <property name="jvmci.version" value="jvmci-20.3-b09" />
+    <property name="jdk8.version"  value="282+07" />
 
     <macrodef name="travis">
         <attribute name="target" />

--- a/build.xml
+++ b/build.xml
@@ -40,16 +40,17 @@
 
     <property name="src.dir"     location="src"/>
     <property name="src_gen.dir" location="src_gen"/>
-    <property name="test.dir"    location="tests"/>
     <property name="lib.dir"     location="libs" />
-    <property name="bd.dir"      location="${lib.dir}/black-diamonds/"/>
+    <property name="bd.dir"      location="${lib.dir}/black-diamonds/" />
+    <property name="unit.dir"    location="tests"/>
     <property name="sdk.dir"     location="${lib.dir}/truffle/sdk" />
     <property name="sdk.build"   location="${sdk.dir}/mxbuild/dists/jdk1.8" />
-    <property name="truffle.dir"   location="${lib.dir}/truffle/truffle" />
-    <property name="truffle.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
+    <property name="truffle.dir" location="${lib.dir}/truffle/truffle" />
+    <property name="svm.dir"     location="${lib.dir}/truffle/substratevm" />
     <property name="vm.dir"        location="${lib.dir}/truffle/vm" />
     <property name="compiler.dir"   location="${lib.dir}/truffle/compiler" />
     <property name="compiler.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
+    <property name="truffle.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
     <property name="junit.version" value="4.12" />
 
     <property name="checkstyle.version" value="8.11" />
@@ -62,15 +63,25 @@
 
     <property environment="env"/>
 
-    <path id="project.classpath">
-        <pathelement location="${classes.dir}" />
-        <pathelement location="${test.dir}" />
-        <pathelement location="${bd.dir}/build/classes" />
+    <path id="boot.cp">
         <pathelement location="${sdk.build}/graal-sdk.jar" />
+        <pathelement location="${truffle.build}/truffle-api.jar" />
+    </path>
+    
+    <path id="common.cp">
+        <pathelement location="${classes.dir}" />
+        <pathelement location="${bd.dir}/build/classes" />
+    </path>
+    
+    <path id="som.cp">
+        <path refid="boot.cp"/>
+        <path refid="common.cp"/>
+        <pathelement location="${unit.dir}" />
+
         <pathelement location="${sdk.build}/word-api.jar" />
         <pathelement location="${lib.dir}/junit-${junit.version}.jar" />
         <pathelement location="${lib.dir}/hamcrest-core-1.3.jar" />
-        <pathelement location="${truffle.build}/truffle-api.jar" />
+
         <pathelement location="${truffle.build}/truffle-dsl-processor.jar" />
     </path>
 
@@ -92,7 +103,20 @@
         <travis target="clean" />
     </target>
 
-    <target name="clobber" description="Do clean, and also clean truffle build" depends="clean">
+    <target name="clean-truffle" if="truffle.and.jvmci.present">
+        <travis target="clean-truffle" start="clean-truffle" />
+
+        <exec executable="${mx.cmd}" dir="${svm.dir}">
+          <arg value="--dynamicimports"/>
+          <arg value="../truffle,../tools,../compiler,../sdk"/>
+          <arg value="clean"/>
+          <env key="JAVA_HOME" value="${jvmci.home}" />
+        </exec>
+
+        <travis target="clean-truffle" />
+    </target>
+
+    <target name="clobber" description="Do clean, and also clean truffle build" depends="clean,clean-truffle">
         <travis target="clobber" start="clobber" />
 
         <exec executable="${mx.cmd}" dir="${truffle.dir}">
@@ -111,43 +135,6 @@
         <ant dir="${bd.dir}" useNativeBasedir="true" target="clean" inheritAll="false" />
 
         <travis target="clobber" />
-    </target>
-
-    <target name="eclipseformat">
-      <travis target="eclipseformat" start="eclipseformat" />
-
-      <pathconvert pathsep=" " property="javafiles">
-        <fileset dir="${src.dir}">
-          <include name="**/*.java"/>
-        </fileset>
-        <fileset dir="${test.dir}">
-          <include name="**/*.java"/>
-        </fileset>
-      </pathconvert>
-      <exec executable="${env.ECLIPSE_EXE}" dir="${basedir}">
-          <arg value="-nosplash"/>
-          <arg value="-application"/>
-          <arg value="-consolelog"/>
-          <arg value="-data"/>
-          <arg value="${basedir}"/>
-          <arg value="-vm"/>
-          <arg value="${env.JAVA_HOME}/bin/java"/>
-          <arg value="org.eclipse.jdt.core.JavaCodeFormatter"/>
-          <arg value="-config"/>
-          <arg value="${basedir}/.settings/org.eclipse.jdt.core.prefs"/>
-          <arg line="${javafiles}"/>
-      </exec>
-      <exec executable="git" dir="${basedir}" failonerror="true">
-          <arg value="status" />
-          <arg value="*.java" />
-      </exec>
-      <exec executable="git" dir="${basedir}" failonerror="true">
-          <arg value="diff-index" />
-          <arg value="--quiet" />
-          <arg value="HEAD" />
-      </exec>
-
-      <travis target="eclipseformat" />
     </target>
 
     <target name="check-core-lib-available">
@@ -186,7 +173,7 @@
         <travis target="libgraal-jdk" />
     </target>
 
-    <target name="bd-libs"> <!-- implicit dependency on truffle-libs -->
+    <target name="bd-libs"> <!-- implicit dependency on truffle-libs/libgraal-jdk -->
         <travis target="bd-libs" start="Build Black Diamonds" />
 
         <ant dir="${bd.dir}" useNativeBasedir="true" target="libs-junit" inheritAll="false">
@@ -242,49 +229,96 @@
             dest="${lib.dir}/hamcrest-core-1.3.jar" />
     </target>
 
+    <target name="eclipseformat">
+      <travis target="eclipseformat" start="Format code with Eclipse" />
+      <pathconvert pathsep=" " property="javafiles">
+        <fileset dir="${src.dir}">
+          <include name="**/*.java"/>
+        </fileset>
+        <fileset dir="${unit.dir}">
+          <include name="**/*.java"/>
+        </fileset>
+      </pathconvert>
+      <exec executable="${env.ECLIPSE_EXE}" dir="${basedir}">
+          <arg value="-nosplash"/>
+          <arg value="-application"/>
+          <arg value="-consolelog"/>
+          <arg value="-data"/>
+          <arg value="${basedir}"/>
+          <arg value="-vm"/>
+          <arg value="${env.JAVA_HOME}/bin/java"/>
+          <arg value="org.eclipse.jdt.core.JavaCodeFormatter"/>
+          <arg value="-config"/>
+          <arg value="${basedir}/.settings/org.eclipse.jdt.core.prefs"/>
+          <arg line="${javafiles}"/>
+      </exec>
+      <travis target="eclipseformat" />
+  </target>
+
+  <target name="eclipseformat-check" depends="eclipseformat">
+      <travis target="eclipseformat-check" start="Check Eclipse Format" />
+      <exec executable="git" dir="${basedir}">
+          <arg value="status" />
+          <arg value="*.java" />
+      </exec>
+      <exec executable="git" dir="${basedir}" failonerror="true">
+          <arg value="diff-index" />
+          <arg value="--quiet" />
+          <arg value="--exit-code" />
+          <arg value="--ignore-submodules" />
+          <arg value="HEAD" />
+      </exec>
+      <travis target="eclipseformat-check" />
+    </target>
+
     <target name="checkstyle-jar">
+        <travis target="checkstyle-jar" start="Get Checkstyle Jar" />
         <mkdir dir="${lib.dir}" />
         <get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
             usetimestamp="true"
             dest="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
+        <travis target="checkstyle-jar" />
     </target>
 
     <target name="checkstyle" depends="checkstyle-jar" description="Check Code with Checkstyle">
+        <travis target="checkstyle" start="Run Checkstyle" />
         <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties" classpath="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
         <checkstyle config=".checkstyle_checks.xml">
-          <fileset dir="src" includes="**/*.java"/>
+          <fileset dir="${src.dir}" includes="**/*.java"/>
+          <fileset dir="${unit.dir}" includes="**/*.java"/>
           <formatter type="plain"/>
         </checkstyle>
+        <travis target="checkstyle" />
     </target>
 
-    <target name="som-compile" description="Compile TruffleSOM, without dependencies">
+    <target name="compile-som" description="Compile TruffleSOM, without dependencies">
         <travis target="compile" start="compile" />
 
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${classes.dir}" />
         <mkdir dir="${src_gen.dir}" />
-        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${classes.dir}" debug="true">
-          <classpath refid="project.classpath" />
+        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${classes.dir}" debug="true"> <!-- for debugging: fork="true"  -->
+          <classpath refid="som.cp" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-XDignore.symbol.file" />
           <compilerarg line="-Xlint:all" />
         </javac>
         <javac includeantruntime="false" srcdir="${src_gen.dir}" destdir="${classes.dir}" debug="true">
-          <classpath refid="project.classpath" />
+          <classpath refid="som.cp" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-Xlint:all" />
         </javac>
-        <javac includeantruntime="false" srcdir="${test.dir}" destdir="${classes.dir}" debug="true">
-          <classpath refid="project.classpath" />
+        <javac includeantruntime="false" srcdir="${unit.dir}" destdir="${classes.dir}" debug="true">
+          <classpath refid="som.cp" />
         </javac>
 
         <travis target="compile" />
     </target>
 
-    <target name="compile-for-jar" depends="truffle-libs,libs,som-compile" description="Compile TruffleSOM without LibGraal">
+    <target name="compile-for-jar" depends="truffle-libs,libs,compile-som" description="Compile TruffleSOM without LibGraal">
     </target>
     
-    <target name="compile" depends="libgraal-jdk,libs,som-compile" description="Compile TruffleSOM with LibGraal">
+    <target name="compile" depends="libgraal-jdk,libs,compile-som" description="Compile TruffleSOM with LibGraal">
     </target>
 
     <target name="jar" depends="compile-for-jar" description="Package as JAR">
@@ -298,7 +332,7 @@
             outputtoformatters="true">
             <jvmarg value="-ea" />
             <jvmarg value="-esa" />
-            <classpath refid="project.classpath" />
+            <classpath refid="som.cp" />
             <batchtest fork="yes" filtertrace="false">
               <fileset dir="tests">
                   <include name="**/*Test*.java"/>
@@ -308,7 +342,7 @@
         </junit>
 
         <java classname="trufflesom.vm.Universe" fork="true" failonerror="true">
-            <classpath refid="project.classpath" />
+            <classpath refid="som.cp" />
             <jvmarg value="-ea" />
             <jvmarg value="-esa" />
             <arg line="-cp Smalltalk TestSuite/TestHarness.som --ignore-inefficacies" />

--- a/build.xml
+++ b/build.xml
@@ -53,7 +53,8 @@
     <property name="truffle.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
     <property name="junit.version" value="4.12" />
 
-    <property name="checkstyle.version" value="8.11" />
+    <property name="checkstyle.version" value="8.36" />
+
     <property name="jvmci.home"  location="${lib.dir}/jvmci${home.ext}" />
 
     <property name="mx.cmd" value="../../mx/mx" />

--- a/build.xml
+++ b/build.xml
@@ -72,6 +72,8 @@
     <path id="common.cp">
         <pathelement location="${classes.dir}" />
         <pathelement location="${bd.dir}/build/classes" />
+
+        <pathelement location="${svm.build}/svm-core.jar" />
     </path>
     
     <path id="som.cp">
@@ -368,6 +370,43 @@
         <travis target="som-test" />
     </target>
 
-    <target name="tests" depends="test, som-test" />
+    <target name="native-tests" depends="native">
+      <travis target="native-tests" start="Run TruffleSOM native image Tests" />
 
+      <exec executable="${src.dir}/../som-native" failonerror="true">
+          <arg value="-cp" />
+          <arg value="Smalltalk" />
+          <arg value="TestSuite/TestHarness.com" />
+      </exec>
+
+      <travis target="native-tests" />
+    </target>
+    
+    <target name="tests" depends="test,som-test" />
+    
+    <target name="native" depends="truffle-libs,libs,jvmci-libs,compile-som,compile-native"></target>
+
+    <target name="compile-native">
+      <travis target="native" start="Build Native Image" />
+
+      <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
+        <env key="JAVA_HOME" value="${jvmci.home}" />
+        <arg line="native-image" />
+        <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
+        <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->
+
+        <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
+        <!-- <arg line="-H:+PrintMethodHistogram" />
+             <arg line="-H:+RuntimeAssertions" />
+             <arg line="-H:+EnforceMaxRuntimeCompileMethods" /> -->
+
+        <arg line="-cp ${ant.refid:common.cp}" />
+        <arg line="trufflesom.vm.Universe" />
+        <arg line="som-native" />
+      </exec>
+
+      <move file="${svm.dir}/som-native" todir="${src.dir}/../" />
+
+      <travis target="native" />
+    </target>
 </project>

--- a/rebench.conf
+++ b/rebench.conf
@@ -101,6 +101,10 @@ executors:
     TruffleSOM-graal:
         path: .
         executable: som
+    TruffleSOM-native:
+        path: .
+        executable: som-native
+    
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:
@@ -117,3 +121,10 @@ experiments:
                     - micro-steady
                     - macro-startup
                     - macro-steady
+            - TruffleSOM-native:
+                suites:
+                    - micro-startup
+                    - micro-steady
+                    - macro-startup
+                    - macro-steady
+            

--- a/src/trufflesom/compiler/SourcecodeCompiler.java
+++ b/src/trufflesom/compiler/SourcecodeCompiler.java
@@ -25,9 +25,7 @@
 package trufflesom.compiler;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.StringReader;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.Source;
@@ -54,11 +52,10 @@ public class SourcecodeCompiler {
       final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe)
       throws IOException, ProgramDefinitionError {
     String fname = path + File.separator + file + ".som";
-    FileReader stream = new FileReader(fname);
-
     File f = new File(fname);
     Source source = SomLanguage.getSource(f);
-    Parser parser = new Parser(stream, f.length(), source, probe, language.getUniverse());
+    Parser parser = new Parser(source.getCharacters().toString(), source, probe,
+        language.getUniverse());
 
     SClass result = compile(parser, systemClass, language.getUniverse());
 
@@ -77,8 +74,7 @@ public class SourcecodeCompiler {
   public SClass compileClass(final String stmt, final SClass systemClass,
       final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe)
       throws ProgramDefinitionError {
-    Parser parser =
-        new Parser(new StringReader(stmt), stmt.length(), null, probe, language.getUniverse());
+    Parser parser = new Parser(stmt, null, probe, language.getUniverse());
 
     SClass result = compile(parser, systemClass, language.getUniverse());
     return result;

--- a/src/trufflesom/interpreter/nodes/dispatch/GenericDispatchNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/GenericDispatchNode.java
@@ -1,6 +1,7 @@
 package trufflesom.interpreter.nodes.dispatch;
 
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
@@ -25,9 +26,8 @@ public final class GenericDispatchNode extends AbstractDispatchNode {
     call = Truffle.getRuntime().createIndirectCallNode();
   }
 
-  @Override
-  public Object executeDispatch(
-      final VirtualFrame frame, final Object[] arguments) {
+  @TruffleBoundary
+  private Object dispatch(final Object[] arguments) {
     Object rcvr = arguments[0];
     SClass rcvrClass = Types.getClassOf(rcvr, universe);
     SInvokable method = rcvrClass.lookupInvokable(selector);
@@ -45,6 +45,12 @@ public final class GenericDispatchNode extends AbstractDispatchNode {
       target = CachedDnuNode.getDnuCallTarget(rcvrClass, universe);
     }
     return call.call(target, args);
+  }
+
+  @Override
+  public Object executeDispatch(
+      final VirtualFrame frame, final Object[] arguments) {
+    return dispatch(arguments);
   }
 
   @Override

--- a/src/trufflesom/interpreter/nodes/dispatch/SuperDispatchNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/SuperDispatchNode.java
@@ -1,6 +1,7 @@
 package trufflesom.interpreter.nodes.dispatch;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -47,6 +48,7 @@ public abstract class SuperDispatchNode extends AbstractDispatchNode {
       return (SClass) clazz.getSuperClass();
     }
 
+    @TruffleBoundary
     private CachedDispatchNode specialize() {
       CompilerAsserts.neverPartOfCompilation("SuperDispatchNode.create2");
       SInvokable method = getLexicalSuperClass().lookupInvokable(selector);

--- a/src/trufflesom/interpreter/nodes/dispatch/UninitializedValuePrimDispatchNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/UninitializedValuePrimDispatchNode.java
@@ -2,12 +2,12 @@ package trufflesom.interpreter.nodes.dispatch;
 
 import static trufflesom.interpreter.TruffleCompiler.transferToInterpreterAndInvalidate;
 
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
+
 import trufflesom.primitives.basics.BlockPrims.ValuePrimitiveNode;
 import trufflesom.vmobjects.SBlock;
 import trufflesom.vmobjects.SInvokable;
-
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node;
 
 
 public final class UninitializedValuePrimDispatchNode

--- a/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseMessageNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseMessageNode.java
@@ -1,6 +1,7 @@
 package trufflesom.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -70,6 +71,7 @@ public abstract class IfTrueIfFalseMessageNode extends TernaryExpressionNode {
   }
 
   @Specialization(replaces = {"doIfTrueIfFalseWithInliningTwoBlocks"})
+  @TruffleBoundary
   public final Object doIfTrueIfFalse(final boolean receiver, final SBlock trueBlock,
       final SBlock falseBlock) {
     CompilerAsserts.neverPartOfCompilation("IfTrueIfFalseMessageNode.10");
@@ -101,6 +103,7 @@ public abstract class IfTrueIfFalseMessageNode extends TernaryExpressionNode {
   }
 
   @Specialization(replaces = {"doIfTrueIfFalseWithInliningTrueValue"})
+  @TruffleBoundary
   public final Object doIfTrueIfFalseTrueValue(final boolean receiver, final Object trueValue,
       final SBlock falseBlock) {
     if (condProf.profile(receiver)) {
@@ -112,6 +115,7 @@ public abstract class IfTrueIfFalseMessageNode extends TernaryExpressionNode {
   }
 
   @Specialization(replaces = {"doIfTrueIfFalseWithInliningFalseValue"})
+  @TruffleBoundary
   public final Object doIfTrueIfFalseFalseValue(final boolean receiver, final SBlock trueBlock,
       final Object falseValue) {
     if (condProf.profile(receiver)) {

--- a/src/trufflesom/interpreter/objectstorage/StorageAnalyzer.java
+++ b/src/trufflesom/interpreter/objectstorage/StorageAnalyzer.java
@@ -1,0 +1,127 @@
+package trufflesom.interpreter.objectstorage;
+
+import java.lang.reflect.Field;
+
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
+import sun.misc.Unsafe;
+import trufflesom.vmobjects.SObject;
+
+
+public class StorageAnalyzer {
+  private static final Unsafe unsafe = UnsafeUtil.load();
+
+  private static final long SMO_PRIM_FIELD_1_OFFSET = getFieldOffset("primField1");
+  private static final long SMO_PRIM_FIELD_2_OFFSET = getFieldOffset("primField2");
+  private static final long SMO_PRIM_FIELD_3_OFFSET = getFieldOffset("primField3");
+  private static final long SMO_PRIM_FIELD_4_OFFSET = getFieldOffset("primField4");
+  private static final long SMO_PRIM_FIELD_5_OFFSET = getFieldOffset("primField5");
+  private static final long SMO_FIELD_1_OFFSET      = getFieldOffset("field1");
+  private static final long SMO_FIELD_2_OFFSET      = getFieldOffset("field2");
+  private static final long SMO_FIELD_3_OFFSET      = getFieldOffset("field3");
+  private static final long SMO_FIELD_4_OFFSET      = getFieldOffset("field4");
+  private static final long SMO_FIELD_5_OFFSET      = getFieldOffset("field5");
+
+  @CompilationFinal(
+      dimensions = 1) private static final DirectObjectAccessor[]                  objAccessors  =
+          new DirectObjectAccessor[SObject.NUM_OBJECT_FIELDS];
+  @CompilationFinal(
+      dimensions = 1) private static final DirectPrimitiveAccessor[]               primAccessors =
+          new DirectPrimitiveAccessor[SObject.NUM_PRIMITIVE_FIELDS];
+
+  private static long getFieldOffset(final String fieldName) {
+    try {
+      Field field = SObject.class.getDeclaredField(fieldName);
+      return unsafe.objectFieldOffset(field);
+    } catch (NoSuchFieldException | SecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Initialize field accessors with the offsets in the S*Object classes.
+   */
+  @TruffleBoundary
+  public static void initAccessors() {
+    if (objAccessors[0] != null) {
+      return;
+    }
+
+    initObjectAccessors();
+    initPrimitiveAccessors();
+  }
+
+  private static void initObjectAccessors() {
+    objAccessors[0] = new DirectObjectAccessor(SMO_FIELD_1_OFFSET);
+    objAccessors[1] = new DirectObjectAccessor(SMO_FIELD_2_OFFSET);
+    objAccessors[2] = new DirectObjectAccessor(SMO_FIELD_3_OFFSET);
+    objAccessors[3] = new DirectObjectAccessor(SMO_FIELD_4_OFFSET);
+    objAccessors[4] = new DirectObjectAccessor(SMO_FIELD_5_OFFSET);
+  }
+
+  private static void initPrimitiveAccessors() {
+    primAccessors[0] = new DirectPrimitiveAccessor(SMO_PRIM_FIELD_1_OFFSET);
+    primAccessors[1] = new DirectPrimitiveAccessor(SMO_PRIM_FIELD_2_OFFSET);
+    primAccessors[2] = new DirectPrimitiveAccessor(SMO_PRIM_FIELD_3_OFFSET);
+    primAccessors[3] = new DirectPrimitiveAccessor(SMO_PRIM_FIELD_4_OFFSET);
+    primAccessors[4] = new DirectPrimitiveAccessor(SMO_PRIM_FIELD_5_OFFSET);
+  }
+
+  public static final class DirectObjectAccessor {
+    private final long fieldOffset;
+
+    private DirectObjectAccessor(final long fieldOffset) {
+      this.fieldOffset = fieldOffset;
+    }
+
+    public long getFieldOffset() {
+      return fieldOffset;
+    }
+
+    public Object read(final SObject obj) {
+      return unsafe.getObject(obj, fieldOffset);
+    }
+
+    public void write(final SObject obj, final Object value) {
+      assert value != null;
+      unsafe.putObject(obj, fieldOffset, value);
+    }
+  }
+
+  public static final class DirectPrimitiveAccessor {
+    private final long offset;
+
+    private DirectPrimitiveAccessor(final long fieldOffset) {
+      offset = fieldOffset;
+    }
+
+    public long getFieldOffset() {
+      return offset;
+    }
+
+    public long readLong(final SObject obj) {
+      return unsafe.getLong(obj, offset);
+    }
+
+    public double readDouble(final SObject obj) {
+      return unsafe.getDouble(obj, offset);
+    }
+
+    public void write(final SObject obj, final long value) {
+      unsafe.putLong(obj, offset, value);
+    }
+
+    public void write(final SObject obj, final double value) {
+      unsafe.putDouble(obj, offset, value);
+    }
+  }
+
+  public static long getPrimitiveFieldOffset(final int primField) {
+    return primAccessors[primField].getFieldOffset();
+  }
+
+  public static long getObjectFieldOffset(final int fieldIndex) {
+    return objAccessors[fieldIndex].getFieldOffset();
+  }
+}

--- a/src/trufflesom/interpreter/objectstorage/StorageLocation.java
+++ b/src/trufflesom/interpreter/objectstorage/StorageLocation.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 
+import sun.misc.Unsafe;
 import trufflesom.interpreter.TruffleCompiler;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
@@ -17,7 +18,6 @@ import trufflesom.interpreter.objectstorage.FieldAccessorNode.WriteLongFieldNode
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.WriteObjectFieldNode;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SObject;
-import sun.misc.Unsafe;
 
 
 public abstract class StorageLocation {
@@ -141,6 +141,11 @@ public abstract class StorageLocation {
       throw new RuntimeException("we should not get here, should we?");
       // return new UninitializedWriteFieldNode(fieldIndex);
     }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("UnwrittenStorageLocation: fieldIdx=" + this.fieldIndex);
+    }
   }
 
   public abstract static class AbstractObjectStorageLocation extends StorageLocation {
@@ -191,6 +196,12 @@ public abstract class StorageLocation {
       assert value != null;
       unsafe.putObject(obj, fieldOffset, value);
     }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("ObjectDirectStorageLocation: fieldIdx=" + this.fieldIndex
+          + " fieldOffset=" + fieldOffset);
+    }
   }
 
   public static final class ObjectArrayStorageLocation extends AbstractObjectStorageLocation {
@@ -218,6 +229,12 @@ public abstract class StorageLocation {
       assert value != null;
       Object[] arr = obj.getExtensionObjFields();
       arr[extensionIndex] = value;
+    }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("ObjectArrayStorageLocation: fieldIdx=" + this.fieldIndex
+          + " fieldOffset=" + extensionIndex);
     }
   }
 
@@ -307,6 +324,12 @@ public abstract class StorageLocation {
       CompilerAsserts.neverPartOfCompilation("StorageLocation");
       return new WriteDoubleFieldNode(fieldIndex, layout, next);
     }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("DoubleDirectStorageLocation: fieldIdx=" + this.fieldIndex
+          + " primMask=" + mask + " fieldOffset=" + offset);
+    }
   }
 
   public static final class LongDirectStoreLocation extends PrimitiveDirectStoreLocation
@@ -365,6 +388,12 @@ public abstract class StorageLocation {
         final ObjectLayout layout, final AbstractWriteFieldNode next) {
       CompilerAsserts.neverPartOfCompilation("StorageLocation");
       return new WriteLongFieldNode(fieldIndex, layout, next);
+    }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("LongDirectStorageLocation: fieldIdx=" + this.fieldIndex
+          + " primMask=" + mask + " fieldOffset=" + offset);
     }
   }
 
@@ -437,6 +466,12 @@ public abstract class StorageLocation {
       CompilerAsserts.neverPartOfCompilation("StorageLocation");
       return new WriteLongFieldNode(fieldIndex, layout, next);
     }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("LongArrayStorageLocation: fieldIdx=" + this.fieldIndex
+          + " primMask=" + mask + " extensionIndex=" + extensionIndex);
+    }
   }
 
   public static final class DoubleArrayStoreLocation extends PrimitiveArrayStoreLocation
@@ -504,5 +539,13 @@ public abstract class StorageLocation {
       CompilerAsserts.neverPartOfCompilation("StorageLocation");
       return new WriteDoubleFieldNode(fieldIndex, layout, next);
     }
+
+    @Override
+    public void debugPrint(final SObject obj) {
+      System.out.println("DoubleArrayStorageLocation: fieldIdx=" + this.fieldIndex
+          + " primMask=" + mask + " extensionIndex=" + extensionIndex);
+    }
   }
+
+  public abstract void debugPrint(SObject obj);
 }

--- a/src/trufflesom/interpreter/objectstorage/UnsafeUtil.java
+++ b/src/trufflesom/interpreter/objectstorage/UnsafeUtil.java
@@ -1,0 +1,24 @@
+package trufflesom.interpreter.objectstorage;
+
+import java.lang.reflect.Field;
+
+import sun.misc.Unsafe;
+
+
+public class UnsafeUtil {
+  public static Unsafe load() {
+    try {
+      return Unsafe.getUnsafe();
+    } catch (SecurityException e) {
+      // can fail, is ok, just to the fallback below
+    }
+    try {
+      Field theUnsafeInstance = Unsafe.class.getDeclaredField("theUnsafe");
+      theUnsafeInstance.setAccessible(true);
+      return (Unsafe) theUnsafeInstance.get(Unsafe.class);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "exception while trying to get Unsafe.theUnsafe via reflection:", e);
+    }
+  }
+}

--- a/src/trufflesom/primitives/arithmetic/DoubleDivPrim.java
+++ b/src/trufflesom/primitives/arithmetic/DoubleDivPrim.java
@@ -3,6 +3,7 @@ package trufflesom.primitives.arithmetic;
 import java.math.BigInteger;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -32,6 +33,7 @@ public abstract class DoubleDivPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final SAbstractObject doLong(final long left, final BigInteger right) {
     CompilerAsserts.neverPartOfCompilation("DoubleDiv100");
     // TODO: need to implement the "/" case here directly... :

--- a/src/trufflesom/primitives/basics/SystemPrims.java
+++ b/src/trufflesom/primitives/basics/SystemPrims.java
@@ -1,5 +1,6 @@
 package trufflesom.primitives.basics;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -72,6 +73,8 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(className = "System", primitive = "fullGC")
   public abstract static class FullGCPrim extends UnarySystemOperation {
+
+    @TruffleBoundary
     @Specialization(guards = "receiver == universe.getSystemObject()")
     public final Object doSObject(final SObject receiver) {
       System.gc();

--- a/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
@@ -1,5 +1,6 @@
 package trufflesom.primitives.reflection;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -72,6 +73,7 @@ public abstract class AbstractSymbolDispatch extends Node {
     return realCachedSend.doPreEvaluated(frame, arguments);
   }
 
+  @TruffleBoundary
   @Specialization(replaces = "doCachedWithoutArgArr", guards = "argsArr == null")
   public Object doUncached(final Object receiver, final SSymbol selector, final Object argsArr,
       @Cached("create()") final IndirectCallNode call) {
@@ -82,6 +84,7 @@ public abstract class AbstractSymbolDispatch extends Node {
     return call.call(invokable.getCallTarget(), arguments);
   }
 
+  @TruffleBoundary
   @Specialization(replaces = "doCached")
   public Object doUncached(final Object receiver, final SSymbol selector, final SArray argsArr,
       @Cached("create()") final IndirectCallNode call,

--- a/src/trufflesom/primitives/reflection/GlobalPrim.java
+++ b/src/trufflesom/primitives/reflection/GlobalPrim.java
@@ -1,5 +1,6 @@
 package trufflesom.primitives.reflection;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
@@ -59,6 +60,7 @@ public abstract class GlobalPrim extends BinarySystemOperation {
       return specialize(argument).getGlobal(frame, argument);
     }
 
+    @TruffleBoundary
     private GetGlobalNode specialize(final SSymbol argument) {
       if (depth < INLINE_CACHE_SIZE) {
         return replace(new CachedGetGlobal(argument, depth, sourceSection, universe));

--- a/src/trufflesom/primitives/reflection/HasGlobalPrim.java
+++ b/src/trufflesom/primitives/reflection/HasGlobalPrim.java
@@ -1,5 +1,6 @@
 package trufflesom.primitives.reflection;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
@@ -50,6 +51,7 @@ public abstract class HasGlobalPrim extends BinarySystemOperation {
     }
 
     @Override
+    @TruffleBoundary
     public boolean hasGlobal(final SSymbol argument) {
       boolean hasGlobal = universe.hasGlobal(argument);
 

--- a/src/trufflesom/primitives/reflection/IndexDispatch.java
+++ b/src/trufflesom/primitives/reflection/IndexDispatch.java
@@ -3,6 +3,7 @@ package trufflesom.primitives.reflection;
 import static trufflesom.interpreter.TruffleCompiler.transferToInterpreterAndInvalidate;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.Node;
 
 import trufflesom.interpreter.nodes.dispatch.DispatchChain;
@@ -39,6 +40,7 @@ public abstract class IndexDispatch extends Node implements DispatchChain {
       super(depth, universe);
     }
 
+    @TruffleBoundary
     private IndexDispatch specialize(final SClass clazz, final int index, final boolean read) {
       transferToInterpreterAndInvalidate("Initialize a dispatch node.");
 
@@ -108,6 +110,7 @@ public abstract class IndexDispatch extends Node implements DispatchChain {
       }
     }
 
+    @TruffleBoundary
     @Override
     public Object executeDispatch(final SObject obj, final int index, final Object value) {
       CompilerAsserts.neverPartOfCompilation();
@@ -136,6 +139,7 @@ public abstract class IndexDispatch extends Node implements DispatchChain {
     }
 
     @Override
+    @TruffleBoundary
     public Object executeDispatch(final SObject obj, final int index) {
       CompilerAsserts.neverPartOfCompilation();
       throw new RuntimeException("This should be never reached.");
@@ -163,11 +167,13 @@ public abstract class IndexDispatch extends Node implements DispatchChain {
     }
 
     @Override
+    @TruffleBoundary
     public Object executeDispatch(final SObject obj, final int index) {
       return obj.getField(index);
     }
 
     @Override
+    @TruffleBoundary
     public Object executeDispatch(final SObject obj, final int index, final Object value) {
       obj.setField(index, value);
       return value;

--- a/src/trufflesom/primitives/reflection/ObjectPrims.java
+++ b/src/trufflesom/primitives/reflection/ObjectPrims.java
@@ -1,6 +1,7 @@
 package trufflesom.primitives.reflection;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -85,6 +86,7 @@ public final class ObjectPrims {
   @Primitive(className = "Object", primitive = "instVarNamed:", selector = "instVarNamed:")
   public abstract static class InstVarNamedPrim extends BinaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final Object doSObject(final SObject receiver, final SSymbol fieldName) {
       CompilerAsserts.neverPartOfCompilation();
       return receiver.getField(receiver.getFieldIndex(fieldName));
@@ -109,6 +111,7 @@ public final class ObjectPrims {
       return receiver.getSOMClass(universe);
     }
 
+    @TruffleBoundary
     @Specialization
     public final SClass doObject(final Object receiver) {
       return Types.getClassOf(receiver, universe);

--- a/src/trufflesom/primitives/reflection/PerformInSuperclassPrim.java
+++ b/src/trufflesom/primitives/reflection/PerformInSuperclassPrim.java
@@ -1,6 +1,7 @@
 package trufflesom.primitives.reflection;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -20,6 +21,7 @@ public abstract class PerformInSuperclassPrim extends TernaryExpressionNode {
   @Child private IndirectCallNode call = Truffle.getRuntime().createIndirectCallNode();
 
   @Specialization
+  @TruffleBoundary
   public final Object doSAbstractObject(final SAbstractObject receiver, final SSymbol selector,
       final SClass clazz) {
     CompilerAsserts.neverPartOfCompilation("PerformInSuperclassPrim");

--- a/src/trufflesom/primitives/reflection/PerformWithArgumentsInSuperclassPrim.java
+++ b/src/trufflesom/primitives/reflection/PerformWithArgumentsInSuperclassPrim.java
@@ -1,6 +1,7 @@
 package trufflesom.primitives.reflection;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -19,6 +20,7 @@ import trufflesom.vmobjects.SSymbol;
 public abstract class PerformWithArgumentsInSuperclassPrim extends QuaternaryExpressionNode {
   @Child private IndirectCallNode call = Truffle.getRuntime().createIndirectCallNode();
 
+  @TruffleBoundary
   @Specialization
   public final Object doSAbstractObject(final Object receiver, final SSymbol selector,
       final Object[] argArr, final SClass clazz) {

--- a/src/trufflesom/vm/Shell.java
+++ b/src/trufflesom/vm/Shell.java
@@ -28,6 +28,8 @@ package trufflesom.vm;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
@@ -42,6 +44,7 @@ public class Shell {
     this.universe = universe;
   }
 
+  @TruffleBoundary
   public Object start() {
     BufferedReader in;
     String stmt;

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -51,6 +51,7 @@ import trufflesom.compiler.Variable;
 import trufflesom.interpreter.Invokable;
 import trufflesom.interpreter.SomLanguage;
 import trufflesom.interpreter.TruffleCompiler;
+import trufflesom.interpreter.objectstorage.StorageAnalyzer;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
@@ -123,6 +124,8 @@ public final class Universe implements IdProvider<SSymbol> {
   }
 
   public static Value eval(final String[] arguments) {
+    StorageAnalyzer.initAccessors();
+
     Builder builder = createContextBuilder();
     builder.arguments(SomLanguage.LANG_ID, arguments);
 

--- a/src/trufflesom/vmobjects/SAbstractObject.java
+++ b/src/trufflesom/vmobjects/SAbstractObject.java
@@ -1,6 +1,7 @@
 package trufflesom.vmobjects;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
@@ -38,12 +39,14 @@ public abstract class SAbstractObject implements TruffleObject {
     return invokable.invoke(arguments);
   }
 
+  @TruffleBoundary
   public static final Object sendUnknownGlobal(final Object receiver,
       final SSymbol globalName, final Universe universe) {
     Object[] arguments = {receiver, globalName};
     return send("unknownGlobal:", arguments, universe);
   }
 
+  @TruffleBoundary
   public static final Object sendEscapedBlock(final Object receiver,
       final SBlock block, final Universe universe) {
     Object[] arguments = {receiver, block};

--- a/src/trufflesom/vmobjects/SAbstractObject.java
+++ b/src/trufflesom/vmobjects/SAbstractObject.java
@@ -26,7 +26,7 @@ public abstract class SAbstractObject implements TruffleObject {
     return "a " + clazz.getName().getString();
   }
 
-  public static final Object send(
+  private static Object send(
       final String selectorString,
       final Object[] arguments, final Universe universe) {
     CompilerAsserts.neverPartOfCompilation("SAbstractObject.send()");

--- a/src/trufflesom/vmobjects/SObject.java
+++ b/src/trufflesom/vmobjects/SObject.java
@@ -223,21 +223,6 @@ public class SObject extends SAbstractObject {
     return new SObject(numFields);
   }
 
-  private static final long FIRST_OBJECT_FIELD_OFFSET = getFirstObjectFieldOffset();
-  private static final long FIRST_PRIM_FIELD_OFFSET   = getFirstPrimFieldOffset();
-  private static final long OBJECT_FIELD_LENGTH       = getObjectFieldLength();
-  private static final long PRIM_FIELD_LENGTH         = getPrimFieldLength();
-
-  public static long getObjectFieldOffset(final int fieldIndex) {
-    assert 0 <= fieldIndex && fieldIndex < NUM_OBJECT_FIELDS;
-    return FIRST_OBJECT_FIELD_OFFSET + fieldIndex * OBJECT_FIELD_LENGTH;
-  }
-
-  public static long getPrimitiveFieldOffset(final int fieldIndex) {
-    assert 0 <= fieldIndex && fieldIndex < NUM_PRIMITIVE_FIELDS;
-    return FIRST_PRIM_FIELD_OFFSET + fieldIndex * PRIM_FIELD_LENGTH;
-  }
-
   public static int getPrimitiveFieldMask(final int fieldIndex) {
     assert 0 <= fieldIndex && fieldIndex < 32; // this limits the number of object fields for
                                                // the moment...
@@ -294,26 +279,6 @@ public class SObject extends SAbstractObject {
 
     StorageLocation location = getLocation(index);
     location.write(this, value);
-  }
-
-  private static long getFirstObjectFieldOffset() {
-    CompilerAsserts.neverPartOfCompilation("SObject.getFirstObjectFieldOffset()");
-    try {
-      final Field firstField = SObject.class.getDeclaredField("field1");
-      return StorageLocation.getFieldOffset(firstField);
-    } catch (NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static long getFirstPrimFieldOffset() {
-    CompilerAsserts.neverPartOfCompilation("SObject.getFirstPrimFieldOffset()");
-    try {
-      final Field firstField = SObject.class.getDeclaredField("primField1");
-      return StorageLocation.getFieldOffset(firstField);
-    } catch (NoSuchFieldException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private static long getObjectFieldLength() {

--- a/src/trufflesom/vmobjects/SObject.java
+++ b/src/trufflesom/vmobjects/SObject.java
@@ -48,20 +48,20 @@ public class SObject extends SAbstractObject {
   public static final int NUM_PRIMITIVE_FIELDS = 5;
   public static final int NUM_OBJECT_FIELDS    = 5;
 
-  @SuppressWarnings("unused") private long primField1;
-  @SuppressWarnings("unused") private long primField2;
-  @SuppressWarnings("unused") private long primField3;
-  @SuppressWarnings("unused") private long primField4;
-  @SuppressWarnings("unused") private long primField5;
+  protected long primField1;
+  protected long primField2;
+  protected long primField3;
+  protected long primField4;
+  protected long primField5;
 
-  @SuppressWarnings("unused") private Object field1;
-  @SuppressWarnings("unused") private Object field2;
-  @SuppressWarnings("unused") private Object field3;
-  @SuppressWarnings("unused") private Object field4;
-  @SuppressWarnings("unused") private Object field5;
+  protected Object field1;
+  protected Object field2;
+  protected Object field3;
+  protected Object field4;
+  protected Object field5;
 
-  @CompilationFinal(dimensions = 0) private long[]   extensionPrimFields;
-  @CompilationFinal(dimensions = 0) private Object[] extensionObjFields;
+  @CompilationFinal(dimensions = 0) protected long[]   extensionPrimFields;
+  @CompilationFinal(dimensions = 0) protected Object[] extensionObjFields;
 
   // we manage the layout entirely in the class, but need to keep a copy here
   // to know in case the layout changed that we can update the instances lazily

--- a/tests/trufflesom/intepreter/objectstorage/BasicStorageTester.java
+++ b/tests/trufflesom/intepreter/objectstorage/BasicStorageTester.java
@@ -1,0 +1,227 @@
+package trufflesom.intepreter.objectstorage;
+
+import java.util.Arrays;
+
+import org.junit.Ignore;
+
+import trufflesom.interpreter.objectstorage.StorageLocation;
+import trufflesom.vm.constants.Nil;
+import trufflesom.vmobjects.SObject;
+
+
+@Ignore // Make sure JUnit doesn't fail, but ignores our custom test
+public class BasicStorageTester {
+
+  private static boolean someAssertionsFailed = false;
+
+  private static final class STestObject extends SObject {
+
+    STestObject(final int numFields) {
+      super(numFields);
+
+      this.extensionObjFields = new Object[numFields - SObject.NUM_OBJECT_FIELDS];
+      this.extensionPrimFields = new long[numFields - SObject.NUM_PRIMITIVE_FIELDS];
+
+      Arrays.fill(this.extensionObjFields, Nil.nilObject);
+    }
+  }
+
+  public static void main(final String[] args) {
+    System.out.println("BasicStorageTester start tests.");
+    System.out.println();
+
+    SObject obj = new STestObject(100);
+
+    testDirectStorage(obj);
+
+    testDirectDouble(obj);
+    testDirectLong(obj);
+    testDirectObject(obj);
+
+    testExtDouble(obj);
+    testExtLong(obj);
+    testExtObject(obj);
+
+    for (int i = 0; i < 100; i++) {
+      SObject doubleObj = new STestObject(100);
+      testDouble(doubleObj, i, i + 1111.11);
+    }
+
+    for (int i = 0; i < 100; i++) {
+      SObject longObj = new STestObject(100);
+      testLong(longObj, i, i + 222222);
+    }
+
+    for (int i = 0; i < 100; i++) {
+      SObject objObj = new STestObject(100);
+      testObject(objObj, i, i);
+    }
+
+    System.out.println("BasicStorageTester completed.");
+
+    if (someAssertionsFailed) {
+      System.out.println("Some tests failed.");
+      System.exit(1);
+    }
+  }
+
+  private static void testDirectStorage(final SObject obj) {
+    System.out.println("\nStart testDirectStorage");
+    System.out.println("\nLong Fields");
+    for (int i = 0; i < SObject.NUM_PRIMITIVE_FIELDS; i++) {
+      testLong(obj, i, i).debugPrint(obj);
+    }
+
+    System.out.println("\nDouble Fields");
+    for (int i = 0; i < SObject.NUM_PRIMITIVE_FIELDS; i++) {
+      testDouble(obj, i, i).debugPrint(obj);
+    }
+
+    System.out.println("\nObject Fields");
+    for (int i = 0; i < SObject.NUM_PRIMITIVE_FIELDS; i++) {
+      testObject(obj, i, i).debugPrint(obj);
+    }
+
+    System.out.println("Done testDirectStorage");
+  }
+
+  private static void testDirectDouble(final SObject obj) {
+    StorageLocation sl = StorageLocation.createForDouble(null, 0, 0);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, 5.5);
+
+    double value = (double) sl.read(obj);
+    assertEquals(5.5, value);
+
+    sl.debugPrint(obj);
+  }
+
+  private static void testDirectLong(final SObject obj) {
+    StorageLocation sl = StorageLocation.createForLong(null, 1, 1);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, 32L);
+
+    long value = (long) sl.read(obj);
+
+    assertEquals(32L, value);
+    sl.debugPrint(obj);
+  }
+
+  private static void testDirectObject(final SObject obj) {
+    StorageLocation sl = StorageLocation.createForObject(null, 2);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, obj);
+
+    Object value = sl.read(obj);
+
+    assertIs(obj, value);
+    sl.debugPrint(obj);
+  }
+
+  private static void testExtDouble(final SObject obj) {
+    StorageLocation sl = StorageLocation.createForDouble(null, 0, 10);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, 5.5);
+
+    double value = (double) sl.read(obj);
+
+    assertEquals(5.5, value);
+  }
+
+  private static void testExtLong(final SObject obj) {
+    StorageLocation sl = StorageLocation.createForLong(null, 1, 11);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, 32L);
+
+    long value = (long) sl.read(obj);
+
+    assertEquals(32, value);
+  }
+
+  private static void testExtObject(final SObject obj) {
+    StorageLocation sl = StorageLocation.createForObject(null, 12);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, obj);
+
+    Object value = sl.read(obj);
+
+    assertIs(obj, value);
+  }
+
+  private static StorageLocation testDouble(final SObject obj, final int idx,
+      final double value) {
+    StorageLocation sl = StorageLocation.createForDouble(null, idx, idx);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, value);
+
+    double readValue = (double) sl.read(obj);
+
+    assertEquals(value, readValue);
+    return sl;
+  }
+
+  private static StorageLocation testLong(final SObject obj, final int idx, final long value) {
+    StorageLocation sl = StorageLocation.createForLong(null, idx, idx);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, value);
+
+    long readValue = (long) sl.read(obj);
+
+    assertEquals(value, readValue);
+    return sl;
+  }
+
+  private static StorageLocation testObject(final SObject obj, final int idx,
+      final Object value) {
+    StorageLocation sl = StorageLocation.createForObject(null, idx);
+    assertIsInitiallyNil(obj, sl);
+
+    sl.write(obj, value);
+
+    Object readValue = sl.read(obj);
+
+    assertIs(value, readValue);
+    return sl;
+  }
+
+  private static void assertIsInitiallyNil(final SObject obj, final StorageLocation sl) {
+    Object nil = sl.read(obj);
+    assertNil(nil);
+  }
+
+  public static void assertNil(final Object actual) {
+    if (Nil.nilObject != actual) {
+      System.out.println("Assert failed. Expected nil, but got actual: " + actual);
+      someAssertionsFailed = true;
+    }
+  }
+
+  public static void assertEquals(final long expected, final long actual) {
+    if (expected != actual) {
+      System.out.println("Assert failed. Expected: " + expected + " actual: " + actual);
+      someAssertionsFailed = true;
+    }
+  }
+
+  public static void assertEquals(final double expected, final double actual) {
+    if (expected != actual) {
+      System.out.println("Assert failed. Expected: " + expected + " actual: " + actual);
+      someAssertionsFailed = true;
+    }
+  }
+
+  public static void assertIs(final Object expected, final Object actual) {
+    if (expected != actual) {
+      System.out.println("Assert failed. Expected: " + expected + " actual: " + actual);
+      someAssertionsFailed = true;
+    }
+  }
+}

--- a/tests/trufflesom/intepreter/objectstorage/BasicStorageTester.java
+++ b/tests/trufflesom/intepreter/objectstorage/BasicStorageTester.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 
 import org.junit.Ignore;
 
+import trufflesom.interpreter.objectstorage.StorageAnalyzer;
 import trufflesom.interpreter.objectstorage.StorageLocation;
+import trufflesom.vm.Universe;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SObject;
 
@@ -27,12 +29,14 @@ public class BasicStorageTester {
   }
 
   public static void main(final String[] args) {
-    System.out.println("BasicStorageTester start tests.");
-    System.out.println();
+    StorageAnalyzer.initAccessors();
+
+    Universe.println("BasicStorageTester start tests.");
+    Universe.println();
+
+    testDirectStorage();
 
     SObject obj = new STestObject(100);
-
-    testDirectStorage(obj);
 
     testDirectDouble(obj);
     testDirectLong(obj);
@@ -57,32 +61,34 @@ public class BasicStorageTester {
       testObject(objObj, i, i);
     }
 
-    System.out.println("BasicStorageTester completed.");
+    Universe.println("BasicStorageTester completed.");
 
     if (someAssertionsFailed) {
-      System.out.println("Some tests failed.");
+      Universe.println("Some tests failed.");
       System.exit(1);
     }
   }
 
-  private static void testDirectStorage(final SObject obj) {
-    System.out.println("\nStart testDirectStorage");
-    System.out.println("\nLong Fields");
+  private static void testDirectStorage() {
+    SObject obj = new STestObject(5);
+    Universe.println("\nStart testDirectStorage");
+    Universe.println("\nLong Fields");
     for (int i = 0; i < SObject.NUM_PRIMITIVE_FIELDS; i++) {
       testLong(obj, i, i).debugPrint(obj);
     }
 
-    System.out.println("\nDouble Fields");
+    obj = new STestObject(5);
+    Universe.println("\nDouble Fields");
     for (int i = 0; i < SObject.NUM_PRIMITIVE_FIELDS; i++) {
       testDouble(obj, i, i).debugPrint(obj);
     }
 
-    System.out.println("\nObject Fields");
+    Universe.println("\nObject Fields");
     for (int i = 0; i < SObject.NUM_PRIMITIVE_FIELDS; i++) {
       testObject(obj, i, i).debugPrint(obj);
     }
 
-    System.out.println("Done testDirectStorage");
+    Universe.println("Done testDirectStorage");
   }
 
   private static void testDirectDouble(final SObject obj) {
@@ -199,28 +205,28 @@ public class BasicStorageTester {
 
   public static void assertNil(final Object actual) {
     if (Nil.nilObject != actual) {
-      System.out.println("Assert failed. Expected nil, but got actual: " + actual);
+      Universe.println("Assert failed. Expected nil, but got actual: " + actual);
       someAssertionsFailed = true;
     }
   }
 
   public static void assertEquals(final long expected, final long actual) {
     if (expected != actual) {
-      System.out.println("Assert failed. Expected: " + expected + " actual: " + actual);
+      Universe.println("Assert failed. Expected: " + expected + " actual: " + actual);
       someAssertionsFailed = true;
     }
   }
 
   public static void assertEquals(final double expected, final double actual) {
     if (expected != actual) {
-      System.out.println("Assert failed. Expected: " + expected + " actual: " + actual);
+      Universe.println("Assert failed. Expected: " + expected + " actual: " + actual);
       someAssertionsFailed = true;
     }
   }
 
   public static void assertIs(final Object expected, final Object actual) {
     if (expected != actual) {
-      System.out.println("Assert failed. Expected: " + expected + " actual: " + actual);
+      Universe.println("Assert failed. Expected: " + expected + " actual: " + actual);
       someAssertionsFailed = true;
     }
   }

--- a/tests/trufflesom/tests/BasicInterpreterTests.java
+++ b/tests/trufflesom/tests/BasicInterpreterTests.java
@@ -36,6 +36,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import trufflesom.interpreter.SomLanguage;
+import trufflesom.interpreter.objectstorage.StorageAnalyzer;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SSymbol;
@@ -181,6 +182,8 @@ public class BasicInterpreterTests {
 
   @Test
   public void testBasicInterpreterBehavior() {
+    StorageAnalyzer.initAccessors();
+
     Builder builder = Universe.createContextBuilder();
     builder.option("som.CLASS_PATH", "Smalltalk:TestSuite/BasicInterpreterTests");
     builder.option("som.TEST_CLASS", testClass);


### PR DESCRIPTION
This PR adds support for native image, i.e., the SubstrateVM/SVM version of TruffleSOM.
After building, there's now a `som-native` binary.

- introduce StorageAnalyzer in our object model implementation, which essentially determines the offsets for unsafe accesses
- added a test for the storage analyzer bit
- update checkstyle to the latest version supported by Eclipse

- added various `@TruffleBoundary` annotations to make the native image compilation work. Unfortunately, these will hide optimizations, which may become desirable when supporting new benchmarks
- change how InlinableNodes are initialized to make sure it works in AOT mode (preinit statically)
- adopt SOMns version of the Lexer to avoid use of reflection, now the file is loaded in a string

/cc @sophie-kaleba might become relevant for you at some point. Gives more options when it comes to experiments.