### PR TITLE
Benchmark native interpreters preferably

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,7 @@ benchmark_job:
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ${ANT} compile native-ast
+    - ${ANT} compile native-ast -Dno.jit=true
+    - ${ANT} compile native-bc  -Dno.jit=true
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf TruffleSOM
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/build.xml
+++ b/build.xml
@@ -419,6 +419,7 @@
         <arg line="native-image" />
         <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
         <arg line="-Dsom.interp=AST" />
+        <arg line="-Dsom.jitCompiler=false" if:true="${no.jit}" />
         <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->
 
         <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
@@ -431,8 +432,10 @@
         <arg line="som-native-ast" />
       </exec>
 
-      <move file="${svm.dir}/som-native-ast" todir="${src.dir}/../" />
 
+      <move file="${svm.dir}/som-native-ast" todir="${src.dir}/../" />
+      <move file="${src.dir}/../som-native-ast" tofile="${src.dir}/../som-native-interp-ast" if:true="${no.jit}" />
+      
       <travis target="native" />
     </target>
 
@@ -446,6 +449,7 @@
         <arg line="native-image" />
         <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
         <arg line="-Dsom.interp=BC" />
+        <arg line="-Dsom.jitCompiler=false" if:true="${no.jit}" />
         <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->
 
         <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
@@ -459,6 +463,8 @@
       </exec>
 
       <move file="${svm.dir}/som-native-bc" todir="${src.dir}/../" />
+      <move file="${src.dir}/../som-native-bc" tofile="${src.dir}/../som-native-interp-bc" if:true="${no.jit}" />
+          
 
       <travis target="native" />
     </target>

--- a/rebench.conf
+++ b/rebench.conf
@@ -114,6 +114,16 @@ executors:
     TruffleSOM-native:
         path: .
         executable: som-native-ast
+    TruffleSOM-native-bc:
+        path: .
+        executable: som-native-bc
+
+    TruffleSOM-native-interp-ast:
+        path: .
+        executable: som-native-interp-ast
+    TruffleSOM-native-interp-bc:
+        path: .
+        executable: som-native-interp-bc
     
 
 # define the benchmarks to be executed for a re-executable benchmark run
@@ -121,14 +131,14 @@ experiments:
     TruffleSOM:
         description: All benchmarks on TruffleSOM (Java, AST Interpreter)
         executions:
-            - TruffleSOM-interp:
-                suites:
-                    - micro-startup
-                    - macro-startup
-            - TruffleSOM-interp-bc:
-                suites:
-                    - micro-startup
-                    - macro-startup
+            # - TruffleSOM-interp:
+            #     suites:
+            #         - micro-startup
+            #         - macro-startup
+            # - TruffleSOM-interp-bc:
+            #     suites:
+            #         - micro-startup
+            #         - macro-startup
             - TruffleSOM-graal:
                 suites:
                     - micro-startup
@@ -141,10 +151,11 @@ experiments:
                     - micro-steady
                     - macro-startup
                     - macro-steady
-            - TruffleSOM-native:
+            - TruffleSOM-native-interp-ast:
                 suites:
                     - micro-startup
-                    - micro-steady
                     - macro-startup
-                    - macro-steady
-            
+            - TruffleSOM-native-interp-bc:
+                suites:
+                    - micro-startup
+                    - macro-startup

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -135,6 +135,10 @@ public final class Universe implements IdProvider<SSymbol> {
     Builder builder = createContextBuilder();
     builder.arguments(SomLanguage.LANG_ID, arguments);
 
+    if (!VmSettings.UseJitCompiler) {
+      builder.option("engine.Compilation", "false");
+    }
+
     Context context = builder.build();
 
     Value returnCode = context.eval(SomLanguage.START);

--- a/src/trufflesom/vm/VmSettings.java
+++ b/src/trufflesom/vm/VmSettings.java
@@ -7,6 +7,7 @@ public class VmSettings implements Settings {
 
   public static final boolean UseAstInterp;
   public static final boolean UseBcInterp;
+  public static final boolean UseJitCompiler;
 
   static {
     String val = System.getProperty("som.interp", "AST").toUpperCase();
@@ -17,6 +18,9 @@ public class VmSettings implements Settings {
       throw new IllegalStateException("The Java property -Dsom.interp=" + val
           + " was set, which is not supported. Currently, only the values BC and AST are supported.");
     }
+
+    val = System.getProperty("som.jitCompiler", "true");
+    UseJitCompiler = "true".equals(val);
   }
 
   @Override


### PR DESCRIPTION
This should reduce a little bit the noise in measurements, and allows me to more clearly see impact on interpreter performance.

This adds the `-Dno.jit=true` flag to build.xml and the `-Dsom.jitCompiler=false` flag to SOM.