### PR TITLE
Quicken Super Sends and optimize Object Instantiation

### DIFF
--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -197,7 +197,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
     return assembleMethod(body, sourceSection, fullSourceSection);
   }
 
-  protected SInvokable assembleMethod(ExpressionNode body, final SourceSection sourceSection,
+  protected SMethod assembleMethod(ExpressionNode body, final SourceSection sourceSection,
       final SourceSection fullSourceSection) {
     if (needsToCatchNonLocalReturn()) {
       body = createCatchNonLocalReturn(body, getFrameOnStackMarker(sourceSection));
@@ -207,7 +207,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
         new Method(getMethodIdentifier(), getSourceSectionForMethod(sourceSection),
             body, currentScope, (ExpressionNode) body.deepCopy(), holderGenc.getLanguage());
 
-    SInvokable meth = Universe.newMethod(signature, truffleMethod, false,
+    SMethod meth = new SMethod(signature, truffleMethod,
         embeddedBlockMethods.toArray(new SMethod[0]), fullSourceSection);
 
     if (structuralProbe != null) {

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -45,6 +45,7 @@ import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SAbstractObject;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
+import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
 
@@ -219,7 +220,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   }
 
   @Override
-  protected SInvokable assembleMethod(final ExpressionNode unused,
+  protected SMethod assembleMethod(final ExpressionNode unused,
       final SourceSection sourceSection, final SourceSection fullSourceSection) {
     byte[] bytecodes = new byte[bytecode.size()];
     int i = 0;

--- a/src/trufflesom/interpreter/Primitive.java
+++ b/src/trufflesom/interpreter/Primitive.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import trufflesom.compiler.MethodGenerationContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.primitives.basics.NewObjectPrim;
 import trufflesom.vmobjects.SInvokable.SMethod;
 
 
@@ -82,5 +83,11 @@ public final class Primitive extends Invokable {
     if (m != null && !(m instanceof Primitive)) {
       m.propagateLoopCountThroughoutLexicalScope(count);
     }
+  }
+
+  public boolean isNewObjectPrimitive() {
+    // Checkstyle: stop
+    return ("new" == name) && expressionOrSequence instanceof NewObjectPrim;
+    // Checkstyle: resume
   }
 }

--- a/src/trufflesom/interpreter/nodes/MessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/MessageSendNode.java
@@ -118,6 +118,11 @@ public final class MessageSendNode {
     }
 
     @Override
+    public String toString() {
+      return getClass().getSimpleName() + "(" + selector.getString() + ")";
+    }
+
+    @Override
     public final Object doPreEvaluated(final VirtualFrame frame,
         final Object[] arguments) {
       return specialize(arguments).doPreEvaluated(frame, arguments);

--- a/src/trufflesom/interpreter/nodes/MessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/MessageSendNode.java
@@ -21,6 +21,7 @@ import trufflesom.interpreter.nodes.specialized.IntIncrementNodeGen;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vm.Universe;
+import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SSymbol;
 
 
@@ -65,6 +66,12 @@ public final class MessageSendNode {
       final Universe universe) {
     return new GenericMessageSendNode(selector, argumentNodes,
         new UninitializedDispatchNode(selector, universe)).initialize(source);
+  }
+
+  public static GenericMessageSendNode createSuper(final SClass clazz, final SSymbol selector,
+      final SourceSection source, final Universe universe) {
+    return new GenericMessageSendNode(selector, null,
+        SuperDispatchNode.create(clazz, selector)).initialize(source);
   }
 
   public abstract static class AbstractMessageSendNode extends ExpressionNode

--- a/src/trufflesom/interpreter/nodes/dispatch/CachedExprNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/CachedExprNode.java
@@ -1,0 +1,45 @@
+package trufflesom.interpreter.nodes.dispatch;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.InvalidAssumptionException;
+
+import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
+
+
+public class CachedExprNode extends AbstractDispatchNode {
+
+  private final DispatchGuard guard;
+
+  @Child protected AbstractDispatchNode nextInCache;
+
+  @Child protected UnaryExpressionNode expr;
+
+  public CachedExprNode(final DispatchGuard guard, final UnaryExpressionNode expr,
+      final AbstractDispatchNode nextInCache) {
+    this.guard = guard;
+    this.expr = expr;
+    this.nextInCache = nextInCache;
+  }
+
+  @Override
+  public Object executeDispatch(
+      final VirtualFrame frame, final Object[] arguments) {
+    Object rcvr = arguments[0];
+    try {
+      if (guard.entryMatches(rcvr)) {
+        return expr.executeEvaluated(frame, arguments[0]);
+      } else {
+        return nextInCache.executeDispatch(frame, arguments);
+      }
+    } catch (InvalidAssumptionException e) {
+      CompilerDirectives.transferToInterpreter();
+      return replace(nextInCache).executeDispatch(frame, arguments);
+    }
+  }
+
+  @Override
+  public final int lengthOfDispatchChain() {
+    return 1 + nextInCache.lengthOfDispatchChain();
+  }
+}

--- a/src/trufflesom/interpreter/nodes/dispatch/SuperDispatchNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/SuperDispatchNode.java
@@ -26,6 +26,17 @@ public abstract class SuperDispatchNode extends AbstractDispatchNode {
         superNode.isClassSide(), universe);
   }
 
+  public static SuperDispatchNode create(final SClass clazz, final SSymbol selector) {
+    SInvokable method = clazz.lookupInvokable(selector);
+
+    if (method == null) {
+      throw new RuntimeException("Currently #dnu with super sent is not yet implemented. ");
+    }
+    DirectCallNode superMethodNode = Truffle.getRuntime().createDirectCallNode(
+        method.getCallTarget());
+    return new CachedDispatchNode(superMethodNode);
+  }
+
   private static final class UninitializedDispatchNode extends SuperDispatchNode {
     private final SSymbol  selector;
     private final SSymbol  holderClass;
@@ -51,14 +62,7 @@ public abstract class SuperDispatchNode extends AbstractDispatchNode {
     @TruffleBoundary
     private CachedDispatchNode specialize() {
       CompilerAsserts.neverPartOfCompilation("SuperDispatchNode.create2");
-      SInvokable method = getLexicalSuperClass().lookupInvokable(selector);
-
-      if (method == null) {
-        throw new RuntimeException("Currently #dnu with super sent is not yet implemented. ");
-      }
-      DirectCallNode superMethodNode = Truffle.getRuntime().createDirectCallNode(
-          method.getCallTarget());
-      return replace(new CachedDispatchNode(superMethodNode));
+      return replace((CachedDispatchNode) create(getLexicalSuperClass(), selector));
     }
 
     @Override

--- a/src/trufflesom/interpreter/nodes/literals/BlockNode.java
+++ b/src/trufflesom/interpreter/nodes/literals/BlockNode.java
@@ -74,7 +74,7 @@ public class BlockNode extends LiteralNode {
     Method adapted = blockIvk.cloneAndAdaptAfterScopeChange(
         inliner.getScope(blockIvk), inliner.contextLevel + 1, true,
         inliner.outerScopeChanged());
-    SMethod method = (SMethod) Universe.newMethod(blockMethod.getSignature(), adapted, false,
+    SMethod method = new SMethod(blockMethod.getSignature(), adapted,
         blockMethod.getEmbeddedBlocks(), blockIvk.getSourceSection());
     replace(createNode(method));
   }

--- a/src/trufflesom/interpreter/objectstorage/ObjectLayout.java
+++ b/src/trufflesom/interpreter/objectstorage/ObjectLayout.java
@@ -71,13 +71,17 @@ public final class ObjectLayout {
     latestLayoutForClass.check();
   }
 
-  Assumption getAssumption() {
+  public Assumption getAssumption() {
     return latestLayoutForClass;
   }
 
   public boolean layoutForSameClass(final ObjectLayout other) {
     // TODO: think we don't need this with new guard logic
     return forClass == other.forClass;
+  }
+
+  public boolean layoutForSameClass(final SClass clazz) {
+    return forClass == clazz;
   }
 
   public int getNumberOfFields() {

--- a/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/primitives/Primitives.java
@@ -113,7 +113,7 @@ import trufflesom.primitives.reflection.PerformWithArgumentsPrimFactory;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
-import trufflesom.vmobjects.SInvokable.SMethod;
+import trufflesom.vmobjects.SInvokable.SPrimitive;
 import trufflesom.vmobjects.SSymbol;
 
 
@@ -130,7 +130,7 @@ public final class Primitives extends PrimitiveLoader<Universe, ExpressionNode, 
   /** Primitives for class and method name. */
   private final HashMap<SSymbol, HashMap<SSymbol, Specializer<Universe, ExpressionNode, SSymbol>>> primitives;
 
-  public static SInvokable constructEmptyPrimitive(final SSymbol signature,
+  public static SPrimitive constructEmptyPrimitive(final SSymbol signature,
       final SomLanguage lang, final SourceSection sourceSection,
       final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe) {
     CompilerAsserts.neverPartOfCompilation();
@@ -142,8 +142,7 @@ public final class Primitives extends PrimitiveLoader<Universe, ExpressionNode, 
         new Primitive(signature.getString(), sourceSection, primNode,
             mgen.getCurrentLexicalScope().getFrameDescriptor(),
             (ExpressionNode) primNode.deepCopy(), lang);
-    SInvokable prim =
-        Universe.newMethod(signature, primMethodNode, true, new SMethod[0], sourceSection);
+    SPrimitive prim = new SPrimitive(signature, primMethodNode, sourceSection);
 
     if (probe != null) {
       String id = prim.getIdentifier();
@@ -226,7 +225,7 @@ public final class Primitives extends PrimitiveLoader<Universe, ExpressionNode, 
     Primitive primMethodNode = new Primitive(signature.getString(), source, primNode,
         mgen.getCurrentLexicalScope().getFrameDescriptor(),
         (ExpressionNode) primNode.deepCopy(), lang);
-    return Universe.newMethod(signature, primMethodNode, true, new SMethod[0], source);
+    return new SPrimitive(signature, primMethodNode, source);
   }
 
   @Override

--- a/src/trufflesom/primitives/basics/NewObjectPrim.java
+++ b/src/trufflesom/primitives/basics/NewObjectPrim.java
@@ -1,20 +1,29 @@
 package trufflesom.primitives.basics;
 
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
-import trufflesom.vm.Universe;
+import trufflesom.interpreter.objectstorage.ObjectLayout;
 import trufflesom.vmobjects.SAbstractObject;
 import trufflesom.vmobjects.SClass;
+import trufflesom.vmobjects.SObject;
 
 
 @GenerateNodeFactory
 @Primitive(className = "Class", primitive = "new")
 public abstract class NewObjectPrim extends UnaryExpressionNode {
-  @Specialization
-  public final SAbstractObject doSClass(final SClass receiver) {
-    return Universe.newInstance(receiver);
+  @Specialization(assumptions = "layout.getAssumption()",
+      guards = "layout.layoutForSameClass(receiver)")
+  public final SAbstractObject doCached(final SClass receiver,
+      @Cached("receiver.getLayoutForInstances()") final ObjectLayout layout) {
+    return new SObject(receiver, layout);
+  }
+
+  @Specialization(replaces = "doCached")
+  public final SAbstractObject doUncached(final SClass receiver) {
+    return new SObject(receiver);
   }
 }

--- a/src/trufflesom/vm/Shell.java
+++ b/src/trufflesom/vm/Shell.java
@@ -79,7 +79,7 @@ public class Shell {
         // If success
         if (myClass != null) {
           // Create and push a new instance of our class on the stack
-          myObject = Universe.newInstance(myClass);
+          myObject = new SObject(myClass);
 
           // Lookup the run: method
           SInvokable shellMethod = myClass.lookupInvokable(universe.symbolFor("run:"));

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -50,7 +50,6 @@ import trufflesom.compiler.Disassembler;
 import trufflesom.compiler.Field;
 import trufflesom.compiler.SourcecodeCompiler;
 import trufflesom.compiler.Variable;
-import trufflesom.interpreter.Invokable;
 import trufflesom.interpreter.SomLanguage;
 import trufflesom.interpreter.TruffleCompiler;
 import trufflesom.interpreter.objectstorage.StorageAnalyzer;
@@ -59,8 +58,6 @@ import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
-import trufflesom.vmobjects.SInvokable.SMethod;
-import trufflesom.vmobjects.SInvokable.SPrimitive;
 import trufflesom.vmobjects.SObject;
 import trufflesom.vmobjects.SSymbol;
 
@@ -471,18 +468,6 @@ public final class Universe implements IdProvider<SSymbol> {
   @TruffleBoundary
   public SClass newClass(final SClass classClass) {
     return new SClass(classClass);
-  }
-
-  @TruffleBoundary
-  public static SInvokable newMethod(final SSymbol signature,
-      final Invokable truffleInvokable, final boolean isPrimitive,
-      final SMethod[] embeddedBlocks, final SourceSection sourceSection) {
-    assert sourceSection != null : "All elements have a lexical representation and thus, are expected to have a source section";
-    if (isPrimitive) {
-      return new SPrimitive(signature, truffleInvokable, sourceSection);
-    } else {
-      return new SMethod(signature, truffleInvokable, embeddedBlocks, sourceSection);
-    }
   }
 
   @TruffleBoundary

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -430,7 +430,7 @@ public final class Universe implements IdProvider<SSymbol> {
 
     // Load the system class and create an instance of it
     systemClass = loadClass(symbolFor("System"));
-    systemObject = newInstance(systemClass);
+    systemObject = new SObject(systemClass);
 
     // Put special objects into the dictionary of globals
     setGlobal("nil", nilObject);
@@ -483,10 +483,6 @@ public final class Universe implements IdProvider<SSymbol> {
     } else {
       return new SMethod(signature, truffleInvokable, embeddedBlocks, sourceSection);
     }
-  }
-
-  public static SObject newInstance(final SClass instanceClass) {
-    return SObject.create(instanceClass);
   }
 
   @TruffleBoundary

--- a/src/trufflesom/vmobjects/SInvokable.java
+++ b/src/trufflesom/vmobjects/SInvokable.java
@@ -36,6 +36,7 @@ import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
 import trufflesom.interpreter.Invokable;
+import trufflesom.interpreter.Primitive;
 import trufflesom.vm.Universe;
 
 
@@ -89,6 +90,11 @@ public abstract class SInvokable extends SAbstractObject {
         return signature.toString();
       }
     }
+
+    @Override
+    public boolean isNewObjectPrimitive() {
+      return false;
+    }
   }
 
   public static final class SPrimitive extends SInvokable {
@@ -114,6 +120,14 @@ public abstract class SInvokable extends SAbstractObject {
       } else {
         return signature.toString();
       }
+    }
+
+    @Override
+    public boolean isNewObjectPrimitive() {
+      // Checkstyle: stop
+      return (signature.getString() == "new")
+          && ((Primitive) invokable).isNewObjectPrimitive();
+      // Checkstyle: resume
     }
   }
 
@@ -174,4 +188,6 @@ public abstract class SInvokable extends SAbstractObject {
   protected final SSymbol      signature;
 
   @CompilationFinal protected SClass holder;
+
+  public abstract boolean isNewObjectPrimitive();
 }


### PR DESCRIPTION
Super sends where not yet previously quickened in the bytecode interpreters.
Now, we use the `Q_SEND` bytecode in the same way as normal sends, and initialize the quickening node on first execution.

Further, this PR optimizes object creation by caching the `ObjectLayout` for a class.
This requires some further changes to expose the `NewObjectPrim` at the lexical location where it is used to be able to benefit from the caching. Previously, there would have only been the primitive itself, which would have been megamorphic since it saw all object instantiations.

To expose the lexical stability, the new prim is now integrated with the dispatch chains. We can't use the existing eager primitive mechanism, because it does not account for inheritance, which is of course an issue with `new` being overridden everywhere. Instead, the dispatch chain checks whether the method to be cached is the new prim, and if so, it will integrate a new instance of `NewObjectPrim` directly in the dispatch chain. This is done for normal and super sends.