### PR TITLE
Add target for a bytecode native image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ user-dict.txt
 /libs/jvmci/
 /libs/jvmci.tar.gz
 /graal_dumps
-/som-native
+/som-native*
 /som-obj-storage-tester
 /workingsets.xml
 /*.launch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,6 @@ benchmark_job:
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ${ANT} compile native
+    - ${ANT} compile native-ast
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf TruffleSOM
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/build.xml
+++ b/build.xml
@@ -395,10 +395,10 @@
         <travis target="som-test" />
     </target>
 
-    <target name="native-tests" depends="native">
+    <target name="native-tests" depends="native-ast">
       <travis target="native-tests" start="Run TruffleSOM native image Tests" />
 
-      <exec executable="${src.dir}/../som-native" failonerror="true">
+      <exec executable="${src.dir}/../som-native-ast" failonerror="true">
           <arg value="-cp" />
           <arg value="Smalltalk" />
           <arg value="TestSuite/TestHarness.com" />
@@ -409,15 +409,16 @@
     
     <target name="tests" depends="test,som-test" />
     
-    <target name="native" depends="truffle-libs,libs,jvmci-libs,compile-som,compile-native"></target>
+    <target name="native-ast" depends="truffle-libs,libs,jvmci-libs,compile-som,compile-native-ast"></target>
 
-    <target name="compile-native">
+    <target name="compile-native-ast">
       <travis target="native" start="Build Native Image" />
 
       <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
         <env key="JAVA_HOME" value="${jvmci.home}" />
         <arg line="native-image" />
         <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
+        <arg line="-Dsom.interp=AST" />
         <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->
 
         <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
@@ -427,13 +428,41 @@
 
         <arg line="-cp ${ant.refid:common.cp}" />
         <arg line="trufflesom.vm.Universe" />
-        <arg line="som-native" />
+        <arg line="som-native-ast" />
       </exec>
 
-      <move file="${svm.dir}/som-native" todir="${src.dir}/../" />
+      <move file="${svm.dir}/som-native-ast" todir="${src.dir}/../" />
 
       <travis target="native" />
     </target>
+
+    <target name="native-bc" depends="truffle-libs,libs,jvmci-libs,compile-som,compile-native-bc"></target>
+
+    <target name="compile-native-bc">
+      <travis target="native" start="Build Native Image" />
+
+      <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
+        <env key="JAVA_HOME" value="${jvmci.home}" />
+        <arg line="native-image" />
+        <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
+        <arg line="-Dsom.interp=BC" />
+        <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->
+
+        <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
+        <!-- <arg line="-H:+PrintMethodHistogram" />
+             <arg line="-H:+RuntimeAssertions" />
+             <arg line="-H:+EnforceMaxRuntimeCompileMethods" /> -->
+
+        <arg line="-cp ${ant.refid:common.cp}" />
+        <arg line="trufflesom.vm.Universe" />
+        <arg line="som-native-bc" />
+      </exec>
+
+      <move file="${svm.dir}/som-native-bc" todir="${src.dir}/../" />
+
+      <travis target="native" />
+    </target>
+
     
     <target name="native-obj-storage-test" depends="truffle-libs,libs,jvmci-libs,compile-som,compile-native-obj-storage-test"></target>
 

--- a/rebench.conf
+++ b/rebench.conf
@@ -113,7 +113,7 @@ executors:
 
     TruffleSOM-native:
         path: .
-        executable: som-native
+        executable: som-native-ast
     
 
 # define the benchmarks to be executed for a re-executable benchmark run


### PR DESCRIPTION
This generates a native image for TruffleSOM with a bytecode interpreter.