### PR TITLE
Optimize frequently used bytecode sequences

### DIFF
--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -49,8 +49,8 @@ import trufflesom.compiler.Variable.Local;
 import trufflesom.interpreter.LexicalScope;
 import trufflesom.interpreter.Method;
 import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.FieldNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
-import trufflesom.interpreter.nodes.FieldNode.FieldWriteNode;
 import trufflesom.interpreter.nodes.ReturnNonLocalNode;
 import trufflesom.interpreter.nodes.literals.BlockNode;
 import trufflesom.primitives.Primitives;
@@ -406,7 +406,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
         holderGenc.getFieldIndex(fieldName), source);
   }
 
-  public FieldWriteNode getObjectFieldWrite(final SSymbol fieldName,
+  public FieldNode getObjectFieldWrite(final SSymbol fieldName,
       final ExpressionNode exp, final Universe universe,
       final SourceSection source) {
     if (!holderGenc.hasField(fieldName)) {

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -503,7 +503,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
 
   protected ExpressionNode expression(final MGenC mgenc)
       throws ProgramDefinitionError {
-    peekForNextSymbolFromLexer();
+    peekForNextSymbolFromLexerIfNecessary();
 
     if (nextSym == Assign) {
       return assignation(mgenc);

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -80,7 +80,7 @@ import trufflesom.vmobjects.SSymbol;
 public abstract class Parser<MGenC extends MethodGenerationContext> {
 
   protected final Universe universe;
-  private final Lexer      lexer;
+  protected final Lexer    lexer;
   private final Source     source;
 
   protected final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe;

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -28,7 +28,7 @@ import bd.inlining.InlinableNodes;
 import bd.source.SourceCoordinate;
 import bd.tools.structure.StructuralProbe;
 import trufflesom.interpreter.nodes.ExpressionNode;
-import trufflesom.interpreter.nodes.FieldNode.FieldWriteNode;
+import trufflesom.interpreter.nodes.FieldNode;
 import trufflesom.interpreter.nodes.GlobalNode;
 import trufflesom.interpreter.nodes.literals.ArrayLiteralNode;
 import trufflesom.interpreter.nodes.literals.BigIntegerLiteralNode;
@@ -160,7 +160,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
       return mgenc.getLocalWriteNode(variableName, exp, source);
     }
 
-    FieldWriteNode fieldWrite = mgenc.getObjectFieldWrite(variableName, exp, universe, source);
+    FieldNode fieldWrite = mgenc.getObjectFieldWrite(variableName, exp, universe, source);
 
     if (fieldWrite != null) {
       return fieldWrite;

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -54,12 +54,11 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
 
     // if no return has been generated so far, we can be sure there was no .
     // terminating the last expression, so the last expression's value must
-    // be
-    // popped off the stack and a ^self be generated
+    // be popped off the stack and a ^self be generated
     if (!mgenc.isFinished()) {
-      bcGen.emitPOP(mgenc);
-      bcGen.emitPUSHARGUMENT(mgenc, (byte) 0, (byte) 0);
-      bcGen.emitRETURNLOCAL(mgenc);
+      // with the new RETURN_SELF, we don't actually need the extra stack space
+      // bcGen.emitPOP(mgenc);
+      bcGen.emitRETURNSELF(mgenc);
       mgenc.markFinished();
     }
 
@@ -89,12 +88,10 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
       bcGen.emitRETURNLOCAL(mgenc);
       mgenc.markFinished();
     } else if (sym == EndTerm) {
-      // it does not matter whether a period has been seen, as the end of
-      // the
-      // method has been found (EndTerm) - so it is safe to emit a "return
-      // self"
-      bcGen.emitPUSHARGUMENT(mgenc, (byte) 0, (byte) 0);
-      bcGen.emitRETURNLOCAL(mgenc);
+      // it does not matter whether a period has been seen,
+      // as the end of the method has been found (EndTerm) -
+      // so it is safe to emit a "return self"
+      bcGen.emitRETURNSELF(mgenc);
       mgenc.markFinished();
     } else {
       expression(mgenc);

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -213,6 +213,19 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     SSymbol msg = binarySelector();
     mgenc.addLiteralIfAbsent(msg, this);
 
+    boolean isPossibleIncOrDec = msg == universe.symPlus || msg == universe.symMinus;
+    if (isPossibleIncOrDec) {
+      if (sym == Integer && text.equals("1")) {
+        expect(Integer);
+        if (msg == universe.symPlus) {
+          bcGen.emitINC(mgenc);
+        } else {
+          bcGen.emitDEC(mgenc);
+        }
+        return;
+      }
+    }
+
     binaryOperand(mgenc);
 
     if (superSend) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -58,7 +58,9 @@ public class BytecodeGenerator {
   }
 
   public void emitPOP(final BytecodeMethodGenContext mgenc) {
-    emit1(mgenc, POP);
+    if (!mgenc.optimizeDupPopPopSequence()) {
+      emit1(mgenc, POP);
+    }
   }
 
   public void emitPUSHARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
@@ -138,14 +140,14 @@ public class BytecodeGenerator {
 
   private void emit2(final BytecodeMethodGenContext mgenc, final byte code, final byte idx) {
     mgenc.addBytecode(code);
-    mgenc.addBytecode(idx);
+    mgenc.addBytecodeArgument(idx);
   }
 
   private void emit3(final BytecodeMethodGenContext mgenc, final byte code, final byte idx,
       final byte ctx) {
     mgenc.addBytecode(code);
-    mgenc.addBytecode(idx);
-    mgenc.addBytecode(ctx);
+    mgenc.addBytecodeArgument(idx);
+    mgenc.addBytecodeArgument(ctx);
   }
 
 }

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -24,7 +24,9 @@
  */
 package trufflesom.compiler.bc;
 
+import static trufflesom.interpreter.bc.Bytecodes.DEC;
 import static trufflesom.interpreter.bc.Bytecodes.DUP;
+import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -46,6 +48,14 @@ import trufflesom.vmobjects.SSymbol;
 
 
 public class BytecodeGenerator {
+
+  public void emitINC(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, INC);
+  }
+
+  public void emitDEC(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, DEC);
+  }
 
   public void emitPOP(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, POP);

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -37,6 +37,7 @@ import static trufflesom.interpreter.bc.Bytecodes.PUSH_GLOBAL;
 import static trufflesom.interpreter.bc.Bytecodes.PUSH_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_NON_LOCAL;
+import static trufflesom.interpreter.bc.Bytecodes.RETURN_SELF;
 import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 
@@ -57,6 +58,10 @@ public class BytecodeGenerator {
 
   public void emitRETURNLOCAL(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, RETURN_LOCAL);
+  }
+
+  public void emitRETURNSELF(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, RETURN_SELF);
   }
 
   public void emitRETURNNONLOCAL(final BytecodeMethodGenContext mgenc) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -115,12 +115,7 @@ public class BytecodeGenerator {
 
   public void emitPOPFIELD(final BytecodeMethodGenContext mgenc, final SSymbol fieldName) {
     assert mgenc.hasField(fieldName);
-
-    byte fieldIndex = mgenc.getFieldIndex(fieldName);
-    byte ctxLevel = mgenc.getMaxContextLevel();
-    if (!mgenc.optimizePushIncPopSequence(fieldIndex, ctxLevel)) {
-      emit3(mgenc, POP_FIELD, fieldIndex, ctxLevel);
-    }
+    emit3(mgenc, POP_FIELD, mgenc.getFieldIndex(fieldName), mgenc.getMaxContextLevel());
   }
 
   public void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -115,7 +115,12 @@ public class BytecodeGenerator {
 
   public void emitPOPFIELD(final BytecodeMethodGenContext mgenc, final SSymbol fieldName) {
     assert mgenc.hasField(fieldName);
-    emit3(mgenc, POP_FIELD, mgenc.getFieldIndex(fieldName), mgenc.getMaxContextLevel());
+
+    byte fieldIndex = mgenc.getFieldIndex(fieldName);
+    byte ctxLevel = mgenc.getMaxContextLevel();
+    if (!mgenc.optimizePushIncPopSequence(fieldIndex, ctxLevel)) {
+      emit3(mgenc, POP_FIELD, fieldIndex, ctxLevel);
+    }
   }
 
   public void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -5,6 +5,7 @@ import static trufflesom.interpreter.bc.Bytecodes.DUP;
 import static trufflesom.interpreter.bc.Bytecodes.HALT;
 import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
+import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -53,7 +54,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   private final LinkedHashMap<SSymbol, Local> outerVars;
 
   private final ArrayList<Byte> bytecode;
-  private final byte[]          lastThreeBytecodes;
+  private final byte[]          last4Bytecodes;
 
   private boolean finished;
 
@@ -80,7 +81,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     literals = new ArrayList<>();
     bytecode = new ArrayList<>();
     outerVars = new LinkedHashMap<>();
-    lastThreeBytecodes = new byte[3];
+    last4Bytecodes = new byte[4];
   }
 
   public byte getMaxContextLevel() {
@@ -104,9 +105,10 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
   public void addBytecode(final byte code) {
     bytecode.add(code);
-    lastThreeBytecodes[0] = lastThreeBytecodes[1];
-    lastThreeBytecodes[1] = lastThreeBytecodes[2];
-    lastThreeBytecodes[2] = code;
+    last4Bytecodes[0] = last4Bytecodes[1];
+    last4Bytecodes[1] = last4Bytecodes[2];
+    last4Bytecodes[2] = last4Bytecodes[3];
+    last4Bytecodes[3] = code;
   }
 
   public void addBytecodeArgument(final byte code) {
@@ -132,11 +134,11 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
    * {@link #optimizeDupPopPopSequence()}.
    */
   public void removeLastPopForBlockLocalReturn() {
-    if (lastThreeBytecodes[2] == POP) {
+    if (last4Bytecodes[3] == POP) {
       int idx = bytecode.size() - 1;
       bytecode.remove(idx);
-    } else if ((lastThreeBytecodes[2] == POP_FIELD || lastThreeBytecodes[2] == POP_LOCAL)
-        && lastThreeBytecodes[1] == -1) {
+    } else if ((last4Bytecodes[3] == POP_FIELD || last4Bytecodes[3] == POP_LOCAL)
+        && last4Bytecodes[2] == -1) {
       // we just removed the DUP and didn't emit the POP using optimizeDupPopPopSequence()
       // so, to make blocks work, we need to reintroduce the DUP
       assert Bytecodes.getBytecodeLength(POP_LOCAL) == Bytecodes.getBytecodeLength(POP_FIELD);
@@ -144,6 +146,14 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
       assert bytecode.get(bytecode.size() - 3) == POP_LOCAL
           || bytecode.get(bytecode.size() - 3) == POP_FIELD;
       bytecode.add(bytecode.size() - 3, DUP);
+    } else if (last4Bytecodes[3] == INC_FIELD) {
+      // we optimized the sequence to an INC_FIELD, which doesn't modify the stack
+      // but since we need the value to return it from the block, we need to push it.
+      last4Bytecodes[3] = INC_FIELD_PUSH;
+      assert Bytecodes.getBytecodeLength(INC_FIELD) == 3;
+      assert Bytecodes.getBytecodeLength(INC_FIELD) == Bytecodes.getBytecodeLength(
+          INC_FIELD_PUSH);
+      bytecode.set(bytecode.size() - 3, INC_FIELD_PUSH);
     }
   }
 
@@ -253,48 +263,89 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
       return false;
     }
 
-    final byte popCandidate = lastThreeBytecodes[2];
-    final byte dupCandidate = lastThreeBytecodes[1];
+    final byte dupCandidate = last4Bytecodes[2];
+    final byte popCandidate = last4Bytecodes[3];
 
     if ((popCandidate == POP_LOCAL || popCandidate == POP_FIELD) && dupCandidate == DUP) {
+      if (popCandidate == POP_FIELD && optimizePushFieldIncDupPopField()) {
+        return true;
+      }
 
       // remove the DUP bytecode
       bytecode.remove(size - 4);
 
-      lastThreeBytecodes[0] = -1;
-      lastThreeBytecodes[1] = -1;
-      lastThreeBytecodes[2] = popCandidate;
+      last4Bytecodes[0] = -1;
+      last4Bytecodes[1] = -1;
+      last4Bytecodes[2] = -1;
+      last4Bytecodes[3] = popCandidate;
       return true;
     }
     return false;
   }
 
-  public boolean optimizePushIncPopSequence(final byte fieldIdx, final byte ctxLevel) {
+  /**
+   * This is going to try to optimize the following sequence, assuming that a pop would be
+   * generated next.
+   *
+   * <pre>
+   *   PUSH_FIELD
+   *   INC
+   *   DUP
+   *   POP_FIELD
+   * </pre>
+   *
+   * @return true, if it optimized it.
+   */
+  private boolean optimizePushFieldIncDupPopField() {
     final int size = bytecode.size();
 
     assert Bytecodes.getBytecodeLength(PUSH_FIELD) == 3;
+    assert Bytecodes.getBytecodeLength(POP_FIELD) == 3;
     assert Bytecodes.getBytecodeLength(INC) == 1;
+    assert Bytecodes.getBytecodeLength(DUP) == 1;
 
-    if (size - 4 < 0) {
+    if (size - (3 + 1 + 1 + 3) < 0) {
       return false;
     }
 
-    final byte incCandidate = lastThreeBytecodes[2];
-    final byte pushCandidate = lastThreeBytecodes[1];
-    final byte pushFieldIdx = bytecode.get(size - 3);
-    final byte pushCtxLevel = bytecode.get(size - 2);
+    final byte pushCandidate = last4Bytecodes[0];
+    final byte incCandidate = last4Bytecodes[1];
+    final byte dupCandidate = last4Bytecodes[2];
+    final byte popCandidate = last4Bytecodes[3];
 
-    if (incCandidate == INC && pushCandidate == PUSH_FIELD &&
-        fieldIdx == pushFieldIdx && pushCtxLevel == ctxLevel) {
+    final int pushBcIdx = size - 3 - 1 - 1 - 3;
+
+    final byte pushFieldIdx = bytecode.get(pushBcIdx + 1);
+    final byte pushCtxLevel = bytecode.get(pushBcIdx + 2);
+
+    final int popBcIdx = size - 3;
+
+    final byte popFieldIdx = bytecode.get(popBcIdx + 1);
+    final byte popCtxLevel = bytecode.get(popBcIdx + 2);
+
+    if (pushCandidate == PUSH_FIELD &&
+        incCandidate == INC &&
+        dupCandidate == DUP &&
+        popCandidate == POP_FIELD &&
+        pushFieldIdx == popFieldIdx && pushCtxLevel == popCtxLevel) {
+      // remove the POP_FIELD bytecode
+      bytecode.remove(bytecode.size() - 1);
+      bytecode.remove(bytecode.size() - 1);
+      bytecode.remove(bytecode.size() - 1);
+
+      // remove the DUP bytecode
+      bytecode.remove(bytecode.size() - 1);
+
       // remove the INC bytecode
-      bytecode.remove(size - 1);
+      bytecode.remove(bytecode.size() - 1);
 
       // replace the PUSH_FIELD bytecode by INC_FIELD
-      bytecode.set(size - 4, INC_FIELD);
+      bytecode.set(pushBcIdx, INC_FIELD);
 
-      lastThreeBytecodes[0] = -1;
-      lastThreeBytecodes[1] = -1;
-      lastThreeBytecodes[2] = INC_FIELD;
+      last4Bytecodes[0] = -1;
+      last4Bytecodes[1] = -1;
+      last4Bytecodes[2] = -1;
+      last4Bytecodes[3] = INC_FIELD;
       return true;
     }
     return false;
@@ -358,6 +409,13 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
           break;
         case RETURN_NON_LOCAL:
           i += 2;
+          break;
+        case INC_FIELD:
+          i += 3;
+          break;
+        case INC_FIELD_PUSH:
+          i += 3;
+          depth++;
           break;
         default:
           throw new IllegalStateException("Illegal bytecode "

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -1,7 +1,9 @@
 package trufflesom.compiler.bc;
 
+import static trufflesom.interpreter.bc.Bytecodes.DEC;
 import static trufflesom.interpreter.bc.Bytecodes.DUP;
 import static trufflesom.interpreter.bc.Bytecodes.HALT;
+import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -264,6 +266,8 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
           i += 2;
           break;
         }
+        case INC:
+        case DEC:
         case RETURN_LOCAL:
         case RETURN_NON_LOCAL:
         case RETURN_SELF:

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -306,7 +306,9 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     int i = 0;
 
     while (i < bytecode.size()) {
-      switch (bytecode.get(i)) {
+      int oldI = i;
+      byte bc = bytecode.get(i);
+      switch (bc) {
         case HALT:
           i++;
           break;
@@ -316,10 +318,10 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
           break;
         case PUSH_LOCAL:
         case PUSH_ARGUMENT:
+        case PUSH_FIELD:
           depth++;
           i += 3;
           break;
-        case PUSH_FIELD:
         case PUSH_BLOCK:
         case PUSH_CONSTANT:
         case PUSH_GLOBAL:
@@ -332,12 +334,9 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
           break;
         case POP_LOCAL:
         case POP_ARGUMENT:
-          depth--;
-          i += 3;
-          break;
         case POP_FIELD:
           depth--;
-          i += 2;
+          i += 3;
           break;
         case SEND:
         case SUPER_SEND: {
@@ -354,14 +353,18 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
         case INC:
         case DEC:
         case RETURN_LOCAL:
-        case RETURN_NON_LOCAL:
         case RETURN_SELF:
           i++;
+          break;
+        case RETURN_NON_LOCAL:
+          i += 2;
           break;
         default:
           throw new IllegalStateException("Illegal bytecode "
               + bytecode.get(i));
       }
+
+      assert oldI + Bytecodes.getBytecodeLength(bc) == i;
 
       if (depth > maxDepth) {
         maxDepth = depth;

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -14,6 +14,7 @@ import static trufflesom.interpreter.bc.Bytecodes.PUSH_GLOBAL;
 import static trufflesom.interpreter.bc.Bytecodes.PUSH_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_NON_LOCAL;
+import static trufflesom.interpreter.bc.Bytecodes.RETURN_SELF;
 import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 
@@ -265,6 +266,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
         }
         case RETURN_LOCAL:
         case RETURN_NON_LOCAL:
+        case RETURN_SELF:
           i++;
           break;
         default:

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -159,12 +159,14 @@ public class Disassembler {
         continue;
       }
       switch (bytecode) {
+        case POP_LOCAL:
         case PUSH_LOCAL: {
           Universe.errorPrintln("local: " + m.getBytecode(b + 1) + ", context: "
               + m.getBytecode(b + 2));
           break;
         }
 
+        case POP_ARGUMENT:
         case PUSH_ARGUMENT: {
           Universe.errorPrintln("argument: " + m.getBytecode(b + 1) + ", context "
               + m.getBytecode(b + 2));
@@ -172,6 +174,7 @@ public class Disassembler {
         }
 
         case INC_FIELD:
+        case POP_FIELD:
         case PUSH_FIELD: {
           int idx = m.getBytecode(b + 1);
           int ctx = m.getBytecode(b + 2);
@@ -194,9 +197,7 @@ public class Disassembler {
           Object constant = m.getConstant(idx);
           SClass constantClass = Types.getClassOf(constant, u);
           Universe.errorPrintln("(index: " + idx + ") value: "
-              + "("
-              + constantClass.getName().toString()
-              + ") "
+              + "(" + constantClass.getName().toString() + ") "
               + constant.toString());
           break;
         }
@@ -209,39 +210,11 @@ public class Disassembler {
           break;
         }
 
-        case POP_LOCAL: {
-          Universe.errorPrintln("local: " + m.getBytecode(b + 1) + ", context: "
-              + m.getBytecode(b + 2));
-          break;
-        }
-
-        case POP_ARGUMENT: {
-          Universe.errorPrintln("argument: " + m.getBytecode(b + 1)
-              + ", context: " + m.getBytecode(b + 2));
-          break;
-        }
-
-        case POP_FIELD: {
-          int idx = m.getBytecode(b + 1);
-          int ctx = m.getBytecode(b + 2);
-          String fieldName = ((SSymbol) clazz.getInstanceFields()
-                                             .debugGetObject(idx)).getString();
-          Universe.errorPrintln("(index: " + idx
-              + ", context: " + ctx + ") field: " + fieldName);
-          break;
-        }
-
         case Q_SEND:
         case Q_SEND_1:
         case Q_SEND_2:
         case Q_SEND_3:
-        case SEND: {
-          int idx = m.getBytecode(b + 1);
-          Universe.errorPrintln("(index: " + idx
-              + ") signature: " + ((SSymbol) m.getConstant(idx)).toString());
-          break;
-        }
-
+        case SEND:
         case SUPER_SEND: {
           int idx = m.getBytecode(b + 1);
           Universe.errorPrintln("(index: " + idx

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -26,6 +26,7 @@
 
 package trufflesom.compiler.bc;
 
+import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.POP_LOCAL;
@@ -170,6 +171,7 @@ public class Disassembler {
           break;
         }
 
+        case INC_FIELD:
         case PUSH_FIELD: {
           int idx = m.getBytecode(b + 1);
           int ctx = m.getBytecode(b + 2);

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -37,6 +37,9 @@ import static trufflesom.interpreter.bc.Bytecodes.PUSH_GLOBAL;
 import static trufflesom.interpreter.bc.Bytecodes.PUSH_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.Q_PUSH_GLOBAL;
 import static trufflesom.interpreter.bc.Bytecodes.Q_SEND;
+import static trufflesom.interpreter.bc.Bytecodes.Q_SEND_1;
+import static trufflesom.interpreter.bc.Bytecodes.Q_SEND_2;
+import static trufflesom.interpreter.bc.Bytecodes.Q_SEND_3;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_NON_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
@@ -227,6 +230,9 @@ public class Disassembler {
         }
 
         case Q_SEND:
+        case Q_SEND_1:
+        case Q_SEND_2:
+        case Q_SEND_3:
         case SEND: {
           int idx = m.getBytecode(b + 1);
           Universe.errorPrintln("(index: " + idx

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -27,6 +27,7 @@
 package trufflesom.compiler.bc;
 
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
+import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.POP_LOCAL;
@@ -185,6 +186,7 @@ public class Disassembler {
         }
 
         case INC_FIELD:
+        case INC_FIELD_PUSH:
         case POP_FIELD:
         case PUSH_FIELD: {
           int idx = bytecodes.get(b + 1);

--- a/src/trufflesom/interpreter/SNodeFactory.java
+++ b/src/trufflesom/interpreter/SNodeFactory.java
@@ -15,8 +15,9 @@ import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalArgumentWriteNode;
 import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalSuperReadNode;
 import trufflesom.interpreter.nodes.ContextualNode;
 import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.FieldNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
-import trufflesom.interpreter.nodes.FieldNode.FieldWriteNode;
+import trufflesom.interpreter.nodes.FieldNode.UninitFieldIncNode;
 import trufflesom.interpreter.nodes.FieldNodeFactory.FieldWriteNodeGen;
 import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableWriteNode;
 import trufflesom.interpreter.nodes.LocalVariableNodeFactory.LocalVariableWriteNodeGen;
@@ -26,6 +27,7 @@ import trufflesom.interpreter.nodes.ReturnNonLocalNode.CatchNonLocalReturnNode;
 import trufflesom.interpreter.nodes.SequenceNode;
 import trufflesom.interpreter.nodes.UninitializedVariableNode.UninitializedVariableReadNode;
 import trufflesom.interpreter.nodes.UninitializedVariableNode.UninitializedVariableWriteNode;
+import trufflesom.interpreter.nodes.specialized.IntIncrementNode;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SSymbol;
 
@@ -43,8 +45,13 @@ public final class SNodeFactory {
     return new FieldReadNode(self, fieldIndex).initialize(source);
   }
 
-  public static FieldWriteNode createFieldWrite(final ExpressionNode self,
+  public static FieldNode createFieldWrite(final ExpressionNode self,
       final ExpressionNode exp, final int fieldIndex, final SourceSection source) {
+    if (exp instanceof IntIncrementNode
+        && ((IntIncrementNode) exp).doesAccessField(fieldIndex)) {
+      return new UninitFieldIncNode(self, fieldIndex, source);
+    }
+
     return FieldWriteNodeGen.create(fieldIndex, self, exp).initialize(source);
   }
 

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -50,11 +50,14 @@ public class Bytecodes {
   public static final byte RETURN_NON_LOCAL = 15;
   public static final byte RETURN_SELF      = 16;
 
-  public static final byte Q_PUSH_GLOBAL = 17;
-  public static final byte Q_SEND        = 18;
-  public static final byte Q_SEND_1      = 19;
-  public static final byte Q_SEND_2      = 20;
-  public static final byte Q_SEND_3      = 21;
+  public static final byte INC = 17;
+  public static final byte DEC = 18;
+
+  public static final byte Q_PUSH_GLOBAL = 19;
+  public static final byte Q_SEND        = 20;
+  public static final byte Q_SEND_1      = 21;
+  public static final byte Q_SEND_2      = 22;
+  public static final byte Q_SEND_3      = 23;
 
   private static final String[] PADDED_BYTECODE_NAMES = new String[] {
       "HALT            ", "DUP             ", "PUSH_LOCAL      ",
@@ -63,6 +66,11 @@ public class Bytecodes {
       "POP_LOCAL       ", "POP_ARGUMENT    ", "POP_FIELD       ",
       "SEND            ", "SUPER_SEND      ", "RETURN_LOCAL    ",
       "RETURN_NON_LOCAL",
+
+      "RETURN_SELF     ",
+
+      "INC             ",
+      "DEC             ",
 
       "Q_PUSH_GLOBAL   ",
       "Q_SEND          ",
@@ -115,6 +123,9 @@ public class Bytecodes {
       1, // RETURN_LOCAL
       2, // RETURN_NON_LOCAL
       1, // RETURN_SELF
+
+      1, // INC
+      1, // DEC
 
       2, // Q_PUSH_GLOBAL
       2, // Q_SEND

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -48,12 +48,13 @@ public class Bytecodes {
   public static final byte SUPER_SEND       = 13;
   public static final byte RETURN_LOCAL     = 14;
   public static final byte RETURN_NON_LOCAL = 15;
+  public static final byte RETURN_SELF      = 16;
 
-  public static final byte Q_PUSH_GLOBAL = 16;
-  public static final byte Q_SEND        = 17;
-  public static final byte Q_SEND_1      = 18;
-  public static final byte Q_SEND_2      = 19;
-  public static final byte Q_SEND_3      = 20;
+  public static final byte Q_PUSH_GLOBAL = 17;
+  public static final byte Q_SEND        = 18;
+  public static final byte Q_SEND_1      = 19;
+  public static final byte Q_SEND_2      = 20;
+  public static final byte Q_SEND_3      = 21;
 
   private static final String[] PADDED_BYTECODE_NAMES = new String[] {
       "HALT            ", "DUP             ", "PUSH_LOCAL      ",
@@ -113,6 +114,7 @@ public class Bytecodes {
       2, // SUPER_SEND
       1, // RETURN_LOCAL
       2, // RETURN_NON_LOCAL
+      1, // RETURN_SELF
 
       2, // Q_PUSH_GLOBAL
       2, // Q_SEND

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -53,13 +53,14 @@ public class Bytecodes {
   public static final byte INC = 17;
   public static final byte DEC = 18;
 
-  public static final byte INC_FIELD = 19;
+  public static final byte INC_FIELD      = 19;
+  public static final byte INC_FIELD_PUSH = 20;
 
-  public static final byte Q_PUSH_GLOBAL = 20;
-  public static final byte Q_SEND        = 21;
-  public static final byte Q_SEND_1      = 22;
-  public static final byte Q_SEND_2      = 23;
-  public static final byte Q_SEND_3      = 24;
+  public static final byte Q_PUSH_GLOBAL = 21;
+  public static final byte Q_SEND        = 22;
+  public static final byte Q_SEND_1      = 23;
+  public static final byte Q_SEND_2      = 24;
+  public static final byte Q_SEND_3      = 25;
 
   private static final String[] PADDED_BYTECODE_NAMES = new String[] {
       "HALT            ", "DUP             ", "PUSH_LOCAL      ",
@@ -75,6 +76,7 @@ public class Bytecodes {
       "DEC             ",
 
       "INC_FIELD       ",
+      "INC_FIELD_PUSH  ",
 
       "Q_PUSH_GLOBAL   ",
       "Q_SEND          ",
@@ -132,6 +134,7 @@ public class Bytecodes {
       1, // DEC
 
       3, // INC_FIELD
+      3, // INC_FIELD_PUSH
 
       2, // Q_PUSH_GLOBAL
       2, // Q_SEND

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -63,8 +63,11 @@ public class Bytecodes {
       "SEND            ", "SUPER_SEND      ", "RETURN_LOCAL    ",
       "RETURN_NON_LOCAL",
 
-      "Q_PUSH_GLOBAL",
-      "Q_SEND", "Q_SEND_1", "Q_SEND_2", "Q_SEND_3",
+      "Q_PUSH_GLOBAL   ",
+      "Q_SEND          ",
+      "Q_SEND_1        ",
+      "Q_SEND_2        ",
+      "Q_SEND_3        ",
   };
 
   private static final String[] BYTECODE_NAMES =

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -53,11 +53,13 @@ public class Bytecodes {
   public static final byte INC = 17;
   public static final byte DEC = 18;
 
-  public static final byte Q_PUSH_GLOBAL = 19;
-  public static final byte Q_SEND        = 20;
-  public static final byte Q_SEND_1      = 21;
-  public static final byte Q_SEND_2      = 22;
-  public static final byte Q_SEND_3      = 23;
+  public static final byte INC_FIELD = 19;
+
+  public static final byte Q_PUSH_GLOBAL = 20;
+  public static final byte Q_SEND        = 21;
+  public static final byte Q_SEND_1      = 22;
+  public static final byte Q_SEND_2      = 23;
+  public static final byte Q_SEND_3      = 24;
 
   private static final String[] PADDED_BYTECODE_NAMES = new String[] {
       "HALT            ", "DUP             ", "PUSH_LOCAL      ",
@@ -71,6 +73,8 @@ public class Bytecodes {
 
       "INC             ",
       "DEC             ",
+
+      "INC_FIELD       ",
 
       "Q_PUSH_GLOBAL   ",
       "Q_SEND          ",
@@ -126,6 +130,8 @@ public class Bytecodes {
 
       1, // INC
       1, // DEC
+
+      3, // INC_FIELD
 
       2, // Q_PUSH_GLOBAL
       2, // Q_SEND

--- a/src/trufflesom/interpreter/nodes/MessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/MessageSendNode.java
@@ -15,7 +15,9 @@ import trufflesom.interpreter.nodes.dispatch.DispatchChain.Cost;
 import trufflesom.interpreter.nodes.dispatch.GenericDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.SuperDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.UninitializedDispatchNode;
+import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
 import trufflesom.interpreter.nodes.nary.EagerlySpecializableNode;
+import trufflesom.interpreter.nodes.specialized.IntIncrementNodeGen;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vm.Universe;
@@ -26,6 +28,15 @@ public final class MessageSendNode {
 
   public static ExpressionNode create(final SSymbol selector,
       final ExpressionNode[] arguments, final SourceSection source, final Universe universe) {
+    if (selector.getString().charAt(0) == '+') {
+      if (arguments[1] instanceof IntegerLiteralNode) {
+        IntegerLiteralNode lit = (IntegerLiteralNode) arguments[1];
+        if (lit.executeLong(null) == 1) {
+          return IntIncrementNodeGen.create(arguments[0]);
+        }
+      }
+    }
+
     Primitives prims = universe.getPrimitives();
     Specializer<Universe, ExpressionNode, SSymbol> specializer =
         prims.getParserSpecializer(selector, arguments);

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -19,6 +19,7 @@ import static trufflesom.interpreter.bc.Bytecodes.Q_SEND_2;
 import static trufflesom.interpreter.bc.Bytecodes.Q_SEND_3;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_NON_LOCAL;
+import static trufflesom.interpreter.bc.Bytecodes.RETURN_SELF;
 import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeLength;
@@ -462,6 +463,10 @@ public class BytecodeLoopNode extends ExpressionNode {
           // stackPointer -= 1;
           doReturnNonLocal(frame, bytecodeIndex, result);
           break;
+        }
+
+        case RETURN_SELF: {
+          return frame.getArguments()[0];
         }
 
         case Q_PUSH_GLOBAL: {

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1,7 +1,9 @@
 package trufflesom.interpreter.nodes.bc;
 
+import static trufflesom.interpreter.bc.Bytecodes.DEC;
 import static trufflesom.interpreter.bc.Bytecodes.DUP;
 import static trufflesom.interpreter.bc.Bytecodes.HALT;
+import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -64,6 +66,7 @@ import trufflesom.interpreter.objectstorage.FieldAccessorNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
 import trufflesom.primitives.Primitives;
+import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SAbstractObject;
 import trufflesom.vmobjects.SArray;
@@ -467,6 +470,41 @@ public class BytecodeLoopNode extends ExpressionNode {
 
         case RETURN_SELF: {
           return frame.getArguments()[0];
+        }
+
+        case INC: {
+          Object top = stack[stackPointer];
+          if (top instanceof Long) {
+            try {
+              stack[stackPointer] = Math.addExact((Long) top, 1L);
+            } catch (ArithmeticException e) {
+              CompilerDirectives.transferToInterpreterAndInvalidate();
+              throw new NotYetImplementedException();
+            }
+          } else {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            if (top instanceof Double) {
+              stack[stackPointer] = ((Double) top) + 1.0d;
+            } else {
+              throw new NotYetImplementedException();
+            }
+          }
+          break;
+        }
+
+        case DEC: {
+          Object top = stack[stackPointer];
+          if (top instanceof Long) {
+            stack[stackPointer] = ((Long) top) - 1;
+          } else {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            if (top instanceof Double) {
+              stack[stackPointer] = ((Double) top) - 1.0d;
+            } else {
+              throw new NotYetImplementedException();
+            }
+          }
+          break;
         }
 
         case Q_PUSH_GLOBAL: {

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -27,7 +27,9 @@ import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeLength;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
@@ -752,8 +754,12 @@ public class BytecodeLoopNode extends ExpressionNode {
     return bytecodes.length;
   }
 
-  public byte getBytecode(final int idx) {
-    return bytecodes[idx];
+  public List<Byte> getBytecodes() {
+    List<Byte> list = new ArrayList<>(bytecodes.length);
+    for (byte b : bytecodes) {
+      list.add(b);
+    }
+    return list;
   }
 
   public Object getConstant(final int idx) {

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -4,6 +4,7 @@ import static trufflesom.interpreter.bc.Bytecodes.DEC;
 import static trufflesom.interpreter.bc.Bytecodes.DUP;
 import static trufflesom.interpreter.bc.Bytecodes.HALT;
 import static trufflesom.interpreter.bc.Bytecodes.INC;
+import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -65,6 +66,7 @@ import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
+import trufflesom.interpreter.objectstorage.FieldAccessorNode.IncrementLongFieldNode;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vm.Universe;
@@ -504,6 +506,44 @@ public class BytecodeLoopNode extends ExpressionNode {
               throw new NotYetImplementedException();
             }
           }
+          break;
+        }
+
+        case INC_FIELD: {
+          byte fieldIdx = bytecodes[bytecodeIndex + 1];
+          byte contextIdx = bytecodes[bytecodeIndex + 2];
+
+          VirtualFrame currentOrContext = frame;
+          if (contextIdx > 0) {
+            currentOrContext = determineContext(currentOrContext, contextIdx);
+          }
+
+          SObject obj = (SObject) currentOrContext.getArguments()[0];
+
+          if (this.quickened == null) {
+            this.quickened = new Node[bytecodes.length];
+          }
+          Node node = quickened[bytecodeIndex];
+          if (node == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            Object val = obj.getField(fieldIdx);
+            if (!(val instanceof Long)) {
+              throw new NotYetImplementedException();
+            }
+
+            try {
+              long longVal = Math.addExact((Long) val, 1);
+              obj.setField(fieldIdx, longVal);
+            } catch (ArithmeticException e) {
+              throw new NotYetImplementedException();
+            }
+
+            node = quickened[bytecodeIndex] =
+                insert(FieldAccessorNode.createIncrement(fieldIdx, obj));
+            break;
+          }
+
+          ((IncrementLongFieldNode) node).increment(obj);
           break;
         }
 

--- a/src/trufflesom/interpreter/nodes/specialized/IntIncrementNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IntIncrementNode.java
@@ -1,0 +1,33 @@
+package trufflesom.interpreter.nodes.specialized;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
+
+
+@NodeChild(value = "rcvr", type = ExpressionNode.class)
+public abstract class IntIncrementNode extends ExpressionNode {
+  @Specialization(rewriteOn = ArithmeticException.class)
+  public long doInc(final long rcvr) {
+    return Math.addExact(rcvr, 1);
+  }
+
+  @Specialization
+  public double doInc(final double rcvr) {
+    return rcvr + 1;
+  }
+
+  public abstract ExpressionNode getRcvr();
+
+  public boolean doesAccessField(final int fieldIdx) {
+    ExpressionNode rcvr = getRcvr();
+    if (rcvr instanceof FieldReadNode) {
+      FieldReadNode r = (FieldReadNode) rcvr;
+      return r.getFieldIndex() == fieldIdx;
+    }
+
+    return false;
+  }
+}

--- a/src/trufflesom/interpreter/objectstorage/FieldAccessorNode.java
+++ b/src/trufflesom/interpreter/objectstorage/FieldAccessorNode.java
@@ -300,17 +300,17 @@ public abstract class FieldAccessorNode extends Node {
       return layout == obj.getObjectLayout();
     }
 
-    public void increment(final SObject obj) {
+    public long increment(final SObject obj) {
       try {
         if (hasExpectedLayout(obj)) {
-          storage.increment(obj);
+          return storage.increment(obj);
         } else {
           ensureNext(obj);
-          nextInCache.increment(obj);
+          return nextInCache.increment(obj);
         }
       } catch (InvalidAssumptionException e) {
         ensureNext(obj);
-        replace(nextInCache).increment(obj);
+        return replace(nextInCache).increment(obj);
       }
     }
 

--- a/src/trufflesom/interpreter/objectstorage/StorageLocation.java
+++ b/src/trufflesom/interpreter/objectstorage/StorageLocation.java
@@ -46,6 +46,8 @@ public abstract class StorageLocation {
     long readLong(SObject obj) throws UnexpectedResultException;
 
     void writeLong(SObject obj, long value);
+
+    void increment(SObject obj);
   }
 
   public interface DoubleStorageLocation {
@@ -364,6 +366,12 @@ public abstract class StorageLocation {
     }
 
     @Override
+    public void increment(final SObject obj) {
+      long val = unsafe.getLong(obj, fieldMemoryOffset);
+      unsafe.putLong(obj, fieldMemoryOffset, Math.addExact(val, 1));
+    }
+
+    @Override
     public void write(final SObject obj, final Object value) {
       assert value != null;
       if (value instanceof Long) {
@@ -437,6 +445,12 @@ public abstract class StorageLocation {
         TruffleCompiler.transferToInterpreterAndInvalidate("unstabelized read node");
         throw new UnexpectedResultException(Nil.nilObject);
       }
+    }
+
+    @Override
+    public void increment(final SObject obj) {
+      long val = obj.getExtendedPrimFields()[extensionIndex];
+      obj.getExtendedPrimFields()[extensionIndex] = Math.addExact(val, 1);
     }
 
     @Override

--- a/src/trufflesom/interpreter/objectstorage/StorageLocation.java
+++ b/src/trufflesom/interpreter/objectstorage/StorageLocation.java
@@ -47,7 +47,7 @@ public abstract class StorageLocation {
 
     void writeLong(SObject obj, long value);
 
-    void increment(SObject obj);
+    long increment(SObject obj);
   }
 
   public interface DoubleStorageLocation {
@@ -366,9 +366,11 @@ public abstract class StorageLocation {
     }
 
     @Override
-    public void increment(final SObject obj) {
+    public long increment(final SObject obj) {
       long val = unsafe.getLong(obj, fieldMemoryOffset);
-      unsafe.putLong(obj, fieldMemoryOffset, Math.addExact(val, 1));
+      long result = Math.addExact(val, 1);
+      unsafe.putLong(obj, fieldMemoryOffset, result);
+      return result;
     }
 
     @Override
@@ -448,9 +450,11 @@ public abstract class StorageLocation {
     }
 
     @Override
-    public void increment(final SObject obj) {
+    public long increment(final SObject obj) {
       long val = obj.getExtendedPrimFields()[extensionIndex];
-      obj.getExtendedPrimFields()[extensionIndex] = Math.addExact(val, 1);
+      long result = Math.addExact(val, 1);
+      obj.getExtendedPrimFields()[extensionIndex] = result;
+      return result;
     }
 
     @Override

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -187,6 +187,9 @@ public final class Universe implements IdProvider<SSymbol> {
     symBlockSelf = symbolFor("$blockSelf");
     symSuper = symbolFor("super");
 
+    symPlus = symbolFor("+");
+    symMinus = symbolFor("-");
+
     // Name for the frameOnStack slot,
     // starting with ! to make it a name that's not possible in Smalltalk
     symFrameOnStack = symbolFor("!frameOnStack");
@@ -775,6 +778,9 @@ public final class Universe implements IdProvider<SSymbol> {
   public final SSymbol symBlockSelf;
   public final SSymbol symFrameOnStack;
   public final SSymbol symSuper;
+
+  public final SSymbol symPlus;
+  public final SSymbol symMinus;
 
   private final HashMap<SSymbol, Association> globals;
 


### PR DESCRIPTION
This PR introduces 5 new bytecodes, and adds optimizations avoid common patterns in the generated bytecode sequences.

#### RETURN_SELF

The bytecode optimizes the common sequence of `[POP,] PUSH_ARGUMENT (0, 0), RETURN_LOCAL`.

Since it's the implicit sequence at the end of many methods, it turned up frequently in the bytecode profile.

It's generated directly in the parser. It is also used for normal methods (not block methods) that end in an explicit `^ self`.

#### INC/DEC

Another common bytecode sequence is `PUSH_CONSTANT 1, SEND +`.
The `SEND -` version was not as common, but still visible in the weighted profiles.

For symmetry, I introduced the `INC` and `DEC` bytecodes, which optimize adding or subtracting 1 from an integer.

They are generated directly in the parser.

#### Optimize DUP, POP_FIELD|POP_LOCAL, POP

One of the common sequences generated by the parser is to duplicate the stack top, pop it into a field or local, and then pop the stack top.

This sequence appeared frequently in the weighted bytecode profile.

To optimize it, I check what the last two bytecodes were, before emitting a POP bytecode.
Because we have variable-length bytecodes, I introduced a buffer that keeps the actual bytecodes around for these optimizations. By resetting the buffer, I can also control when to avoid such optimizations.

At the end of blocks, in some cases I need to reintroduce the `DUP` to get the correct semantics for implicit block returns.

#### INC_FIELD, INC_FIELD_PUSH

After introducing `INC`, the sequence to increment a field by `PUSH_FIELD, INC, POP_FIELD` appeared as very common.
`INC_FIELD` optimizes the sequence and avoid accessing the stack.
`INC_FIELD_PUSH` is like `INC_FIELD`, but pushes the result. This is needed for the implicit return of blocks.

This optimizations interacts with the optimization for `DUP, POP_FIELD` and is triggered as part of it.

#### Optimize INC and INC_FIELD in the AST interpreter with IntIncrementNode and FieldIncNode

The same pattern of incrementing also appears in the AST interpreter. These new nodes short-cut the complex combination of nodes to optimize the pattern.

## Warning

None of these optimizations attempt to cover all possible cases.
Thus, they are not safe and can result in run-time errors, because of unsupported values.
