### PR TITLE
Add bytecode-level inlining of ifTrue/ifFalse* messages

### DIFF
--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -39,6 +39,7 @@ import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.source.SourceSection;
 
 import bd.basic.ProgramDefinitionError;
+import bd.inlining.Scope;
 import bd.inlining.ScopeBuilder;
 import bd.inlining.nodes.Inlinable;
 import bd.tools.structure.StructuralProbe;
@@ -62,7 +63,8 @@ import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
 
-public class MethodGenerationContext implements ScopeBuilder<MethodGenerationContext> {
+public class MethodGenerationContext
+    implements ScopeBuilder<MethodGenerationContext>, Scope<LexicalScope, Method> {
 
   protected final ClassGenerationContext  holderGenc;
   protected final MethodGenerationContext outerGenc;
@@ -143,6 +145,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
 
     if (frameOnStack == null) {
       assert needsToCatchNonLocalReturn;
+      assert !locals.containsKey(universe.symFrameOnStack);
 
       frameOnStack = new Internal(universe.symFrameOnStack, source);
       frameOnStack.init(
@@ -219,8 +222,14 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
     return meth;
   }
 
-  public void setVarsOnMethodScope() {
-    Variable[] vars = new Variable[arguments.size() + locals.size()];
+  @Override
+  @SuppressWarnings("unchecked")
+  public Variable[] getVariables() {
+    int numVars = arguments.size() + locals.size();
+    if (frameOnStack != null) {
+      numVars += 1;
+    }
+    Variable[] vars = new Variable[numVars];
     int i = 0;
     for (Argument a : arguments.values()) {
       vars[i] = a;
@@ -231,7 +240,16 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
       vars[i] = l;
       i += 1;
     }
-    currentScope.setVariables(vars);
+
+    if (frameOnStack != null) {
+      vars[i] = frameOnStack;
+    }
+
+    return vars;
+  }
+
+  public void setVarsOnMethodScope() {
+    currentScope.setVariables(getVariables());
   }
 
   private SourceSection getSourceSectionForMethod(final SourceSection ssBody) {
@@ -501,5 +519,20 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
   public String toString() {
     return "MethodGenC(" + holderGenc.getName().getString() + ">>" + signature.toString()
         + ")";
+  }
+
+  @Override
+  public LexicalScope getOuterScopeOrNull() {
+    return currentScope.getOuterScopeOrNull();
+  }
+
+  @Override
+  public LexicalScope getScope(final Method method) {
+    return currentScope.getScope(method);
+  }
+
+  @Override
+  public String getName() {
+    return getMethodIdentifier();
   }
 }

--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -440,14 +440,18 @@ public class MethodGenerationContext
         holderGenc.getFieldIndex(fieldName), source);
   }
 
+  protected void addLocal(final Local l, final SSymbol name) {
+    assert !locals.containsKey(name);
+    locals.put(name, l);
+    currentScope.addVariable(l);
+  }
+
   public void mergeIntoScope(final LexicalScope scope, final SMethod toBeInlined) {
     for (Variable v : scope.getVariables()) {
       Local l = v.splitToMergeIntoOuterScope(universe, currentScope.getFrameDescriptor());
       if (l != null) { // can happen for instance for the block self, which we omit
         SSymbol name = l.getQualifiedName(universe);
-        assert !locals.containsKey(name);
-        locals.put(name, l);
-        currentScope.addVariable(l);
+        addLocal(l, name);
       }
     }
 

--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -422,7 +422,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
         holderGenc.getFieldIndex(fieldName), source);
   }
 
-  public void mergeIntoScope(final LexicalScope scope, final SMethod outer) {
+  public void mergeIntoScope(final LexicalScope scope, final SMethod toBeInlined) {
     for (Variable v : scope.getVariables()) {
       Local l = v.splitToMergeIntoOuterScope(universe, currentScope.getFrameDescriptor());
       if (l != null) { // can happen for instance for the block self, which we omit
@@ -433,7 +433,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
       }
     }
 
-    SMethod[] embeddedBlocks = outer.getEmbeddedBlocks();
+    SMethod[] embeddedBlocks = toBeInlined.getEmbeddedBlocks();
     LexicalScope[] embeddedScopes = scope.getEmbeddedScopes();
 
     assert ((embeddedBlocks == null || embeddedBlocks.length == 0) &&
@@ -450,7 +450,7 @@ public class MethodGenerationContext implements ScopeBuilder<MethodGenerationCon
       }
     }
 
-    boolean removed = embeddedBlockMethods.remove(outer);
+    boolean removed = embeddedBlockMethods.remove(toBeInlined);
     assert removed;
     currentScope.removeMerged(scope);
   }

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -8,6 +8,7 @@ import static trufflesom.compiler.Symbol.Exit;
 import static trufflesom.compiler.Symbol.Identifier;
 import static trufflesom.compiler.Symbol.Integer;
 import static trufflesom.compiler.Symbol.Keyword;
+import static trufflesom.compiler.Symbol.NewBlock;
 import static trufflesom.compiler.Symbol.NewTerm;
 import static trufflesom.compiler.Symbol.OperatorSequence;
 import static trufflesom.compiler.Symbol.Period;
@@ -268,7 +269,17 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
       formula(mgenc);
     } while (sym == Keyword);
 
-    SSymbol msg = universe.symbolFor(kw.toString());
+    String kwStr = kw.toString();
+
+    if (!superSend && (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrue()) ||
+        ("ifFalse:".equals(kwStr) && mgenc.inlineIfFalse()) ||
+        ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse()) ||
+        ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfFalseIfTrue()))) {
+      // all done
+      return;
+    }
+
+    SSymbol msg = universe.symbolFor(kwStr);
 
     mgenc.addLiteralIfAbsent(msg, this);
 
@@ -277,6 +288,83 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     } else {
       emitSEND(mgenc, msg);
     }
+  }
+
+  private boolean inlineIfTrue(final BytecodeMethodGenContext mgenc)
+      throws ProgramDefinitionError {
+    // HACK: we do assume that the receiver on the stack is a boolean
+    // HACK: similar to the {@see IfInlinedLiteralNode}
+    // HACK: we don't support anything but booleans at the moment
+
+    // if it's not a literal block, well, then we can't do anything anyway
+    if (sym != NewBlock) {
+      return false;
+    }
+
+    int jumpOffsetIdxToSkipTrueBranch = emitJumpOnFalseWithDummyOffset(mgenc);
+
+    inlinedBlock(mgenc);
+
+    peekForNextSymbolFromLexerIfNecessary();
+
+    if (sym == Keyword && "ifFalse:".equals(text) && nextSym == NewBlock) {
+      expect(Keyword);
+      int jumpOffsetIdxToSkipFalseBranch = emitJumpWithDummyOffset(mgenc);
+      patchJumpOffsetToPointToNextInstruction(mgenc, jumpOffsetIdxToSkipTrueBranch);
+      inlinedBlock(mgenc);
+      patchJumpOffsetToPointToNextInstruction(mgenc, jumpOffsetIdxToSkipFalseBranch);
+    } else {
+      patchJumpOffsetToPointToNextInstruction(mgenc, jumpOffsetIdxToSkipTrueBranch);
+    }
+
+    return true;
+  }
+
+  private boolean ifFalseMessages(final BytecodeMethodGenContext mgenc)
+      throws ProgramDefinitionError {
+    // HACK: we do assume that the receiver on the stack is a boolean
+    // HACK: similar to the {@see IfInlinedLiteralNode}
+    // HACK: we don't support anything but booleans at the moment
+
+    // if it's not a literal block, well, then we can't do anything anyway
+    if (sym != NewBlock) {
+      return false;
+    }
+
+    int jumpOffsetIdxToSkipFalseBranch = emitJumpOnTrueWithDummyOffset(mgenc);
+
+    inlinedBlock(mgenc);
+
+    peekForNextSymbolFromLexerIfNecessary();
+
+    if (sym == Keyword && "ifTrue:".equals(text) && nextSym == NewBlock) {
+      expect(Keyword);
+      int jumpOffsetIdxToSkipTrueBranch = emitJumpWithDummyOffset(mgenc);
+      patchJumpOffsetToPointToNextInstruction(mgenc, jumpOffsetIdxToSkipFalseBranch);
+      inlinedBlock(mgenc);
+      patchJumpOffsetToPointToNextInstruction(mgenc, jumpOffsetIdxToSkipTrueBranch);
+    } else {
+      patchJumpOffsetToPointToNextInstruction(mgenc, jumpOffsetIdxToSkipFalseBranch);
+    }
+
+    return true;
+  }
+
+  private void inlinedBlock(final BytecodeMethodGenContext mgenc)
+      throws ProgramDefinitionError {
+    // needs to make sure that we simply don't generate a LOCAL_RETURN at the end
+    // just leaving the last value on the stack is the right semantics
+
+    expect(NewBlock);
+    mgenc.startProcessingDirectlyInlinedBlockBody();
+
+    try {
+      blockContents(mgenc);
+    } finally {
+      mgenc.endProcessingDirectlyInlinedBlockBody();
+    }
+
+    expect(EndBlock);
   }
 
   private void formula(final BytecodeMethodGenContext mgenc) throws ProgramDefinitionError {

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -270,10 +270,10 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
 
     String kwStr = kw.toString();
 
-    if (!superSend && (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrue()) ||
-        ("ifFalse:".equals(kwStr) && mgenc.inlineIfFalse()) ||
-        ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse()) ||
-        ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfFalseIfTrue()))) {
+    if (!superSend && (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrue(this)) ||
+        ("ifFalse:".equals(kwStr) && mgenc.inlineIfFalse(this)) ||
+        ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this)) ||
+        ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfFalseIfTrue(this)))) {
       // all done
       return;
     }

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -172,6 +172,18 @@ public final class BytecodeGenerator {
     emit2(mgenc, PUSH_CONSTANT, literalIndex);
   }
 
+  public static void emitJUMP(final BytecodeMethodGenContext mgenc, final byte offset) {
+    emit2(mgenc, JUMP, offset);
+  }
+
+  public static void emitJUMPONTRUE(final BytecodeMethodGenContext mgenc, final byte offset) {
+    emit2(mgenc, JUMP_ON_TRUE, offset);
+  }
+
+  public static void emitJUMPONFALSE(final BytecodeMethodGenContext mgenc, final byte offset) {
+    emit2(mgenc, JUMP_ON_FALSE, offset);
+  }
+
   public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, JUMP_ON_TRUE);
     return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -70,11 +70,15 @@ public final class BytecodeGenerator {
 
   public static void emitINCFIELD(final BytecodeMethodGenContext mgenc, final byte fieldIdx,
       final byte ctx) {
+    assert fieldIdx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, INC_FIELD, fieldIdx, ctx);
   }
 
   public static void emitINCFIELDPUSH(final BytecodeMethodGenContext mgenc,
       final byte fieldIdx, final byte ctx) {
+    assert fieldIdx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, INC_FIELD_PUSH, fieldIdx, ctx);
   }
 
@@ -86,6 +90,8 @@ public final class BytecodeGenerator {
 
   public static void emitPUSHARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
+    assert idx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, PUSH_ARGUMENT, idx, ctx);
   }
 
@@ -115,6 +121,7 @@ public final class BytecodeGenerator {
   public static void emitPUSHLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
     assert idx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, PUSH_LOCAL, idx, ctx);
   }
 
@@ -126,6 +133,8 @@ public final class BytecodeGenerator {
 
   public static void emitPUSHFIELD(final BytecodeMethodGenContext mgenc, final byte fieldIdx,
       final byte ctx) {
+    assert fieldIdx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, PUSH_FIELD, fieldIdx, ctx);
   }
 
@@ -136,11 +145,15 @@ public final class BytecodeGenerator {
 
   public static void emitPOPARGUMENT(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
+    assert idx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, POP_ARGUMENT, idx, ctx);
   }
 
   public static void emitPOPLOCAL(final BytecodeMethodGenContext mgenc, final byte idx,
       final byte ctx) {
+    assert idx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, POP_LOCAL, idx, ctx);
   }
 
@@ -152,6 +165,8 @@ public final class BytecodeGenerator {
 
   public static void emitPOPFIELD(final BytecodeMethodGenContext mgenc, final byte fieldIdx,
       final byte ctx) {
+    assert fieldIdx >= 0;
+    assert ctx >= 0;
     emit3(mgenc, POP_FIELD, fieldIdx, ctx);
   }
 
@@ -169,6 +184,7 @@ public final class BytecodeGenerator {
 
   public static void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc,
       final byte literalIndex) {
+    assert literalIndex >= 0;
     emit2(mgenc, PUSH_CONSTANT, literalIndex);
   }
 

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -26,6 +26,7 @@ package trufflesom.compiler.bc;
 
 import static trufflesom.interpreter.bc.Bytecodes.DEC;
 import static trufflesom.interpreter.bc.Bytecodes.DUP;
+import static trufflesom.interpreter.bc.Bytecodes.HALT;
 import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
@@ -54,6 +55,10 @@ import trufflesom.vmobjects.SSymbol;
 
 public final class BytecodeGenerator {
   private BytecodeGenerator() {}
+
+  public static void emitHALT(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, HALT);
+  }
 
   public static void emitINC(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, INC);
@@ -119,6 +124,11 @@ public final class BytecodeGenerator {
     emit3(mgenc, PUSH_FIELD, mgenc.getFieldIndex(fieldName), mgenc.getMaxContextLevel());
   }
 
+  public static void emitPUSHFIELD(final BytecodeMethodGenContext mgenc, final byte fieldIdx,
+      final byte ctx) {
+    emit3(mgenc, PUSH_FIELD, fieldIdx, ctx);
+  }
+
   public static void emitPUSHGLOBAL(final BytecodeMethodGenContext mgenc,
       final SSymbol global) {
     emit2(mgenc, PUSH_GLOBAL, mgenc.findLiteralIndex(global));
@@ -138,6 +148,11 @@ public final class BytecodeGenerator {
       final SSymbol fieldName) {
     assert mgenc.hasField(fieldName);
     emit3(mgenc, POP_FIELD, mgenc.getFieldIndex(fieldName), mgenc.getMaxContextLevel());
+  }
+
+  public static void emitPOPFIELD(final BytecodeMethodGenContext mgenc, final byte fieldIdx,
+      final byte ctx) {
+    emit3(mgenc, POP_FIELD, fieldIdx, ctx);
   }
 
   public static void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -31,8 +31,10 @@ import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
-import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE;
-import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -192,21 +194,35 @@ public final class BytecodeGenerator {
     emit2(mgenc, JUMP, offset);
   }
 
-  public static void emitJUMPONTRUE(final BytecodeMethodGenContext mgenc, final byte offset) {
-    emit2(mgenc, JUMP_ON_TRUE, offset);
+  public static void emitJUMPONTRUETOPNIL(final BytecodeMethodGenContext mgenc,
+      final byte offset) {
+    emit2(mgenc, JUMP_ON_TRUE_TOP_NIL, offset);
   }
 
-  public static void emitJUMPONFALSE(final BytecodeMethodGenContext mgenc, final byte offset) {
-    emit2(mgenc, JUMP_ON_FALSE, offset);
+  public static void emitJUMPONFALSETOPNIL(final BytecodeMethodGenContext mgenc,
+      final byte offset) {
+    emit2(mgenc, JUMP_ON_FALSE_TOP_NIL, offset);
   }
 
-  public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc) {
-    emit1(mgenc, JUMP_ON_TRUE);
+  public static void emitJUMPONTRUEPOP(final BytecodeMethodGenContext mgenc,
+      final byte offset) {
+    emit2(mgenc, JUMP_ON_TRUE_POP, offset);
+  }
+
+  public static void emitJUMPONFALSEPOP(final BytecodeMethodGenContext mgenc,
+      final byte offset) {
+    emit2(mgenc, JUMP_ON_FALSE_POP, offset);
+  }
+
+  public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc,
+      final boolean needsPop) {
+    emit1(mgenc, needsPop ? JUMP_ON_TRUE_POP : JUMP_ON_TRUE_TOP_NIL);
     return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
   }
 
-  public static int emitJumpOnFalseWithDummyOffset(final BytecodeMethodGenContext mgenc) {
-    emit1(mgenc, JUMP_ON_FALSE);
+  public static int emitJumpOnFalseWithDummyOffset(final BytecodeMethodGenContext mgenc,
+      final boolean needsPop) {
+    emit1(mgenc, needsPop ? JUMP_ON_FALSE_POP : JUMP_ON_FALSE_TOP_NIL);
     return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
   }
 

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -29,6 +29,9 @@ import static trufflesom.interpreter.bc.Bytecodes.DUP;
 import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -152,6 +155,27 @@ public final class BytecodeGenerator {
   public static void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc,
       final byte literalIndex) {
     emit2(mgenc, PUSH_CONSTANT, literalIndex);
+  }
+
+  public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, JUMP_ON_TRUE);
+    return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+  }
+
+  public static int emitJumpOnFalseWithDummyOffset(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, JUMP_ON_FALSE);
+    return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+  }
+
+  public static int emitJumpWithDummyOffset(final BytecodeMethodGenContext mgenc) {
+    emit1(mgenc, JUMP);
+    return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+  }
+
+  public static void patchJumpOffsetToPointToNextInstruction(
+      final BytecodeMethodGenContext mgenc,
+      final int idxOfOffset) {
+    mgenc.patchJumpOffsetToPointToNextInstruction(idxOfOffset);
   }
 
   private static void emit1(final BytecodeMethodGenContext mgenc, final byte code) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -51,6 +51,8 @@ import static trufflesom.interpreter.bc.Bytecodes.RETURN_SELF;
 import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 
+import trufflesom.compiler.Parser.ParseError;
+import trufflesom.compiler.ParserBc;
 import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
@@ -233,8 +235,8 @@ public final class BytecodeGenerator {
 
   public static void patchJumpOffsetToPointToNextInstruction(
       final BytecodeMethodGenContext mgenc,
-      final int idxOfOffset) {
-    mgenc.patchJumpOffsetToPointToNextInstruction(idxOfOffset);
+      final int idxOfOffset, final ParserBc parser) throws ParseError {
+    mgenc.patchJumpOffsetToPointToNextInstruction(idxOfOffset, parser);
   }
 
   private static void emit1(final BytecodeMethodGenContext mgenc, final byte code) {

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -151,7 +151,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     int jumpOffset = bytecode.size() - instructionStart;
 
     assert jumpOffset > 0
-        && jumpOffset <= Byte.MAX_VALUE : "The jumpOffset for the JUMP* bytecode is too large or small. jumpOffset="
+        && jumpOffset <= 0xff : "The jumpOffset for the JUMP* bytecode is too large or small. jumpOffset="
             + jumpOffset;
 
     bytecode.set(idxOfOffset, (byte) jumpOffset);

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -303,6 +303,10 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   }
 
   private ExpressionNode constructTrivialBody() {
+    if (isBlockMethod()) {
+      return null;
+    }
+
     ExpressionNode expr = optimizeLiteralReturn();
 
     if (expr == null) {
@@ -457,10 +461,6 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   }
 
   private FieldReadNode optimizeFieldGetter() {
-    if (isBlockMethod()) {
-      return null;
-    }
-
     final byte pushCandidate = lastBytecodeIsOneOf(1, PUSH_FIELD_BYTECODES);
     if (pushCandidate == INVALID) {
       return null;
@@ -482,10 +482,6 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   }
 
   private ExpressionNode optimizeFieldSetter() {
-    if (isBlockMethod()) {
-      return null;
-    }
-
     // example sequence: PUSH_ARG1 DUP POP_FIELD_1 RETURN_SELF
     final byte pushCandidate = lastBytecodeIs(3, PUSH_ARGUMENT);
     if (pushCandidate == INVALID) {

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -7,6 +7,9 @@ import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.INVALID;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -610,6 +613,10 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
           break;
         case INC_FIELD_PUSH:
           depth++;
+          break;
+        case JUMP:
+        case JUMP_ON_TRUE:
+        case JUMP_ON_FALSE:
           break;
         default:
           throw new IllegalStateException("Illegal bytecode "

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -237,11 +237,11 @@ public class Disassembler {
         }
 
         case JUMP:
-          int offset = bytecodes.get(b + 1);
         case JUMP_ON_TRUE_TOP_NIL:
         case JUMP_ON_FALSE_TOP_NIL:
         case JUMP_ON_TRUE_POP:
         case JUMP_ON_FALSE_POP: {
+          int offset = Byte.toUnsignedInt(bytecodes.get(b + 1));
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b + offset) + ")");

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -28,6 +28,9 @@ package trufflesom.compiler.bc;
 
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.POP_LOCAL;
@@ -211,6 +214,7 @@ public class Disassembler {
           if (m != null) {
             dumpMethod((SMethod) m.getConstant(idx), indent + "\t");
           }
+          Universe.errorPrintln();
           break;
         }
 
@@ -227,6 +231,16 @@ public class Disassembler {
                 + constant.toString());
           }
           Universe.errorPrintln();
+          break;
+        }
+
+        case JUMP:
+        case JUMP_ON_TRUE:
+        case JUMP_ON_FALSE: {
+          int offset = bytecodes.get(b + 1);
+
+          Universe.errorPrintln(
+              "(jump offset: " + offset + " -> jump target: " + (b + offset) + ")");
           break;
         }
 

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -29,8 +29,10 @@ package trufflesom.compiler.bc;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
-import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE;
-import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.POP_LOCAL;
@@ -235,9 +237,11 @@ public class Disassembler {
         }
 
         case JUMP:
-        case JUMP_ON_TRUE:
-        case JUMP_ON_FALSE: {
           int offset = bytecodes.get(b + 1);
+        case JUMP_ON_TRUE_TOP_NIL:
+        case JUMP_ON_FALSE_TOP_NIL:
+        case JUMP_ON_TRUE_POP:
+        case JUMP_ON_FALSE_POP: {
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b + offset) + ")");

--- a/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/interpreter/Invokable.java
@@ -9,8 +9,6 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.compiler.MethodGenerationContext;
-import trufflesom.compiler.Parser.ParseError;
-import trufflesom.compiler.bc.BytecodeMethodGenContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.interpreter.nodes.bc.BytecodeLoopNode;
 import trufflesom.vmobjects.SClass;
@@ -56,9 +54,6 @@ public abstract class Invokable extends RootNode {
   /** Inline invokable into the lexical context of the target method generation context. */
   public abstract ExpressionNode inline(MethodGenerationContext targetMgenc,
       SMethod toBeInlined);
-
-  public abstract void inlineBytecode(BytecodeMethodGenContext mgenc, SMethod toBeInlined)
-      throws ParseError;
 
   public BytecodeLoopNode getBodyForInlining() {
     return (BytecodeLoopNode) expressionOrSequence.getFirstMethodBodyNode();

--- a/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/interpreter/Invokable.java
@@ -50,8 +50,9 @@ public abstract class Invokable extends RootNode {
     return expressionOrSequence.executeGeneric(frame);
   }
 
-  /** Inline invokable into the lexical context of the given builder. */
-  public abstract ExpressionNode inline(MethodGenerationContext mgenc, SMethod outer);
+  /** Inline invokable into the lexical context of the target method generation context. */
+  public abstract ExpressionNode inline(MethodGenerationContext targetMgenc,
+      SMethod toBeInlined);
 
   @Override
   public final boolean isCloningAllowed() {

--- a/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/interpreter/Invokable.java
@@ -9,7 +9,10 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import bd.primitives.nodes.PreevaluatedExpression;
 import trufflesom.compiler.MethodGenerationContext;
+import trufflesom.compiler.Parser.ParseError;
+import trufflesom.compiler.bc.BytecodeMethodGenContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.bc.BytecodeLoopNode;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable.SMethod;
 
@@ -53,6 +56,13 @@ public abstract class Invokable extends RootNode {
   /** Inline invokable into the lexical context of the target method generation context. */
   public abstract ExpressionNode inline(MethodGenerationContext targetMgenc,
       SMethod toBeInlined);
+
+  public abstract void inlineBytecode(BytecodeMethodGenContext mgenc, SMethod toBeInlined)
+      throws ParseError;
+
+  public BytecodeLoopNode getBodyForInlining() {
+    return (BytecodeLoopNode) expressionOrSequence.getFirstMethodBodyNode();
+  }
 
   @Override
   public final boolean isCloningAllowed() {

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -76,10 +76,11 @@ public final class Method extends Invokable {
 
   public Method cloneAndAdaptAfterScopeChange(final BytecodeMethodGenContext mgenc,
       final LexicalScope adaptedScope, final int appliesTo,
-      final boolean cloneAdaptedAsUninitialized, final boolean outerScopeChanged) {
+      final boolean cloneAdaptedAsUninitialized,
+      final boolean requiresChangesToContextLevels) {
     Scope<?, ?> scope = mgenc == null ? adaptedScope : mgenc;
     ExpressionNode adaptedBody = ScopeAdaptationVisitor.adapt(uninitializedBody, scope,
-        appliesTo, outerScopeChanged, getLanguage(SomLanguage.class));
+        appliesTo, requiresChangesToContextLevels, getLanguage(SomLanguage.class));
 
     ExpressionNode uninit;
     if (cloneAdaptedAsUninitialized) {
@@ -106,7 +107,7 @@ public final class Method extends Invokable {
   public Node deepCopy() {
     LexicalScope splitScope = currentLexicalScope.split();
     assert currentLexicalScope != splitScope;
-    return cloneAndAdaptAfterScopeChange(null, splitScope, 0, false, true);
+    return cloneAndAdaptAfterScopeChange(null, splitScope, 0, false, false);
   }
 
   @Override

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -28,6 +28,8 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import bd.inlining.ScopeAdaptationVisitor;
 import trufflesom.compiler.MethodGenerationContext;
+import trufflesom.compiler.Parser.ParseError;
+import trufflesom.compiler.bc.BytecodeMethodGenContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.vmobjects.SInvokable.SMethod;
 
@@ -112,5 +114,12 @@ public final class Method extends Invokable {
     mgenc.mergeIntoScope(currentLexicalScope, toBeInlined);
     return ScopeAdaptationVisitor.adapt(uninitializedBody, mgenc.getCurrentLexicalScope(), 0,
         true, getLanguage(SomLanguage.class));
+  }
+
+  @Override
+  public void inlineBytecode(final BytecodeMethodGenContext mgenc, final SMethod toBeInlined)
+      throws ParseError {
+    mgenc.mergeIntoScope(currentLexicalScope, toBeInlined);
+    getBodyForInlining().inlineInto(mgenc);
   }
 }

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -26,9 +26,9 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.source.SourceSection;
 
+import bd.inlining.Scope;
 import bd.inlining.ScopeAdaptationVisitor;
 import trufflesom.compiler.MethodGenerationContext;
-import trufflesom.compiler.Parser.ParseError;
 import trufflesom.compiler.bc.BytecodeMethodGenContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.vmobjects.SInvokable.SMethod;
@@ -74,10 +74,11 @@ public final class Method extends Invokable {
     return "Method " + getName() + " @" + Integer.toHexString(hashCode());
   }
 
-  public Method cloneAndAdaptAfterScopeChange(final LexicalScope adaptedScope,
-      final int appliesTo, final boolean cloneAdaptedAsUninitialized,
-      final boolean outerScopeChanged) {
-    ExpressionNode adaptedBody = ScopeAdaptationVisitor.adapt(uninitializedBody, adaptedScope,
+  public Method cloneAndAdaptAfterScopeChange(final BytecodeMethodGenContext mgenc,
+      final LexicalScope adaptedScope, final int appliesTo,
+      final boolean cloneAdaptedAsUninitialized, final boolean outerScopeChanged) {
+    Scope<?, ?> scope = mgenc == null ? adaptedScope : mgenc;
+    ExpressionNode adaptedBody = ScopeAdaptationVisitor.adapt(uninitializedBody, scope,
         appliesTo, outerScopeChanged, getLanguage(SomLanguage.class));
 
     ExpressionNode uninit;
@@ -105,21 +106,14 @@ public final class Method extends Invokable {
   public Node deepCopy() {
     LexicalScope splitScope = currentLexicalScope.split();
     assert currentLexicalScope != splitScope;
-    return cloneAndAdaptAfterScopeChange(splitScope, 0, false, true);
+    return cloneAndAdaptAfterScopeChange(null, splitScope, 0, false, true);
   }
 
   @Override
   public ExpressionNode inline(final MethodGenerationContext mgenc,
       final SMethod toBeInlined) {
     mgenc.mergeIntoScope(currentLexicalScope, toBeInlined);
-    return ScopeAdaptationVisitor.adapt(uninitializedBody, mgenc.getCurrentLexicalScope(), 0,
-        true, getLanguage(SomLanguage.class));
-  }
-
-  @Override
-  public void inlineBytecode(final BytecodeMethodGenContext mgenc, final SMethod toBeInlined)
-      throws ParseError {
-    mgenc.mergeIntoScope(currentLexicalScope, toBeInlined);
-    getBodyForInlining().inlineInto(mgenc);
+    return ScopeAdaptationVisitor.adapt(uninitializedBody, mgenc, 0, true,
+        getLanguage(SomLanguage.class));
   }
 }

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -107,8 +107,9 @@ public final class Method extends Invokable {
   }
 
   @Override
-  public ExpressionNode inline(final MethodGenerationContext mgenc, final SMethod outer) {
-    mgenc.mergeIntoScope(currentLexicalScope, outer);
+  public ExpressionNode inline(final MethodGenerationContext mgenc,
+      final SMethod toBeInlined) {
+    mgenc.mergeIntoScope(currentLexicalScope, toBeInlined);
     return ScopeAdaptationVisitor.adapt(uninitializedBody, mgenc.getCurrentLexicalScope(), 0,
         true, getLanguage(SomLanguage.class));
   }

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -56,11 +56,15 @@ public class Bytecodes {
   public static final byte INC_FIELD      = 19;
   public static final byte INC_FIELD_PUSH = 20;
 
-  public static final byte Q_PUSH_GLOBAL = 21;
-  public static final byte Q_SEND        = 22;
-  public static final byte Q_SEND_1      = 23;
-  public static final byte Q_SEND_2      = 24;
-  public static final byte Q_SEND_3      = 25;
+  public static final byte JUMP          = 21;
+  public static final byte JUMP_ON_TRUE  = 22;
+  public static final byte JUMP_ON_FALSE = 23;
+
+  public static final byte Q_PUSH_GLOBAL = 24;
+  public static final byte Q_SEND        = 25;
+  public static final byte Q_SEND_1      = 26;
+  public static final byte Q_SEND_2      = 27;
+  public static final byte Q_SEND_3      = 28;
 
   public static final byte INVALID = -1;
 
@@ -111,6 +115,10 @@ public class Bytecodes {
         "INC_FIELD       ",
         "INC_FIELD_PUSH  ",
 
+        "JUMP            ",
+        "JUMP_ON_TRUE    ",
+        "JUMP_ON_FALSE   ",
+
         "Q_PUSH_GLOBAL   ",
         "Q_SEND          ",
         "Q_SEND_1        ",
@@ -146,6 +154,10 @@ public class Bytecodes {
 
         3, // INC_FIELD
         3, // INC_FIELD_PUSH
+
+        2, // JUMP
+        2, // JUMP_ON_TRUE
+        2, // JUMP_ON_FALSE
 
         2, // Q_PUSH_GLOBAL
         2, // Q_SEND

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -56,15 +56,17 @@ public class Bytecodes {
   public static final byte INC_FIELD      = 19;
   public static final byte INC_FIELD_PUSH = 20;
 
-  public static final byte JUMP          = 21;
-  public static final byte JUMP_ON_TRUE  = 22;
-  public static final byte JUMP_ON_FALSE = 23;
+  public static final byte JUMP                  = 21;
+  public static final byte JUMP_ON_TRUE_TOP_NIL  = 22;
+  public static final byte JUMP_ON_FALSE_TOP_NIL = 23;
+  public static final byte JUMP_ON_TRUE_POP      = 24;
+  public static final byte JUMP_ON_FALSE_POP     = 25;
 
-  public static final byte Q_PUSH_GLOBAL = 24;
-  public static final byte Q_SEND        = 25;
-  public static final byte Q_SEND_1      = 26;
-  public static final byte Q_SEND_2      = 27;
-  public static final byte Q_SEND_3      = 28;
+  public static final byte Q_PUSH_GLOBAL = 26;
+  public static final byte Q_SEND        = 27;
+  public static final byte Q_SEND_1      = 28;
+  public static final byte Q_SEND_2      = 29;
+  public static final byte Q_SEND_3      = 30;
 
   public static final byte INVALID = -1;
 
@@ -116,8 +118,10 @@ public class Bytecodes {
         "INC_FIELD_PUSH  ",
 
         "JUMP            ",
-        "JUMP_ON_TRUE    ",
-        "JUMP_ON_FALSE   ",
+        "JUMP_ON_TRUE_TOP_NIL",
+        "JUMP_ON_FALSE_TOP_NIL",
+        "JUMP_ON_TRUE_POP",
+        "JUMP_ON_FALSE_POP",
 
         "Q_PUSH_GLOBAL   ",
         "Q_SEND          ",
@@ -156,8 +160,10 @@ public class Bytecodes {
         3, // INC_FIELD_PUSH
 
         2, // JUMP
-        2, // JUMP_ON_TRUE
-        2, // JUMP_ON_FALSE
+        2, // JUMP_ON_TRUE_TOP_NIL
+        2, // JUMP_ON_FALSE_TOP_NIL
+        2, // JUMP_ON_TRUE_POP
+        2, // JUMP_ON_FALSE_POP
 
         2, // Q_PUSH_GLOBAL
         2, // Q_SEND

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -4,6 +4,11 @@ import static trufflesom.compiler.bc.BytecodeGenerator.emitDEC;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitDUP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitHALT;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitINC;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitINCFIELD;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitINCFIELDPUSH;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMP;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMPONFALSE;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMPONTRUE;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOPARGUMENT;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOPFIELD;
@@ -1010,6 +1015,38 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
 
         case DEC: {
           emitDEC(mgenc);
+          break;
+        }
+
+        case INC_FIELD: {
+          byte fieldIdx = bytecodes[i + 1];
+          byte contextIdx = bytecodes[i + 2];
+          emitINCFIELD(mgenc, fieldIdx, (byte) (contextIdx - 1));
+          break;
+        }
+
+        case INC_FIELD_PUSH: {
+          byte fieldIdx = bytecodes[i + 1];
+          byte contextIdx = bytecodes[i + 2];
+          emitINCFIELDPUSH(mgenc, fieldIdx, (byte) (contextIdx - 1));
+          break;
+        }
+
+        case JUMP: {
+          byte offset = bytecodes[i + 1];
+          emitJUMP(mgenc, offset);
+          break;
+        }
+
+        case JUMP_ON_TRUE: {
+          byte offset = bytecodes[i + 1];
+          emitJUMPONTRUE(mgenc, offset);
+          break;
+        }
+
+        case JUMP_ON_FALSE: {
+          byte offset = bytecodes[i + 1];
+          emitJUMPONFALSE(mgenc, offset);
           break;
         }
 

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -229,6 +229,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case PUSH_ARGUMENT: {
           byte argIdx = bytecodes[bytecodeIndex + 1];
           byte contextIdx = bytecodes[bytecodeIndex + 2];
+          assert contextIdx >= 0;
 
           VirtualFrame currentOrContext = frame;
           if (contextIdx > 0) {
@@ -1077,6 +1078,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
           ScopeElement<ExpressionNode> se = inliner.getAdaptedVar(local);
 
           bytecodes[i + 2] = (byte) se.contextLevel;
+          assert bytecodes[i + 2] >= 0;
           localsAndOuters[localIdx] = ((Local) se.var).getSlot();
           break;
         }
@@ -1187,6 +1189,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
     byte contextIdx = bytecodes[i + 2];
     if (contextIdx >= inliner.contextLevel) {
       byte ctx = (byte) (contextIdx - 1);
+      assert ctx >= 0;
       bytecodes[i + 2] = ctx;
     }
   }

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -630,7 +630,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         }
 
         case JUMP: {
-          byte offset = bytecodes[bytecodeIndex + 1];
+          int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
           nextBytecodeIndex = bytecodeIndex + offset;
           break;
         }
@@ -638,7 +638,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case JUMP_ON_TRUE_TOP_NIL: {
           Object val = stack[stackPointer];
           if (val == Boolean.TRUE) {
-            byte offset = bytecodes[bytecodeIndex + 1];
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
             nextBytecodeIndex = bytecodeIndex + offset;
             stack[stackPointer] = Nil.nilObject;
           } else {
@@ -650,7 +650,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case JUMP_ON_FALSE_TOP_NIL: {
           Object val = stack[stackPointer];
           if (val == Boolean.FALSE) {
-            byte offset = bytecodes[bytecodeIndex + 1];
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
             nextBytecodeIndex = bytecodeIndex + offset;
             stack[stackPointer] = Nil.nilObject;
           } else {

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -6,6 +6,9 @@ import static trufflesom.interpreter.bc.Bytecodes.HALT;
 import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE;
 import static trufflesom.interpreter.bc.Bytecodes.POP;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
 import static trufflesom.interpreter.bc.Bytecodes.POP_FIELD;
@@ -588,6 +591,34 @@ public class BytecodeLoopNode extends ExpressionNode {
           long value = ((IncrementLongFieldNode) node).increment(obj);
           stackPointer += 1;
           stack[stackPointer] = value;
+          break;
+        }
+
+        case JUMP: {
+          byte offset = bytecodes[bytecodeIndex + 1];
+          nextBytecodeIndex = bytecodeIndex + offset;
+          break;
+        }
+
+        case JUMP_ON_TRUE: {
+          Object val = stack[stackPointer];
+          if (val == Boolean.TRUE) {
+            byte offset = bytecodes[bytecodeIndex + 1];
+            nextBytecodeIndex = bytecodeIndex + offset;
+          } else {
+            stackPointer -= 1;
+          }
+          break;
+        }
+
+        case JUMP_ON_FALSE: {
+          Object val = stack[stackPointer];
+          if (val == Boolean.FALSE) {
+            byte offset = bytecodes[bytecodeIndex + 1];
+            nextBytecodeIndex = bytecodeIndex + offset;
+          } else {
+            stackPointer -= 1;
+          }
           break;
         }
 

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -946,6 +946,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
               targetContextLevel + 1, true, true);
           SMethod newMethod = new SMethod(blockMethod.getSignature(), adapted,
               blockMethod.getEmbeddedBlocks(), blockIvk.getSourceSection());
+          newMethod.setHolder(blockMethod.getHolder());
           mgenc.addLiteralIfAbsent(newMethod, null);
           emitPUSHBLOCK(mgenc, newMethod);
           break;
@@ -1145,6 +1146,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
                   inliner.contextLevel + 1, true, requiresChangesToContextLevels);
           SMethod newMethod = new SMethod(blockMethod.getSignature(), adapted,
               blockMethod.getEmbeddedBlocks(), blockIvk.getSourceSection());
+          newMethod.setHolder(blockMethod.getHolder());
           literalsAndConstants[literalIdx] = newMethod;
           break;
         }

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1021,6 +1021,9 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
           byte newCtx = (byte) (contextIdx - 1);
           if (newCtx == 0) {
             emitRETURNLOCAL(mgenc);
+            // emitted to avoid having jumps being broken
+            // but should not be executed
+            emitHALT(mgenc);
           } else {
             emitRETURNNONLOCAL(mgenc);
           }

--- a/src/trufflesom/interpreter/nodes/literals/BlockNode.java
+++ b/src/trufflesom/interpreter/nodes/literals/BlockNode.java
@@ -72,9 +72,8 @@ public class BlockNode extends LiteralNode {
     }
 
     Method blockIvk = (Method) blockMethod.getInvokable();
-    Method adapted = blockIvk.cloneAndAdaptAfterScopeChange(
-        inliner.getScope(blockIvk), inliner.contextLevel + 1, true,
-        inliner.outerScopeChanged());
+    Method adapted = blockIvk.cloneAndAdaptAfterScopeChange(null, inliner.getScope(blockIvk),
+        inliner.contextLevel + 1, true, inliner.outerScopeChanged());
     SMethod method = new SMethod(blockMethod.getSignature(), adapted,
         blockMethod.getEmbeddedBlocks(), blockIvk.getSourceSection());
     replace(createNode(method));

--- a/src/trufflesom/interpreter/nodes/literals/BlockNode.java
+++ b/src/trufflesom/interpreter/nodes/literals/BlockNode.java
@@ -76,6 +76,7 @@ public class BlockNode extends LiteralNode {
         inliner.contextLevel + 1, true, inliner.outerScopeChanged());
     SMethod method = new SMethod(blockMethod.getSignature(), adapted,
         blockMethod.getEmbeddedBlocks(), blockIvk.getSourceSection());
+    method.setHolder(blockMethod.getHolder());
     replace(createNode(method));
   }
 


### PR DESCRIPTION
This PR implements bytecode-level inlining of `#ifTrue:`, `#ifFalse:`, `#ifTrue:ifFalse:`, and `#ifFalse:ifTrue:`.

As always, inlining is a somewhat hairy exercise, and this is no different here.
I rely on much of the infrastructure for the AST interpreters, but need to handle the bytecodes separately.

To make the inlining work easily, I now exclude all block methods from the trivial optimizations. This way, I don't need special handling and bytecode reconstruction for those.

Mandelbrot seems to suffer a little in performance from this. As far as I can tell, this is an issue with boxing elimination, which doesn't trigger as completely as before.