### PR TITLE
Optimize access, and other trivial methods

### DIFF
--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -325,6 +325,18 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
     return 0;
   }
 
+  public int getContextLevel(final Variable var) {
+    if (locals.containsValue(var) || arguments.containsValue(var)) {
+      return 0;
+    }
+
+    if (outerGenc != null) {
+      return 1 + outerGenc.getContextLevel(var);
+    }
+
+    return 0;
+  }
+
   public Local getEmbeddedLocal(final SSymbol embeddedName) {
     return locals.get(embeddedName);
   }
@@ -354,16 +366,13 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
         new AccessNodeState(holderGenc.getName(), holderGenc.isClassSide()), source);
   }
 
-  public ExpressionNode getLocalReadNode(final SSymbol variableName,
-      final SourceSection source) {
-    Variable variable = getVariable(variableName);
-    return variable.getReadNode(getContextLevel(variableName), source);
+  public ExpressionNode getLocalReadNode(final Variable variable, final SourceSection source) {
+    return variable.getReadNode(getContextLevel(variable), source);
   }
 
-  public ExpressionNode getLocalWriteNode(final SSymbol variableName,
+  public ExpressionNode getLocalWriteNode(final Variable variable,
       final ExpressionNode valExpr, final SourceSection source) {
-    Variable variable = getVariable(variableName);
-    return variable.getWriteNode(getContextLevel(variableName), valExpr, source);
+    return variable.getWriteNode(getContextLevel(variable), valExpr, source);
   }
 
   protected Local getLocal(final SSymbol varName) {

--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -270,12 +270,8 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
     addArgument(arg, source);
   }
 
-  public void addLocalIfAbsent(final SSymbol local, final SourceSection source) {
-    if (locals.containsKey(local)) {
-      return;
-    }
-
-    addLocal(local, source);
+  public boolean hasLocal(final SSymbol local) {
+    return locals.containsKey(local);
   }
 
   public Local addLocal(final SSymbol local, final SourceSection source) {

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -662,7 +662,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     // now look up first local variables, or method arguments
     Variable variable = mgenc.getVariable(variableName);
     if (variable != null) {
-      return mgenc.getLocalReadNode(variableName, source);
+      return mgenc.getLocalReadNode(variable, source);
     }
 
     // then object fields

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -673,7 +673,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     }
 
     // and finally assume it is a global
-    return GlobalNode.create(variableName, universe, source);
+    return GlobalNode.create(variableName, universe).initialize(source);
   }
 
   private void getSymbolFromLexer() {

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -138,6 +138,9 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     }
 
     protected String expectedSymbolAsString() {
+      if (expected == null) {
+        return null;
+      }
       return expected.toString();
     }
 
@@ -157,7 +160,9 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
       msg = msg.replace("%(line)d", java.lang.Integer.toString(sourceCoordinate.startLine));
       msg =
           msg.replace("%(column)d", java.lang.Integer.toString(sourceCoordinate.startColumn));
-      msg = msg.replace("%(expected)s", expectedStr);
+      if (expectedStr != null) {
+        msg = msg.replace("%(expected)s", expectedStr);
+      }
       msg = msg.replace("%(found)s", foundStr);
       return msg;
     }
@@ -492,7 +497,12 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
   private void locals(final MGenC mgenc) throws ProgramDefinitionError {
     while (isIdentifier(sym)) {
       SourceCoordinate coord = getCoordinate();
-      mgenc.addLocalIfAbsent(variable(), getSource(coord));
+      SSymbol var = variable();
+      if (mgenc.hasLocal(var)) {
+        throw new ParseError("Declared the variable " + var.getString() + " multiple times.",
+            null, this);
+      }
+      mgenc.addLocal(var, getSource(coord));
     }
   }
 

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -102,7 +102,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
   private ExpressionNode createSequenceNode(final SourceCoordinate coord,
       final List<ExpressionNode> expressions) {
     if (expressions.size() == 0) {
-      return GlobalNode.create(universe.symNil, universe, getSource(coord));
+      return GlobalNode.create(universe.symNil, universe).initialize(getSource(coord));
     } else if (expressions.size() == 1) {
       return expressions.get(0);
     }

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -157,7 +157,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
       final SSymbol variableName, final ExpressionNode exp, final SourceSection source) {
     Variable variable = mgenc.getVariable(variableName);
     if (variable != null) {
-      return mgenc.getLocalWriteNode(variableName, exp, source);
+      return mgenc.getLocalWriteNode(variable, exp, source);
     }
 
     FieldNode fieldWrite = mgenc.getObjectFieldWrite(variableName, exp, universe, source);

--- a/src/trufflesom/compiler/Variable.java
+++ b/src/trufflesom/compiler/Variable.java
@@ -1,5 +1,9 @@
 package trufflesom.compiler;
 
+import static trufflesom.compiler.bc.BytecodeGenerator.emitPOPARGUMENT;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitPOPLOCAL;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitPUSHARGUMENT;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitPUSHLOCAL;
 import static trufflesom.interpreter.SNodeFactory.createArgumentRead;
 import static trufflesom.interpreter.SNodeFactory.createArgumentWrite;
 import static trufflesom.interpreter.SNodeFactory.createLocalVarRead;
@@ -16,7 +20,6 @@ import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.source.SourceSection;
 
 import bd.inlining.NodeState;
-import trufflesom.compiler.bc.BytecodeGenerator;
 import trufflesom.compiler.bc.BytecodeMethodGenContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.vm.NotYetImplementedException;
@@ -50,9 +53,9 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   @Override
   public abstract ExpressionNode getReadNode(int contextLevel, SourceSection source);
 
-  protected abstract void emitPop(BytecodeGenerator bcGen, BytecodeMethodGenContext mgenc);
+  protected abstract void emitPop(BytecodeMethodGenContext mgenc);
 
-  protected abstract void emitPush(BytecodeGenerator bcGen, BytecodeMethodGenContext mgenc);
+  protected abstract void emitPush(BytecodeMethodGenContext mgenc);
 
   public abstract Variable split(FrameDescriptor descriptor);
 
@@ -144,14 +147,13 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     }
 
     @Override
-    public void emitPop(final BytecodeGenerator bcGen, final BytecodeMethodGenContext mgenc) {
-      bcGen.emitPOPARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(name));
+    public void emitPop(final BytecodeMethodGenContext mgenc) {
+      emitPOPARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(name));
     }
 
     @Override
-    protected void emitPush(final BytecodeGenerator bcGen,
-        final BytecodeMethodGenContext mgenc) {
-      bcGen.emitPUSHARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(name));
+    protected void emitPush(final BytecodeMethodGenContext mgenc) {
+      emitPUSHARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(name));
     }
   }
 
@@ -203,16 +205,15 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     }
 
     @Override
-    public void emitPop(final BytecodeGenerator bcGen, final BytecodeMethodGenContext mgenc) {
+    public void emitPop(final BytecodeMethodGenContext mgenc) {
       int contextLevel = mgenc.getContextLevel(name);
-      bcGen.emitPOPLOCAL(mgenc, mgenc.getLocalIndex(this, contextLevel), (byte) contextLevel);
+      emitPOPLOCAL(mgenc, mgenc.getLocalIndex(this, contextLevel), (byte) contextLevel);
     }
 
     @Override
-    protected void emitPush(final BytecodeGenerator bcGen,
-        final BytecodeMethodGenContext mgenc) {
+    protected void emitPush(final BytecodeMethodGenContext mgenc) {
       int contextLevel = mgenc.getContextLevel(name);
-      bcGen.emitPUSHLOCAL(mgenc, mgenc.getLocalIndex(this, contextLevel), (byte) contextLevel);
+      emitPUSHLOCAL(mgenc, mgenc.getLocalIndex(this, contextLevel), (byte) contextLevel);
     }
   }
 
@@ -260,12 +261,12 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     }
 
     @Override
-    public void emitPop(final BytecodeGenerator bcGen, final BytecodeMethodGenContext mgenc) {
+    public void emitPop(final BytecodeMethodGenContext mgenc) {
       throw new NotYetImplementedException();
     }
 
     @Override
-    public void emitPush(final BytecodeGenerator bcGen, final BytecodeMethodGenContext mgenc) {
+    public void emitPush(final BytecodeMethodGenContext mgenc) {
       throw new NotYetImplementedException();
     }
 

--- a/src/trufflesom/compiler/Variable.java
+++ b/src/trufflesom/compiler/Variable.java
@@ -148,12 +148,12 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
 
     @Override
     public void emitPop(final BytecodeMethodGenContext mgenc) {
-      emitPOPARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(name));
+      emitPOPARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(this));
     }
 
     @Override
     protected void emitPush(final BytecodeMethodGenContext mgenc) {
-      emitPUSHARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(name));
+      emitPUSHARGUMENT(mgenc, (byte) index, (byte) mgenc.getContextLevel(this));
     }
   }
 
@@ -206,13 +206,13 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
 
     @Override
     public void emitPop(final BytecodeMethodGenContext mgenc) {
-      int contextLevel = mgenc.getContextLevel(name);
+      int contextLevel = mgenc.getContextLevel(this);
       emitPOPLOCAL(mgenc, mgenc.getLocalIndex(this, contextLevel), (byte) contextLevel);
     }
 
     @Override
-    protected void emitPush(final BytecodeMethodGenContext mgenc) {
-      int contextLevel = mgenc.getContextLevel(name);
+    public void emitPush(final BytecodeMethodGenContext mgenc) {
+      int contextLevel = mgenc.getContextLevel(this);
       emitPUSHLOCAL(mgenc, mgenc.getLocalIndex(this, contextLevel), (byte) contextLevel);
     }
   }

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -47,107 +47,113 @@ import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
 
-public class BytecodeGenerator {
+public final class BytecodeGenerator {
+  private BytecodeGenerator() {}
 
-  public void emitINC(final BytecodeMethodGenContext mgenc) {
+  public static void emitINC(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, INC);
   }
 
-  public void emitDEC(final BytecodeMethodGenContext mgenc) {
+  public static void emitDEC(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, DEC);
   }
 
-  public void emitPOP(final BytecodeMethodGenContext mgenc) {
+  public static void emitPOP(final BytecodeMethodGenContext mgenc) {
     if (!mgenc.optimizeDupPopPopSequence()) {
       emit1(mgenc, POP);
     }
   }
 
-  public void emitPUSHARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
+  public static void emitPUSHARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
     emit3(mgenc, PUSH_ARGUMENT, idx, ctx);
   }
 
-  public void emitRETURNLOCAL(final BytecodeMethodGenContext mgenc) {
+  public static void emitRETURNLOCAL(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, RETURN_LOCAL);
   }
 
-  public void emitRETURNSELF(final BytecodeMethodGenContext mgenc) {
+  public static void emitRETURNSELF(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, RETURN_SELF);
   }
 
-  public void emitRETURNNONLOCAL(final BytecodeMethodGenContext mgenc) {
+  public static void emitRETURNNONLOCAL(final BytecodeMethodGenContext mgenc) {
     emit2(mgenc, RETURN_NON_LOCAL, mgenc.getMaxContextLevel());
   }
 
-  public void emitDUP(final BytecodeMethodGenContext mgenc) {
+  public static void emitDUP(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, DUP);
   }
 
-  public void emitPUSHBLOCK(final BytecodeMethodGenContext mgenc, final SMethod blockMethod) {
+  public static void emitPUSHBLOCK(final BytecodeMethodGenContext mgenc,
+      final SMethod blockMethod) {
     emit2(mgenc, PUSH_BLOCK, mgenc.findLiteralIndex(blockMethod));
   }
 
-  public void emitPUSHLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,
+  public static void emitPUSHLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
     assert idx >= 0;
     emit3(mgenc, PUSH_LOCAL, idx, ctx);
   }
 
-  public void emitPUSHFIELD(final BytecodeMethodGenContext mgenc, final SSymbol fieldName) {
+  public static void emitPUSHFIELD(final BytecodeMethodGenContext mgenc,
+      final SSymbol fieldName) {
     assert mgenc.hasField(fieldName);
     emit3(mgenc, PUSH_FIELD, mgenc.getFieldIndex(fieldName), mgenc.getMaxContextLevel());
   }
 
-  public void emitPUSHGLOBAL(final BytecodeMethodGenContext mgenc, final SSymbol global) {
+  public static void emitPUSHGLOBAL(final BytecodeMethodGenContext mgenc,
+      final SSymbol global) {
     emit2(mgenc, PUSH_GLOBAL, mgenc.findLiteralIndex(global));
   }
 
-  public void emitPOPARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
+  public static void emitPOPARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
     emit3(mgenc, POP_ARGUMENT, idx, ctx);
   }
 
-  public void emitPOPLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,
+  public static void emitPOPLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
     emit3(mgenc, POP_LOCAL, idx, ctx);
   }
 
-  public void emitPOPFIELD(final BytecodeMethodGenContext mgenc, final SSymbol fieldName) {
+  public static void emitPOPFIELD(final BytecodeMethodGenContext mgenc,
+      final SSymbol fieldName) {
     assert mgenc.hasField(fieldName);
     emit3(mgenc, POP_FIELD, mgenc.getFieldIndex(fieldName), mgenc.getMaxContextLevel());
   }
 
-  public void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {
+  public static void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {
     emit2(mgenc, SUPER_SEND, mgenc.findLiteralIndex(msg));
   }
 
-  public void emitSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {
+  public static void emitSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {
     emit2(mgenc, SEND, mgenc.findLiteralIndex(msg));
   }
 
-  public void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc, final Object lit) {
+  public static void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc, final Object lit) {
     emit2(mgenc, PUSH_CONSTANT, mgenc.findLiteralIndex(lit));
   }
 
-  public void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc, final byte literalIndex) {
+  public static void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc,
+      final byte literalIndex) {
     emit2(mgenc, PUSH_CONSTANT, literalIndex);
   }
 
-  private void emit1(final BytecodeMethodGenContext mgenc, final byte code) {
+  private static void emit1(final BytecodeMethodGenContext mgenc, final byte code) {
     mgenc.addBytecode(code);
   }
 
-  private void emit2(final BytecodeMethodGenContext mgenc, final byte code, final byte idx) {
+  private static void emit2(final BytecodeMethodGenContext mgenc, final byte code,
+      final byte idx) {
     mgenc.addBytecode(code);
     mgenc.addBytecodeArgument(idx);
   }
 
-  private void emit3(final BytecodeMethodGenContext mgenc, final byte code, final byte idx,
-      final byte ctx) {
+  private static void emit3(final BytecodeMethodGenContext mgenc, final byte code,
+      final byte idx, final byte ctx) {
     mgenc.addBytecode(code);
     mgenc.addBytecodeArgument(idx);
     mgenc.addBytecodeArgument(ctx);
   }
-
 }

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -87,7 +87,9 @@ public final class BytecodeGenerator {
 
   public static void emitPUSHBLOCK(final BytecodeMethodGenContext mgenc,
       final SMethod blockMethod) {
-    emit2(mgenc, PUSH_BLOCK, mgenc.findLiteralIndex(blockMethod));
+    byte litIdx = mgenc.findLiteralIndex(blockMethod);
+    assert litIdx >= 0;
+    emit2(mgenc, PUSH_BLOCK, litIdx);
   }
 
   public static void emitPUSHLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -27,6 +27,8 @@ package trufflesom.compiler.bc;
 import static trufflesom.interpreter.bc.Bytecodes.DEC;
 import static trufflesom.interpreter.bc.Bytecodes.DUP;
 import static trufflesom.interpreter.bc.Bytecodes.INC;
+import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
+import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -56,6 +58,16 @@ public final class BytecodeGenerator {
 
   public static void emitDEC(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, DEC);
+  }
+
+  public static void emitINCFIELD(final BytecodeMethodGenContext mgenc, final byte fieldIdx,
+      final byte ctx) {
+    emit3(mgenc, INC_FIELD, fieldIdx, ctx);
+  }
+
+  public static void emitINCFIELDPUSH(final BytecodeMethodGenContext mgenc,
+      final byte fieldIdx, final byte ctx) {
+    emit3(mgenc, INC_FIELD_PUSH, fieldIdx, ctx);
   }
 
   public static void emitPOP(final BytecodeMethodGenContext mgenc) {

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -191,7 +191,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   private byte getPositionIn(final Local local, final LinkedHashMap<SSymbol, Local> map) {
     byte i = 0;
     for (Local l : map.values()) {
-      if (l == local) {
+      if (l.equals(local)) {
         return i;
       }
       i += 1;

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -219,9 +219,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     return (byte) (size + locals.size());
   }
 
-  @Override
-  protected SMethod assembleMethod(final ExpressionNode unused,
-      final SourceSection sourceSection, final SourceSection fullSourceSection) {
+  private BytecodeLoopNode constructBytecodeBody(final SourceSection sourceSection) {
     byte[] bytecodes = new byte[bytecode.size()];
     int i = 0;
     for (byte bc : bytecode) {
@@ -246,11 +244,25 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     FrameSlot frameOnStackMarker =
         throwsNonLocalReturn ? getFrameOnStackMarker(sourceSection).getSlot() : null;
 
-    ExpressionNode body = new BytecodeLoopNode(
+    return new BytecodeLoopNode(
         bytecodes, locals.size(), localsAndOuters, literalsArr, computeStackDepth(),
         frameOnStackMarker, universe);
-    body.initialize(sourceSection);
+  }
 
+  private ExpressionNode constructTrivialBody() {
+    // TODO: recognize the sequences that can be isTrivial() expression nodes
+    return null;
+  }
+
+  @Override
+  protected SMethod assembleMethod(final ExpressionNode unused,
+      final SourceSection sourceSection, final SourceSection fullSourceSection) {
+    ExpressionNode body = constructTrivialBody();
+    if (body == null) {
+      body = constructBytecodeBody(sourceSection);
+    }
+
+    body.initialize(sourceSection);
     return super.assembleMethod(body, sourceSection, fullSourceSection);
   }
 

--- a/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/interpreter/Invokable.java
@@ -7,6 +7,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.SourceSection;
 
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.compiler.MethodGenerationContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.vmobjects.SClass;
@@ -69,5 +70,14 @@ public abstract class Invokable extends RootNode {
 
   public void setHolder(final SClass holder) {
     this.holder = holder;
+  }
+
+  @Override
+  public boolean isTrivial() {
+    return expressionOrSequence.isTrivial();
+  }
+
+  public PreevaluatedExpression copyTrivialNode() {
+    return expressionOrSequence.copyTrivialNode();
   }
 }

--- a/src/trufflesom/interpreter/Primitive.java
+++ b/src/trufflesom/interpreter/Primitive.java
@@ -12,7 +12,6 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import trufflesom.compiler.MethodGenerationContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
-import trufflesom.primitives.basics.NewObjectPrim;
 import trufflesom.vmobjects.SInvokable.SMethod;
 
 
@@ -83,11 +82,5 @@ public final class Primitive extends Invokable {
     if (m != null && !(m instanceof Primitive)) {
       m.propagateLoopCountThroughoutLexicalScope(count);
     }
-  }
-
-  public boolean isNewObjectPrimitive() {
-    // Checkstyle: stop
-    return ("new" == name) && expressionOrSequence instanceof NewObjectPrim;
-    // Checkstyle: resume
   }
 }

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -62,33 +62,12 @@ public class Bytecodes {
   public static final byte Q_SEND_2      = 24;
   public static final byte Q_SEND_3      = 25;
 
-  private static final String[] PADDED_BYTECODE_NAMES = new String[] {
-      "HALT            ", "DUP             ", "PUSH_LOCAL      ",
-      "PUSH_ARGUMENT   ", "PUSH_FIELD      ", "PUSH_BLOCK      ",
-      "PUSH_CONSTANT   ", "PUSH_GLOBAL     ", "POP             ",
-      "POP_LOCAL       ", "POP_ARGUMENT    ", "POP_FIELD       ",
-      "SEND            ", "SUPER_SEND      ", "RETURN_LOCAL    ",
-      "RETURN_NON_LOCAL",
+  public static final byte INVALID = -1;
 
-      "RETURN_SELF     ",
+  private static final String[] PADDED_BYTECODE_NAMES;
+  private static final String[] BYTECODE_NAMES;
 
-      "INC             ",
-      "DEC             ",
-
-      "INC_FIELD       ",
-      "INC_FIELD_PUSH  ",
-
-      "Q_PUSH_GLOBAL   ",
-      "Q_SEND          ",
-      "Q_SEND_1        ",
-      "Q_SEND_2        ",
-      "Q_SEND_3        ",
-  };
-
-  private static final String[] BYTECODE_NAMES =
-      Stream.of(PADDED_BYTECODE_NAMES).map(String::trim).toArray(String[]::new);
-
-  private static final byte NUM_BYTECODES = (byte) BYTECODE_NAMES.length;
+  public static final byte NUM_BYTECODES;
 
   private static void checkBytecodeIndex(final byte bytecode) {
     if (bytecode < 0 || bytecode >= NUM_BYTECODES) {
@@ -111,35 +90,70 @@ public class Bytecodes {
   }
 
   // Static array holding lengths of each bytecode
-  @CompilationFinal(dimensions = 1) private static final int[] BYTECODE_LENGTH = new int[] {
-      1, // HALT
-      1, // DUP
-      3, // PUSH_LOCAL
-      3, // PUSH_ARGUMENT
-      3, // PUSH_FIELD
-      2, // PUSH_BLOCK
-      2, // PUSH_CONSTANT
-      2, // PUSH_GLOBAL
-      1, // POP
-      3, // POP_LOCAL
-      3, // POP_ARGUMENT
-      3, // POP_FIELD
-      2, // SEND
-      2, // SUPER_SEND
-      1, // RETURN_LOCAL
-      2, // RETURN_NON_LOCAL
-      1, // RETURN_SELF
+  @CompilationFinal(dimensions = 1) private static final int[] BYTECODE_LENGTH;
 
-      1, // INC
-      1, // DEC
+  static {
+    NUM_BYTECODES = Q_SEND_3 + 1;
 
-      3, // INC_FIELD
-      3, // INC_FIELD_PUSH
+    PADDED_BYTECODE_NAMES = new String[] {
+        "HALT            ", "DUP             ", "PUSH_LOCAL      ",
+        "PUSH_ARGUMENT   ", "PUSH_FIELD      ", "PUSH_BLOCK      ",
+        "PUSH_CONSTANT   ", "PUSH_GLOBAL     ", "POP             ",
+        "POP_LOCAL       ", "POP_ARGUMENT    ", "POP_FIELD       ",
+        "SEND            ", "SUPER_SEND      ", "RETURN_LOCAL    ",
+        "RETURN_NON_LOCAL",
 
-      2, // Q_PUSH_GLOBAL
-      2, // Q_SEND
-      2, // Q_SEND_1
-      2, // Q_SEND_2
-      2, // Q_SEND_3
-  };
+        "RETURN_SELF     ",
+
+        "INC             ",
+        "DEC             ",
+
+        "INC_FIELD       ",
+        "INC_FIELD_PUSH  ",
+
+        "Q_PUSH_GLOBAL   ",
+        "Q_SEND          ",
+        "Q_SEND_1        ",
+        "Q_SEND_2        ",
+        "Q_SEND_3        ",
+    };
+
+    assert PADDED_BYTECODE_NAMES.length == NUM_BYTECODES : "Inconsistency between number of bytecodes and defined padded names";
+
+    BYTECODE_NAMES = Stream.of(PADDED_BYTECODE_NAMES).map(String::trim).toArray(String[]::new);
+
+    BYTECODE_LENGTH = new int[] {
+        1, // HALT
+        1, // DUP
+        3, // PUSH_LOCAL
+        3, // PUSH_ARGUMENT
+        3, // PUSH_FIELD
+        2, // PUSH_BLOCK
+        2, // PUSH_CONSTANT
+        2, // PUSH_GLOBAL
+        1, // POP
+        3, // POP_LOCAL
+        3, // POP_ARGUMENT
+        3, // POP_FIELD
+        2, // SEND
+        2, // SUPER_SEND
+        1, // RETURN_LOCAL
+        2, // RETURN_NON_LOCAL
+        1, // RETURN_SELF
+
+        1, // INC
+        1, // DEC
+
+        3, // INC_FIELD
+        3, // INC_FIELD_PUSH
+
+        2, // Q_PUSH_GLOBAL
+        2, // Q_SEND
+        2, // Q_SEND_1
+        2, // Q_SEND_2
+        2, // Q_SEND_3
+    };
+
+    assert BYTECODE_LENGTH.length == NUM_BYTECODES : "The BYTECODE_LENGTH array is not having the same size as number of bytecodes";
+  }
 }

--- a/src/trufflesom/interpreter/nodes/ArgumentReadNode.java
+++ b/src/trufflesom/interpreter/nodes/ArgumentReadNode.java
@@ -45,6 +45,10 @@ public abstract class ArgumentReadNode {
     public SSymbol getInvocationIdentifier() {
       return arg.name;
     }
+
+    public boolean isSelfRead() {
+      return argumentIndex == 0;
+    }
   }
 
   public static class LocalArgumentWriteNode extends ExpressionNode {

--- a/src/trufflesom/interpreter/nodes/ExpressionNode.java
+++ b/src/trufflesom/interpreter/nodes/ExpressionNode.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.interpreter.TypesGen;
 import trufflesom.vmobjects.SAbstractObject;
 import trufflesom.vmobjects.SArray;
@@ -39,6 +40,15 @@ import trufflesom.vmobjects.SSymbol;
 public abstract class ExpressionNode extends SOMNode {
 
   public abstract Object executeGeneric(VirtualFrame frame);
+
+  public boolean isTrivial() {
+    return false;
+  }
+
+  public PreevaluatedExpression copyTrivialNode() {
+    throw new UnsupportedOperationException(
+        "Some of the subclasses may be trivial and implement this");
+  }
 
   @Override
   public ExpressionNode getFirstMethodBodyNode() {

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -28,6 +28,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
+import bd.primitives.nodes.PreevaluatedExpression;
 import bd.tools.nodes.Invocation;
 import trufflesom.interpreter.SArguments;
 import trufflesom.interpreter.TruffleCompiler;
@@ -38,7 +39,8 @@ import trufflesom.vmobjects.SAbstractObject;
 import trufflesom.vmobjects.SSymbol;
 
 
-public abstract class GlobalNode extends ExpressionNode implements Invocation<SSymbol> {
+public abstract class GlobalNode extends ExpressionNode
+    implements Invocation<SSymbol>, PreevaluatedExpression {
 
   public static GlobalNode create(final SSymbol globalName, final Universe universe,
       final SourceSection source) {
@@ -67,6 +69,21 @@ public abstract class GlobalNode extends ExpressionNode implements Invocation<SS
   @Override
   public final SSymbol getInvocationIdentifier() {
     return globalName;
+  }
+
+  @Override
+  public boolean isTrivial() {
+    return true;
+  }
+
+  @Override
+  public PreevaluatedExpression copyTrivialNode() {
+    return (PreevaluatedExpression) copy();
+  }
+
+  @Override
+  public Object doPreEvaluated(final VirtualFrame frame, final Object[] args) {
+    return executeGeneric(frame);
   }
 
   private abstract static class AbstractUninitializedGlobalReadNode extends GlobalNode {

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -26,7 +26,6 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import bd.primitives.nodes.PreevaluatedExpression;
 import bd.tools.nodes.Invocation;
@@ -42,22 +41,21 @@ import trufflesom.vmobjects.SSymbol;
 public abstract class GlobalNode extends ExpressionNode
     implements Invocation<SSymbol>, PreevaluatedExpression {
 
-  public static GlobalNode create(final SSymbol globalName, final Universe universe,
-      final SourceSection source) {
+  public static GlobalNode create(final SSymbol globalName, final Universe universe) {
     if (globalName == universe.symNil) {
-      return new NilGlobalNode(globalName).initialize(source);
+      return new NilGlobalNode(globalName);
     } else if (globalName.getString().equals("true")) {
-      return new TrueGlobalNode(globalName).initialize(source);
+      return new TrueGlobalNode(globalName);
     } else if (globalName.getString().equals("false")) {
-      return new FalseGlobalNode(globalName).initialize(source);
+      return new FalseGlobalNode(globalName);
     }
 
     // Get the global from the universe
     Association assoc = universe.getGlobalsAssociation(globalName);
     if (assoc != null) {
-      return new CachedGlobalReadNode(globalName, assoc, source);
+      return new CachedGlobalReadNode(globalName, assoc);
     }
-    return new UninitializedGlobalReadNode(globalName, source, universe);
+    return new UninitializedGlobalReadNode(globalName, universe);
   }
 
   protected final SSymbol globalName;
@@ -89,11 +87,9 @@ public abstract class GlobalNode extends ExpressionNode
   private abstract static class AbstractUninitializedGlobalReadNode extends GlobalNode {
     protected final Universe universe;
 
-    AbstractUninitializedGlobalReadNode(final SSymbol globalName,
-        final SourceSection source, final Universe universe) {
+    AbstractUninitializedGlobalReadNode(final SSymbol globalName, final Universe universe) {
       super(globalName);
       this.universe = universe;
-      initialize(source);
     }
 
     protected abstract Object executeUnknownGlobal(VirtualFrame frame);
@@ -105,8 +101,8 @@ public abstract class GlobalNode extends ExpressionNode
       // Get the global from the universe
       Association assoc = universe.getGlobalsAssociation(globalName);
       if (assoc != null) {
-        return replace((GlobalNode) new CachedGlobalReadNode(
-            globalName, assoc, sourceSection)).executeGeneric(frame);
+        return replace(
+            (GlobalNode) new CachedGlobalReadNode(globalName, assoc)).executeGeneric(frame);
       } else {
         return executeUnknownGlobal(frame);
       }
@@ -115,9 +111,8 @@ public abstract class GlobalNode extends ExpressionNode
 
   private static final class UninitializedGlobalReadNode
       extends AbstractUninitializedGlobalReadNode {
-    UninitializedGlobalReadNode(final SSymbol globalName, final SourceSection source,
-        final Universe universe) {
-      super(globalName, source, universe);
+    UninitializedGlobalReadNode(final SSymbol globalName, final Universe universe) {
+      super(globalName, universe);
     }
 
     @Override
@@ -134,8 +129,8 @@ public abstract class GlobalNode extends ExpressionNode
   public static final class UninitializedGlobalReadWithoutErrorNode
       extends AbstractUninitializedGlobalReadNode {
     public UninitializedGlobalReadWithoutErrorNode(final SSymbol globalName,
-        final SourceSection source, final Universe universe) {
-      super(globalName, source, universe);
+        final Universe universe) {
+      super(globalName, universe);
     }
 
     @Override
@@ -148,12 +143,10 @@ public abstract class GlobalNode extends ExpressionNode
     private final Association            assoc;
     @CompilationFinal private Assumption assumption;
 
-    private CachedGlobalReadNode(final SSymbol globalName, final Association assoc,
-        final SourceSection source) {
+    private CachedGlobalReadNode(final SSymbol globalName, final Association assoc) {
       super(globalName);
       this.assoc = assoc;
       this.assumption = assoc.getAssumption();
-      initialize(source);
     }
 
     @Override

--- a/src/trufflesom/interpreter/nodes/SequenceNode.java
+++ b/src/trufflesom/interpreter/nodes/SequenceNode.java
@@ -21,7 +21,6 @@
  */
 package trufflesom.interpreter.nodes;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeCost;
@@ -70,28 +69,6 @@ public final class SequenceNode extends ExpressionNode {
 
   @Override
   public PreevaluatedExpression copyTrivialNode() {
-    return new WriteAndReturnSelf(expressions[0].copyTrivialNode());
-  }
-
-  private static final class WriteAndReturnSelf extends ExpressionNode
-      implements PreevaluatedExpression {
-    @Child PreevaluatedExpression write;
-
-    WriteAndReturnSelf(final PreevaluatedExpression write) {
-      this.write = write;
-    }
-
-    @Override
-    public Object doPreEvaluated(final VirtualFrame frame, final Object[] args) {
-      write.doPreEvaluated(frame, args);
-      return args[0];
-    }
-
-    @Override
-    public Object executeGeneric(final VirtualFrame frame) {
-      CompilerDirectives.transferToInterpreter();
-      throw new UnsupportedOperationException();
-    }
-
+    return expressions[0].copyTrivialNode();
   }
 }

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -261,7 +261,8 @@ public class BytecodeLoopNode extends ExpressionNode {
           byte literalIdx = bytecodes[bytecodeIndex + 1];
           SSymbol globalName = (SSymbol) literalsAndConstants[literalIdx];
 
-          GlobalNode quickened = GlobalNode.create(globalName, universe, sourceSection);
+          GlobalNode quickened =
+              GlobalNode.create(globalName, universe).initialize(sourceSection);
           quickenBytecode(bytecodeIndex, Q_PUSH_GLOBAL, quickened);
 
           // TODO: what's the correct semantics here? the outer or the closed self? normally,

--- a/src/trufflesom/interpreter/nodes/dispatch/CachedExprNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/CachedExprNode.java
@@ -4,7 +4,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
-import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
+import bd.primitives.nodes.PreevaluatedExpression;
 
 
 public class CachedExprNode extends AbstractDispatchNode {
@@ -13,9 +13,9 @@ public class CachedExprNode extends AbstractDispatchNode {
 
   @Child protected AbstractDispatchNode nextInCache;
 
-  @Child protected UnaryExpressionNode expr;
+  @Child protected PreevaluatedExpression expr;
 
-  public CachedExprNode(final DispatchGuard guard, final UnaryExpressionNode expr,
+  public CachedExprNode(final DispatchGuard guard, final PreevaluatedExpression expr,
       final AbstractDispatchNode nextInCache) {
     this.guard = guard;
     this.expr = expr;
@@ -28,7 +28,7 @@ public class CachedExprNode extends AbstractDispatchNode {
     Object rcvr = arguments[0];
     try {
       if (guard.entryMatches(rcvr)) {
-        return expr.executeEvaluated(frame, arguments[0]);
+        return expr.doPreEvaluated(frame, arguments);
       } else {
         return nextInCache.executeDispatch(frame, arguments);
       }

--- a/src/trufflesom/interpreter/nodes/dispatch/SuperDispatchNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/SuperDispatchNode.java
@@ -6,9 +6,8 @@ import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.interpreter.nodes.ISuperReadNode;
-import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
-import trufflesom.primitives.basics.NewObjectPrimFactory;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
@@ -35,8 +34,8 @@ public abstract class SuperDispatchNode extends AbstractDispatchNode {
       throw new RuntimeException("Currently #dnu with super sent is not yet implemented. ");
     }
 
-    if (method.isNewObjectPrimitive()) {
-      return new CachedExprNode(NewObjectPrimFactory.create(null));
+    if (method.isTrivial()) {
+      return new CachedExprNode(method.copyTrivialNode());
     }
 
     DirectCallNode superMethodNode = Truffle.getRuntime().createDirectCallNode(
@@ -94,16 +93,16 @@ public abstract class SuperDispatchNode extends AbstractDispatchNode {
   }
 
   private static final class CachedExprNode extends SuperDispatchNode {
-    @Child private UnaryExpressionNode expr;
+    @Child private PreevaluatedExpression expr;
 
-    private CachedExprNode(final UnaryExpressionNode expr) {
+    private CachedExprNode(final PreevaluatedExpression expr) {
       this.expr = expr;
     }
 
     @Override
     public Object executeDispatch(
         final VirtualFrame frame, final Object[] arguments) {
-      return expr.executeEvaluated(frame, arguments[0]);
+      return expr.doPreEvaluated(frame, arguments);
     }
   }
 

--- a/src/trufflesom/interpreter/nodes/dispatch/UninitializedDispatchNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/UninitializedDispatchNode.java
@@ -6,10 +6,9 @@ import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.interpreter.Types;
 import trufflesom.interpreter.nodes.MessageSendNode.GenericMessageSendNode;
-import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
-import trufflesom.primitives.basics.NewObjectPrimFactory;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
@@ -51,10 +50,11 @@ public final class UninitializedDispatchNode extends AbstractDispatchNode {
       SClass rcvrClass = Types.getClassOf(rcvr, universe);
       SInvokable method = rcvrClass.lookupInvokable(selector);
       CallTarget callTarget = null;
-      UnaryExpressionNode expr = null;
+      PreevaluatedExpression expr = null;
       if (method != null) {
-        if (method.isNewObjectPrimitive()) {
-          expr = NewObjectPrimFactory.create(null);
+        if (method.isTrivial()) {
+          expr = method.copyTrivialNode();
+          assert expr != null;
         } else {
           callTarget = method.getCallTarget();
         }

--- a/src/trufflesom/interpreter/nodes/literals/BlockNode.java
+++ b/src/trufflesom/interpreter/nodes/literals/BlockNode.java
@@ -7,6 +7,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 import bd.inlining.ScopeAdaptationVisitor;
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.compiler.MethodGenerationContext;
 import trufflesom.compiler.Variable;
 import trufflesom.compiler.Variable.Argument;
@@ -106,6 +107,16 @@ public class BlockNode extends LiteralNode {
     @Override
     protected BlockNode createNode(final SMethod adapted) {
       return new BlockNodeWithContext(adapted, universe).initialize(sourceSection);
+    }
+
+    @Override
+    public boolean isTrivial() {
+      return false;
+    }
+
+    @Override
+    public PreevaluatedExpression copyTrivialNode() {
+      throw new UnsupportedOperationException("Block literals with context are not trivial.");
     }
   }
 }

--- a/src/trufflesom/interpreter/nodes/literals/LiteralNode.java
+++ b/src/trufflesom/interpreter/nodes/literals/LiteralNode.java
@@ -43,4 +43,14 @@ public abstract class LiteralNode extends ExpressionNode
   public ExpressionNode inline(final MethodGenerationContext mgenc) {
     return this;
   }
+
+  @Override
+  public boolean isTrivial() {
+    return true;
+  }
+
+  @Override
+  public PreevaluatedExpression copyTrivialNode() {
+    return (PreevaluatedExpression) copy();
+  }
 }

--- a/src/trufflesom/interpreter/nodes/literals/LiteralNode.java
+++ b/src/trufflesom/interpreter/nodes/literals/LiteralNode.java
@@ -21,6 +21,8 @@
  */
 package trufflesom.interpreter.nodes.literals;
 
+import java.math.BigInteger;
+
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
@@ -29,11 +31,48 @@ import bd.inlining.nodes.Inlinable;
 import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.compiler.MethodGenerationContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.vmobjects.SArray;
+import trufflesom.vmobjects.SBlock;
+import trufflesom.vmobjects.SSymbol;
 
 
 @NodeInfo(cost = NodeCost.NONE)
 public abstract class LiteralNode extends ExpressionNode
     implements PreevaluatedExpression, Inlinable<MethodGenerationContext> {
+  public static LiteralNode create(final Object literal) {
+    if (literal instanceof SArray) {
+      return new ArrayLiteralNode((SArray) literal);
+    }
+
+    if (literal instanceof BigInteger) {
+      return new BigIntegerLiteralNode((BigInteger) literal);
+    }
+
+    if (literal instanceof SBlock) {
+      throw new IllegalArgumentException(
+          "SBlock isn't supported here, BlockNodes need to be constructed directly.");
+    }
+
+    if (literal instanceof Long) {
+      return new IntegerLiteralNode((Long) literal);
+    }
+
+    if (literal instanceof Double) {
+      return new DoubleLiteralNode((Double) literal);
+    }
+
+    if (literal instanceof String) {
+      return new StringLiteralNode((String) literal);
+    }
+
+    if (literal instanceof SSymbol) {
+      return new SymbolLiteralNode((SSymbol) literal);
+    }
+
+    throw new IllegalAccessError(
+        "Can't create a literal node for " + literal.getClass().getSimpleName());
+  }
+
   @Override
   public final Object doPreEvaluated(final VirtualFrame frame, final Object[] arguments) {
     return executeGeneric(frame);

--- a/src/trufflesom/primitives/basics/NewObjectPrim.java
+++ b/src/trufflesom/primitives/basics/NewObjectPrim.java
@@ -5,6 +5,7 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
 import trufflesom.interpreter.objectstorage.ObjectLayout;
 import trufflesom.vmobjects.SAbstractObject;
@@ -25,5 +26,15 @@ public abstract class NewObjectPrim extends UnaryExpressionNode {
   @Specialization(replaces = "doCached")
   public final SAbstractObject doUncached(final SClass receiver) {
     return new SObject(receiver);
+  }
+
+  @Override
+  public boolean isTrivial() {
+    return true;
+  }
+
+  @Override
+  public PreevaluatedExpression copyTrivialNode() {
+    return NewObjectPrimFactory.create(null);
   }
 }

--- a/src/trufflesom/primitives/reflection/GlobalPrim.java
+++ b/src/trufflesom/primitives/reflection/GlobalPrim.java
@@ -84,7 +84,8 @@ public abstract class GlobalPrim extends BinarySystemOperation {
         final Universe universe) {
       this.depth = depth;
       this.name = name;
-      getGlobal = new UninitializedGlobalReadWithoutErrorNode(name, source, universe);
+      getGlobal =
+          new UninitializedGlobalReadWithoutErrorNode(name, universe).initialize(source);
       next = new UninitializedGetGlobal(this.depth + 1, universe).initialize(source);
     }
 

--- a/src/trufflesom/vm/NotYetImplementedException.java
+++ b/src/trufflesom/vm/NotYetImplementedException.java
@@ -2,4 +2,12 @@ package trufflesom.vm;
 
 public final class NotYetImplementedException extends RuntimeException {
   private static final long serialVersionUID = -1862914873966278087L;
+
+  public NotYetImplementedException() {
+    super();
+  }
+
+  public NotYetImplementedException(final String message) {
+    super(message);
+  }
 }

--- a/src/trufflesom/vmobjects/SInvokable.java
+++ b/src/trufflesom/vmobjects/SInvokable.java
@@ -35,8 +35,8 @@ import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
+import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.interpreter.Invokable;
-import trufflesom.interpreter.Primitive;
 import trufflesom.vm.Universe;
 
 
@@ -90,11 +90,6 @@ public abstract class SInvokable extends SAbstractObject {
         return signature.toString();
       }
     }
-
-    @Override
-    public boolean isNewObjectPrimitive() {
-      return false;
-    }
   }
 
   public static final class SPrimitive extends SInvokable {
@@ -120,14 +115,6 @@ public abstract class SInvokable extends SAbstractObject {
       } else {
         return signature.toString();
       }
-    }
-
-    @Override
-    public boolean isNewObjectPrimitive() {
-      // Checkstyle: stop
-      return (signature.getString() == "new")
-          && ((Primitive) invokable).isNewObjectPrimitive();
-      // Checkstyle: resume
     }
   }
 
@@ -189,5 +176,16 @@ public abstract class SInvokable extends SAbstractObject {
 
   @CompilationFinal protected SClass holder;
 
-  public abstract boolean isNewObjectPrimitive();
+  public boolean isTrivial() {
+    return invokable.isTrivial();
+  }
+
+  public PreevaluatedExpression copyTrivialNode() {
+    if (!isTrivial()) {
+      throw new IllegalStateException();
+    }
+    PreevaluatedExpression n = invokable.copyTrivialNode();
+    assert n != null;
+    return n;
+  }
 }


### PR DESCRIPTION
This PR adds an optimization that inlines trivial methods like accessors, but also the NewObjectPrim into the dispatch chain.
Support is added for bytecode on AST interpreters.
The bytecode interpreter also uses the trivial AST nodes instead of a separate bytecode loop for the trivial methods.

There are a few other changes:
 - NotYetImplemented has now constructor with message
 - we error when multiple locals have the same name
 - the BytecodeGen is now static
 - fixed equality if locals
 - refactored things to use the Variable objects for lookups, instead of symbols
 - rewrite how bytecode matching, tracking, and optimizations are done to provide a more high-level infrastructure and helpers