### PR TITLE
Avoid need for instances of SObject for Booleans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
+/.metadata
 build
 src_gen
 user-dict.txt
 /libs/*.jar
 /libs/jvmci/
+/libs/jvmci.tar.gz
+/graal_dumps
+/som-native
+/som-obj-storage-tester
+/workingsets.xml
+/*.launch
+/rebench.data
+/payload.json

--- a/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileCache.java
+++ b/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileCache.java
@@ -18,13 +18,9 @@ public abstract class WhileCache extends BinaryExpressionNode {
   public static final int INLINE_CACHE_SIZE = 6;
 
   protected final boolean predicateBool;
-  private final SObject   trueObject;
-  private final SObject   falseObject;
 
   public WhileCache(final boolean predicateBool, final Universe universe) {
     this.predicateBool = predicateBool;
-    this.trueObject = universe.getTrueObject();
-    this.falseObject = universe.getFalseObject();
   }
 
   @Specialization(limit = "INLINE_CACHE_SIZE",
@@ -40,13 +36,9 @@ public abstract class WhileCache extends BinaryExpressionNode {
   private boolean obj2bool(final Object o) {
     if (o instanceof Boolean) {
       return (boolean) o;
-    } else if (o == trueObject) {
-      CompilerAsserts.neverPartOfCompilation("obj2Bool1");
-      return true;
     } else {
-      CompilerAsserts.neverPartOfCompilation("obj2Bool2");
-      assert o == falseObject;
-      return false;
+      throw new IllegalStateException(
+          "This should not happen! There are no objects that are booleans, and we only support booleans.");
     }
   }
 

--- a/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileCache.java
+++ b/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileCache.java
@@ -45,9 +45,8 @@ public abstract class WhileCache extends BinaryExpressionNode {
   @Specialization(replaces = "doCached")
   public final SObject doUncached(final VirtualFrame frame, final SBlock loopCondition,
       final SBlock loopBody) {
-    CompilerAsserts.neverPartOfCompilation("WhileCache.GenericDispatch"); // no caching, direct
-                                                                          // invokes, no loop
-                                                                          // count reporting...
+    // no caching, direct invokes, no loop count reporting...
+    CompilerAsserts.neverPartOfCompilation("WhileCache.GenericDispatch");
 
     Object conditionResult = loopCondition.getMethod().invoke(new Object[] {loopCondition});
 

--- a/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
@@ -2,12 +2,10 @@ package trufflesom.primitives.basics;
 
 import java.math.BigInteger;
 
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.BinaryExpressionNode.BinarySystemOperation;
-import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SArray;
 import trufflesom.vmobjects.SBlock;
 import trufflesom.vmobjects.SInvokable;
@@ -18,17 +16,6 @@ import trufflesom.vmobjects.SSymbol;
 @Primitive(className = "Object", primitive = "==", selector = "==")
 public abstract class EqualsEqualsPrim extends BinarySystemOperation {
 
-  @CompilationFinal private SObject trueObject;
-  @CompilationFinal private SObject falseObject;
-
-  @Override
-  public EqualsEqualsPrim initialize(final Universe universe) {
-    super.initialize(universe);
-    this.trueObject = universe.getTrueObject();
-    this.falseObject = universe.getFalseObject();
-    return this;
-  }
-
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {
     return left == right;
@@ -36,8 +23,7 @@ public abstract class EqualsEqualsPrim extends BinarySystemOperation {
 
   @Specialization
   public final boolean doBoolean(final boolean left, final SObject right) {
-    return (left && trueObject == right) ||
-        (!left && falseObject == right);
+    return false;
   }
 
   @Specialization

--- a/src/trufflesom/primitives/basics/EqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsPrim.java
@@ -2,12 +2,10 @@ package trufflesom.primitives.basics;
 
 import java.math.BigInteger;
 
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.BinaryExpressionNode.BinarySystemOperation;
-import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SObject;
 import trufflesom.vmobjects.SSymbol;
 
@@ -18,17 +16,6 @@ import trufflesom.vmobjects.SSymbol;
 @Primitive(selector = "=")
 public abstract class EqualsPrim extends BinarySystemOperation {
 
-  @CompilationFinal private SObject trueObject;
-  @CompilationFinal private SObject falseObject;
-
-  @Override
-  public BinarySystemOperation initialize(final Universe universe) {
-    super.initialize(universe);
-    this.trueObject = universe.getTrueObject();
-    this.falseObject = universe.getFalseObject();
-    return this;
-  }
-
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {
     return left == right;
@@ -36,8 +23,7 @@ public abstract class EqualsPrim extends BinarySystemOperation {
 
   @Specialization
   public final boolean doBoolean(final boolean left, final SObject right) {
-    return (left && right == trueObject) ||
-        (!left && right == falseObject);
+    return false;
   }
 
   @Specialization

--- a/src/trufflesom/primitives/basics/UnequalsPrim.java
+++ b/src/trufflesom/primitives/basics/UnequalsPrim.java
@@ -2,12 +2,10 @@ package trufflesom.primitives.basics;
 
 import java.math.BigInteger;
 
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.BinaryExpressionNode.BinarySystemOperation;
-import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SObject;
 import trufflesom.vmobjects.SSymbol;
 
@@ -20,17 +18,6 @@ import trufflesom.vmobjects.SSymbol;
 @Primitive(selector = "~=")
 public abstract class UnequalsPrim extends BinarySystemOperation {
 
-  @CompilationFinal private SObject trueObject;
-  @CompilationFinal private SObject falseObject;
-
-  @Override
-  public BinarySystemOperation initialize(final Universe universe) {
-    super.initialize(universe);
-    this.trueObject = universe.getTrueObject();
-    this.falseObject = universe.getFalseObject();
-    return this;
-  }
-
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {
     return left != right;
@@ -38,8 +25,7 @@ public abstract class UnequalsPrim extends BinarySystemOperation {
 
   @Specialization
   public final boolean doBoolean(final boolean left, final SObject right) {
-    return (left && right != trueObject) ||
-        (!left && right != falseObject);
+    return true;
   }
 
   @Specialization

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -416,18 +416,14 @@ public final class Universe implements IdProvider<SSymbol> {
     // Load the generic block class
     blockClasses[0] = loadClass(symbolFor("Block"));
 
-    // Setup the true and false objects
-    trueObject = newInstance(trueClass);
-    falseObject = newInstance(falseClass);
-
     // Load the system class and create an instance of it
     systemClass = loadClass(symbolFor("System"));
     systemObject = newInstance(systemClass);
 
     // Put special objects into the dictionary of globals
     setGlobal("nil", nilObject);
-    setGlobal("true", trueObject);
-    setGlobal("false", falseObject);
+    setGlobal("true", true);
+    setGlobal("false", false);
     setGlobal("system", systemObject);
 
     // Load the remaining block classes
@@ -723,14 +719,6 @@ public final class Universe implements IdProvider<SSymbol> {
     // Checkstyle: resume
   }
 
-  public SObject getTrueObject() {
-    return trueObject;
-  }
-
-  public SObject getFalseObject() {
-    return falseObject;
-  }
-
   public SObject getSystemObject() {
     return systemObject;
   }
@@ -771,8 +759,6 @@ public final class Universe implements IdProvider<SSymbol> {
 
   public final SClass booleanClass;
 
-  @CompilationFinal private SObject trueObject;
-  @CompilationFinal private SObject falseObject;
   @CompilationFinal private SObject systemObject;
 
   @CompilationFinal private SClass trueClass;

--- a/src/trufflesom/vmobjects/SObject.java
+++ b/src/trufflesom/vmobjects/SObject.java
@@ -26,7 +26,6 @@ package trufflesom.vmobjects;
 
 import static trufflesom.interpreter.TruffleCompiler.transferToInterpreterAndInvalidate;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -279,43 +278,5 @@ public class SObject extends SAbstractObject {
 
     StorageLocation location = getLocation(index);
     location.write(this, value);
-  }
-
-  private static long getObjectFieldLength() {
-    CompilerAsserts.neverPartOfCompilation("getObjectFieldLength()");
-
-    try {
-      long dist = getFieldDistance("field1", "field2");
-      // this can go wrong if the VM rearranges fields to fill holes in the
-      // memory layout of the object structure
-      assert dist == 4
-          || dist == 8 : "We expect these fields to be adjecent and either 32 or 64bit appart.";
-      return dist;
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static long getPrimFieldLength() {
-    CompilerAsserts.neverPartOfCompilation("getPrimFieldLength()");
-
-    try {
-      long dist = getFieldDistance("primField1", "primField2");
-      // this can go wrong if the VM rearranges fields to fill holes in the
-      // memory layout of the object structure
-      assert dist == 8 : "We expect these fields to be adjecent and 64bit appart.";
-      return dist;
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static long getFieldDistance(final String field1, final String field2)
-      throws NoSuchFieldException,
-      IllegalAccessException {
-    final Field firstField = SObject.class.getDeclaredField(field1);
-    final Field secondField = SObject.class.getDeclaredField(field2);
-    return StorageLocation.getFieldOffset(secondField)
-        - StorageLocation.getFieldOffset(firstField);
   }
 }


### PR DESCRIPTION
This PR removes the instantiation of the classes `True` and `False` from the code base.
It's not needed, because we use Java's `true` and `false` to represent the only instances of these classes there are.

The PR also does a bit of maintenance:
 - remove unused code from Object (left over from object model changes for #47)
 - add more things to .gitignore
 - fix some comment formatting