### PR TITLE
Native image >21.1 black lists many operations from compilation

### DIFF
--- a/src/trufflesom/interpreter/nodes/bc/BinaryPrimitiveWrapper.java
+++ b/src/trufflesom/interpreter/nodes/bc/BinaryPrimitiveWrapper.java
@@ -2,6 +2,7 @@ package trufflesom.interpreter.nodes.bc;
 
 import static trufflesom.interpreter.bc.Bytecodes.Q_SEND;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
@@ -34,6 +35,7 @@ public class BinaryPrimitiveWrapper extends BinaryExpressionNode {
 
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
+    CompilerDirectives.transferToInterpreter();
     throw new UnsupportedOperationException(
         "In the bytecode interpreter, `executeEvaluated` is expected to be used");
   }

--- a/src/trufflesom/interpreter/nodes/bc/TernaryPrimitiveWrapper.java
+++ b/src/trufflesom/interpreter/nodes/bc/TernaryPrimitiveWrapper.java
@@ -2,6 +2,7 @@ package trufflesom.interpreter.nodes.bc;
 
 import static trufflesom.interpreter.bc.Bytecodes.Q_SEND;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
@@ -34,6 +35,7 @@ public class TernaryPrimitiveWrapper extends TernaryExpressionNode {
 
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
+    CompilerDirectives.transferToInterpreter();
     throw new UnsupportedOperationException(
         "In the bytecode interpreter, `executeEvaluated` is expected to be used");
   }

--- a/src/trufflesom/interpreter/nodes/bc/UnaryPrimitiveWrapper.java
+++ b/src/trufflesom/interpreter/nodes/bc/UnaryPrimitiveWrapper.java
@@ -2,6 +2,7 @@ package trufflesom.interpreter.nodes.bc;
 
 import static trufflesom.interpreter.bc.Bytecodes.Q_SEND;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
@@ -34,6 +35,7 @@ public class UnaryPrimitiveWrapper extends UnaryExpressionNode {
 
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
+    CompilerDirectives.transferToInterpreter();
     throw new UnsupportedOperationException(
         "In the bytecode interpreter, `executeEvaluated` is expected to be used");
   }

--- a/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileWithDynamicBlocksNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileWithDynamicBlocksNode.java
@@ -1,5 +1,6 @@
 package trufflesom.interpreter.nodes.specialized.whileloops;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 import trufflesom.vm.NotYetImplementedException;
@@ -26,7 +27,7 @@ public final class WhileWithDynamicBlocksNode extends AbstractWhileNode {
 
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
-    // CompilerAsserts.neverPartOfCompilation("WhileWithDynamicBlocksNode.generic");
+    CompilerDirectives.transferToInterpreter();
     throw new NotYetImplementedException();
   }
 

--- a/src/trufflesom/primitives/EmptyPrim.java
+++ b/src/trufflesom/primitives/EmptyPrim.java
@@ -1,5 +1,6 @@
 package trufflesom.primitives;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 import trufflesom.interpreter.nodes.ExpressionNode;
@@ -29,6 +30,7 @@ public final class EmptyPrim extends UnaryExpressionNode {
 
   @Override
   public Object executeEvaluated(final VirtualFrame frame, final Object receiver) {
+    CompilerDirectives.transferToInterpreter();
     Universe.errorExit(
         "Warning: undefined primitive called: " + signature + " at: " + getSourceSection());
     return null;

--- a/src/trufflesom/primitives/arithmetic/AdditionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/AdditionPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -21,11 +22,13 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final BigInteger doLongWithOverflow(final long left, final long argument) {
     return BigInteger.valueOf(left).add(BigInteger.valueOf(argument));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.add(right);
     return reduceToLongIfPossible(result);
@@ -37,21 +40,25 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final String doString(final String left, final String right) {
     return left + right;
   }
 
   @Specialization
+  @TruffleBoundary
   public final String doSSymbol(final SSymbol left, final SSymbol right) {
     return left.getString() + right.getString();
   }
 
   @Specialization
+  @TruffleBoundary
   public final String doSSymbol(final SSymbol left, final String right) {
     return left.getString() + right;
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger argument) {
     return doBigInteger(BigInteger.valueOf(left), argument);
   }
@@ -62,16 +69,19 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doDouble(final BigInteger left, final double right) {
     return left.doubleValue() + right;
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doDouble(final double left, final BigInteger right) {
     return left + right.doubleValue();
   }
@@ -82,11 +92,13 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final String doString(final String left, final SClass right) {
     return left + right.getName().getString();
   }
 
   @Specialization
+  @TruffleBoundary
   public final String doString(final String left, final SSymbol right) {
     return left + right.getString();
   }

--- a/src/trufflesom/primitives/arithmetic/DividePrim.java
+++ b/src/trufflesom/primitives/arithmetic/DividePrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -17,17 +18,20 @@ public abstract class DividePrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.divide(right);
     return reduceToLongIfPossible(result);
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/trufflesom/primitives/arithmetic/GreaterThanPrim.java
+++ b/src/trufflesom/primitives/arithmetic/GreaterThanPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -19,6 +20,7 @@ public abstract class GreaterThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) > 0;
   }
@@ -29,6 +31,7 @@ public abstract class GreaterThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -39,6 +42,7 @@ public abstract class GreaterThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/trufflesom/primitives/arithmetic/LessThanOrEqualPrim.java
+++ b/src/trufflesom/primitives/arithmetic/LessThanOrEqualPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -19,6 +20,7 @@ public abstract class LessThanOrEqualPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) <= 0;
   }
@@ -29,6 +31,7 @@ public abstract class LessThanOrEqualPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -39,6 +42,7 @@ public abstract class LessThanOrEqualPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/trufflesom/primitives/arithmetic/LessThanPrim.java
+++ b/src/trufflesom/primitives/arithmetic/LessThanPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -19,6 +20,7 @@ public abstract class LessThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) < 0;
   }
@@ -29,6 +31,7 @@ public abstract class LessThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -39,6 +42,7 @@ public abstract class LessThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/trufflesom/primitives/arithmetic/LogicAndPrim.java
+++ b/src/trufflesom/primitives/arithmetic/LogicAndPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -17,16 +18,19 @@ public abstract class LogicAndPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.and(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/trufflesom/primitives/arithmetic/ModuloPrim.java
+++ b/src/trufflesom/primitives/arithmetic/ModuloPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -24,16 +25,19 @@ public abstract class ModuloPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.mod(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -46,9 +50,5 @@ public abstract class ModuloPrim extends ArithmeticPrim {
   @Specialization
   public final long doLong(final long left, final long right) {
     return Math.floorMod(left, right);
-  }
-
-  public final Object doLongPromotion(final long left, final long right) {
-    return doBigInteger(BigInteger.valueOf(left), right);
   }
 }

--- a/src/trufflesom/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/trufflesom/primitives/arithmetic/MultiplicationPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -19,11 +20,13 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLongWithOverflow(final long left, final long right) {
     return BigInteger.valueOf(left).multiply(BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.multiply(right);
     return reduceToLongIfPossible(result);
@@ -35,6 +38,7 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -45,6 +49,7 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
@@ -55,11 +60,13 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doDouble(final BigInteger left, final double right) {
     return left.doubleValue() * right;
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doDouble(final double left, final BigInteger right) {
     return left * right.doubleValue();
   }

--- a/src/trufflesom/primitives/arithmetic/RemainderPrim.java
+++ b/src/trufflesom/primitives/arithmetic/RemainderPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -22,16 +23,19 @@ public abstract class RemainderPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.remainder(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -44,9 +48,5 @@ public abstract class RemainderPrim extends ArithmeticPrim {
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long right) {
     return left % right;
-  }
-
-  public final Object doLongPromotion(final long left, final long right) {
-    return doBigInteger(BigInteger.valueOf(left), right);
   }
 }

--- a/src/trufflesom/primitives/arithmetic/SqrtPrim.java
+++ b/src/trufflesom/primitives/arithmetic/SqrtPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.BranchProfile;
@@ -32,6 +33,7 @@ public abstract class SqrtPrim extends UnaryExpressionNode {
   }
 
   @Specialization
+  @TruffleBoundary
   public final double doBigInteger(final BigInteger receiver) {
     return Math.sqrt(receiver.doubleValue());
   }

--- a/src/trufflesom/primitives/arithmetic/SubtractionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/SubtractionPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -19,11 +20,13 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final BigInteger doLongWithOverflow(final long left, final long right) {
     return BigInteger.valueOf(left).subtract(BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.subtract(right);
     return reduceToLongIfPossible(result);
@@ -35,6 +38,7 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -45,6 +49,7 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
@@ -55,11 +60,13 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doDouble(final BigInteger left, final double right) {
     return left.doubleValue() - right;
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doDouble(final double left, final BigInteger right) {
     return left - right.doubleValue();
   }

--- a/src/trufflesom/primitives/basics/EqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.basics;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
@@ -32,6 +33,7 @@ public abstract class EqualsPrim extends BinarySystemOperation {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) == 0;
   }
@@ -57,11 +59,13 @@ public abstract class EqualsPrim extends BinarySystemOperation {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/trufflesom/primitives/basics/HashPrim.java
+++ b/src/trufflesom/primitives/basics/HashPrim.java
@@ -1,5 +1,6 @@
 package trufflesom.primitives.basics;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -19,11 +20,13 @@ public abstract class HashPrim extends UnaryExpressionNode {
   }
 
   @Specialization
+  @TruffleBoundary
   public final long doSSymbol(final SSymbol receiver) {
     return receiver.getString().hashCode();
   }
 
   @Specialization
+  @TruffleBoundary
   public final long doSAbstractObject(final SAbstractObject receiver) {
     return receiver.hashCode();
   }

--- a/src/trufflesom/primitives/basics/IntegerPrims.java
+++ b/src/trufflesom/primitives/basics/IntegerPrims.java
@@ -40,6 +40,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public final long doBig(final BigInteger receiver) {
       return receiver.intValue();
     }
@@ -55,6 +56,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public final long doBig(final BigInteger receiver) {
       return Integer.toUnsignedLong(receiver.intValue());
     }
@@ -119,6 +121,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public final BigInteger doLongWithOverflow(final long receiver, final long right) {
       assert right >= 0; // currently not defined for negative values of right
       assert right <= Integer.MAX_VALUE;
@@ -146,16 +149,19 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public BigInteger doLongBig(final long left, final BigInteger right) {
       return BigInteger.valueOf(left).min(right);
     }
 
     @Specialization
+    @TruffleBoundary
     public BigInteger doBigLong(final BigInteger left, final long right) {
       return left.min(BigInteger.valueOf(right));
     }
 
     @Specialization
+    @TruffleBoundary
     public BigInteger doBig(final BigInteger left, final BigInteger right) {
       return left.min(right);
     }
@@ -171,16 +177,19 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public BigInteger doLongBig(final long left, final BigInteger right) {
       return BigInteger.valueOf(left).max(right);
     }
 
     @Specialization
+    @TruffleBoundary
     public BigInteger doBigLong(final BigInteger left, final long right) {
       return left.max(BigInteger.valueOf(right));
     }
 
     @Specialization
+    @TruffleBoundary
     public BigInteger doBig(final BigInteger left, final BigInteger right) {
       return left.max(right);
     }
@@ -218,11 +227,13 @@ public abstract class IntegerPrims {
     }
 
     @Specialization(guards = "minLong(receiver)")
+    @TruffleBoundary
     public final BigInteger doLongMinValue(final long receiver) {
       return BigInteger.valueOf(Long.MIN_VALUE).abs();
     }
 
     @Specialization
+    @TruffleBoundary
     public final BigInteger doBig(final BigInteger receiver) {
       return receiver.abs();
     }

--- a/src/trufflesom/primitives/basics/StringPrims.java
+++ b/src/trufflesom/primitives/basics/StringPrims.java
@@ -18,21 +18,25 @@ public class StringPrims {
   @Primitive(className = "String", primitive = "concatenate:")
   public abstract static class ConcatPrim extends BinaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final String doString(final String receiver, final String argument) {
       return receiver + argument;
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doString(final String receiver, final SSymbol argument) {
       return receiver + argument.getString();
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doSSymbol(final SSymbol receiver, final String argument) {
       return receiver.getString() + argument;
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doSSymbol(final SSymbol receiver, final SSymbol argument) {
       return receiver.getString() + argument.getString();
     }

--- a/src/trufflesom/primitives/basics/UnequalsPrim.java
+++ b/src/trufflesom/primitives/basics/UnequalsPrim.java
@@ -2,6 +2,7 @@ package trufflesom.primitives.basics;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
@@ -34,6 +35,7 @@ public abstract class UnequalsPrim extends BinarySystemOperation {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) != 0;
   }
@@ -59,11 +61,13 @@ public abstract class UnequalsPrim extends BinarySystemOperation {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }


### PR DESCRIPTION
This PR adds the `@TruffleBoundary` to make compilation work.