### PR TITLE
Add inlining of #whileTrue:/whileFalse: loops

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ build_and_test_job:
   tags: [benchmarks, infinity]
   script:
     - ${ANT} tests native-obj-storage-test native-tests
-    - ./som -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/tests/SomSomTests.som
+    - ./som -G -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/tests/SomSomTests.som
 
 benchmark_job:
   stage: benchmark

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -270,12 +270,16 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
 
     String kwStr = kw.toString();
 
-    if (!superSend && (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrue(this)) ||
-        ("ifFalse:".equals(kwStr) && mgenc.inlineIfFalse(this)) ||
-        ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this)) ||
-        ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfFalseIfTrue(this)))) {
-      // all done
-      return;
+    if (!superSend) {
+      if (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrue(this)) ||
+          ("ifFalse:".equals(kwStr) && mgenc.inlineIfFalse(this)) ||
+          ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this)) ||
+          ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfFalseIfTrue(this)) ||
+          ("whileTrue:".equals(kwStr) && mgenc.inlineWhileTrue(this)) ||
+          ("whileFalse:".equals(kwStr) && mgenc.inlineWhileFalse(this))) {
+        // all done
+        return;
+      }
     }
 
     SSymbol msg = universe.symbolFor(kwStr);

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -271,12 +271,12 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     String kwStr = kw.toString();
 
     if (!superSend) {
-      if (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrue(this)) ||
-          ("ifFalse:".equals(kwStr) && mgenc.inlineIfFalse(this)) ||
-          ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this)) ||
-          ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfFalseIfTrue(this)) ||
-          ("whileTrue:".equals(kwStr) && mgenc.inlineWhileTrue(this)) ||
-          ("whileFalse:".equals(kwStr) && mgenc.inlineWhileFalse(this))) {
+      if (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrueOrIfFalse(this, true)) ||
+          ("ifFalse:".equals(kwStr) && mgenc.inlineIfTrueOrIfFalse(this, false)) ||
+          ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this, true)) ||
+          ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this, false)) ||
+          ("whileTrue:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, true)) ||
+          ("whileFalse:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, false))) {
         // all done
         return;
       }

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -31,6 +31,7 @@ import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_POP;
@@ -226,6 +227,16 @@ public final class BytecodeGenerator {
       final boolean needsPop) {
     emit1(mgenc, needsPop ? JUMP_ON_FALSE_POP : JUMP_ON_FALSE_TOP_NIL);
     return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+  }
+
+  public static void emitJumpWithOffset(final BytecodeMethodGenContext mgenc,
+      final byte offset) {
+    emit2(mgenc, JUMP, offset);
+  }
+
+  public static void emitJumpBackwardsWithOffset(final BytecodeMethodGenContext mgenc,
+      final byte offset) {
+    emit2(mgenc, JUMP_BACKWARDS, offset);
   }
 
   public static int emitJumpWithDummyOffset(final BytecodeMethodGenContext mgenc) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -193,30 +193,6 @@ public final class BytecodeGenerator {
     emit2(mgenc, PUSH_CONSTANT, literalIndex);
   }
 
-  public static void emitJUMP(final BytecodeMethodGenContext mgenc, final byte offset) {
-    emit2(mgenc, JUMP, offset);
-  }
-
-  public static void emitJUMPONTRUETOPNIL(final BytecodeMethodGenContext mgenc,
-      final byte offset) {
-    emit2(mgenc, JUMP_ON_TRUE_TOP_NIL, offset);
-  }
-
-  public static void emitJUMPONFALSETOPNIL(final BytecodeMethodGenContext mgenc,
-      final byte offset) {
-    emit2(mgenc, JUMP_ON_FALSE_TOP_NIL, offset);
-  }
-
-  public static void emitJUMPONTRUEPOP(final BytecodeMethodGenContext mgenc,
-      final byte offset) {
-    emit2(mgenc, JUMP_ON_TRUE_POP, offset);
-  }
-
-  public static void emitJUMPONFALSEPOP(final BytecodeMethodGenContext mgenc,
-      final byte offset) {
-    emit2(mgenc, JUMP_ON_FALSE_POP, offset);
-  }
-
   public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc,
       final boolean needsPop) {
     emit1(mgenc, needsPop ? JUMP_ON_TRUE_POP : JUMP_ON_TRUE_TOP_NIL);
@@ -250,17 +226,17 @@ public final class BytecodeGenerator {
     mgenc.patchJumpOffsetToPointToNextInstruction(idxOfOffset, parser);
   }
 
-  private static void emit1(final BytecodeMethodGenContext mgenc, final byte code) {
+  public static void emit1(final BytecodeMethodGenContext mgenc, final byte code) {
     mgenc.addBytecode(code);
   }
 
-  private static void emit2(final BytecodeMethodGenContext mgenc, final byte code,
+  public static void emit2(final BytecodeMethodGenContext mgenc, final byte code,
       final byte idx) {
     mgenc.addBytecode(code);
     mgenc.addBytecodeArgument(idx);
   }
 
-  private static void emit3(final BytecodeMethodGenContext mgenc, final byte code,
+  public static void emit3(final BytecodeMethodGenContext mgenc, final byte code,
       final byte idx, final byte ctx) {
     mgenc.addBytecode(code);
     mgenc.addBytecodeArgument(idx);

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -31,6 +31,8 @@ import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
@@ -196,28 +198,34 @@ public final class BytecodeGenerator {
   public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc,
       final boolean needsPop) {
     emit1(mgenc, needsPop ? JUMP_ON_TRUE_POP : JUMP_ON_TRUE_TOP_NIL);
-    return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+    int idx = mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+    mgenc.addBytecodeArgument((byte) 0);
+    return idx;
   }
 
   public static int emitJumpOnFalseWithDummyOffset(final BytecodeMethodGenContext mgenc,
       final boolean needsPop) {
     emit1(mgenc, needsPop ? JUMP_ON_FALSE_POP : JUMP_ON_FALSE_TOP_NIL);
-    return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+    int idx = mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+    mgenc.addBytecodeArgument((byte) 0);
+    return idx;
   }
 
   public static void emitJumpWithOffset(final BytecodeMethodGenContext mgenc,
-      final byte offset) {
-    emit2(mgenc, JUMP, offset);
+      final byte offset1, final byte offset2) {
+    emit3(mgenc, offset2 == 0 ? JUMP : JUMP2, offset1, offset2);
   }
 
   public static void emitJumpBackwardsWithOffset(final BytecodeMethodGenContext mgenc,
-      final byte offset) {
-    emit2(mgenc, JUMP_BACKWARDS, offset);
+      final byte offset1, final byte offset2) {
+    emit3(mgenc, offset2 == 0 ? JUMP_BACKWARDS : JUMP2_BACKWARDS, offset1, offset2);
   }
 
   public static int emitJumpWithDummyOffset(final BytecodeMethodGenContext mgenc) {
     emit1(mgenc, JUMP);
-    return mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+    int idx = mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
+    mgenc.addBytecodeArgument((byte) 0);
+    return idx;
   }
 
   public static void patchJumpOffsetToPointToNextInstruction(

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -818,14 +818,12 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     isCurrentlyInliningBlock = true;
     toBeInlined1.getInvokable().inline(this, toBeInlined1);
-    isCurrentlyInliningBlock = false;
 
     int jumpOffsetIdxToSkipLoopBody = emitJumpOnFalseWithDummyOffset(this, true);
 
-    isCurrentlyInliningBlock = true;
     toBeInlined2.getInvokable().inline(this, toBeInlined2);
-    isCurrentlyInliningBlock = false;
 
+    resetLastBytecodeBuffer();
     emitPOP(this);
 
     emitJumpBackwardsWithOffset(this, getBackwardsJumpOffsetToTarget(loopBeginIdx, parser));
@@ -834,6 +832,8 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     addLiteralIfAbsent(Nil.nilObject, parser);
     emitPUSHCONSTANT(this, Nil.nilObject);
+
+    isCurrentlyInliningBlock = false;
 
     resetLastBytecodeBuffer();
 

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -29,6 +29,12 @@ package trufflesom.compiler.bc;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_BACKWARDS;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_FALSE_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_FALSE_TOP_NIL;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_TRUE_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_TRUE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
@@ -226,16 +232,28 @@ public class Disassembler {
         case JUMP_ON_TRUE_TOP_NIL:
         case JUMP_ON_FALSE_TOP_NIL:
         case JUMP_ON_TRUE_POP:
-        case JUMP_ON_FALSE_POP: {
-          int offset = Byte.toUnsignedInt(bytecodes.get(b + 1));
+        case JUMP_ON_FALSE_POP:
+        case JUMP2:
+        case JUMP2_ON_TRUE_TOP_NIL:
+        case JUMP2_ON_FALSE_TOP_NIL:
+        case JUMP2_ON_TRUE_POP:
+        case JUMP2_ON_FALSE_POP: {
+          int offset1 = Byte.toUnsignedInt(bytecodes.get(b + 1));
+          int offset2 = Byte.toUnsignedInt(bytecodes.get(b + 2));
+
+          int offset = offset2 << 8 + offset1;
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b + offset) + ")");
           break;
         }
 
-        case JUMP_BACKWARDS: {
-          int offset = Byte.toUnsignedInt(bytecodes.get(b + 1));
+        case JUMP_BACKWARDS:
+        case JUMP2_BACKWARDS: {
+          int offset1 = Byte.toUnsignedInt(bytecodes.get(b + 1));
+          int offset2 = Byte.toUnsignedInt(bytecodes.get(b + 2));
+
+          int offset = offset2 << 8 + offset1;
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b - offset) + ")");

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -29,6 +29,7 @@ package trufflesom.compiler.bc;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_POP;
@@ -230,6 +231,14 @@ public class Disassembler {
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b + offset) + ")");
+          break;
+        }
+
+        case JUMP_BACKWARDS: {
+          int offset = Byte.toUnsignedInt(bytecodes.get(b + 1));
+
+          Universe.errorPrintln(
+              "(jump offset: " + offset + " -> jump target: " + (b - offset) + ")");
           break;
         }
 

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -61,12 +61,13 @@ public class Bytecodes {
   public static final byte JUMP_ON_FALSE_TOP_NIL = 23;
   public static final byte JUMP_ON_TRUE_POP      = 24;
   public static final byte JUMP_ON_FALSE_POP     = 25;
+  public static final byte JUMP_BACKWARDS        = 26;
 
-  public static final byte Q_PUSH_GLOBAL = 26;
-  public static final byte Q_SEND        = 27;
-  public static final byte Q_SEND_1      = 28;
-  public static final byte Q_SEND_2      = 29;
-  public static final byte Q_SEND_3      = 30;
+  public static final byte Q_PUSH_GLOBAL = 27;
+  public static final byte Q_SEND        = 28;
+  public static final byte Q_SEND_1      = 29;
+  public static final byte Q_SEND_2      = 30;
+  public static final byte Q_SEND_3      = 31;
 
   public static final byte INVALID = -1;
 
@@ -122,6 +123,7 @@ public class Bytecodes {
         "JUMP_ON_FALSE_TOP_NIL",
         "JUMP_ON_TRUE_POP",
         "JUMP_ON_FALSE_POP",
+        "JUMP_BACKWARDS  ",
 
         "Q_PUSH_GLOBAL   ",
         "Q_SEND          ",
@@ -164,6 +166,7 @@ public class Bytecodes {
         2, // JUMP_ON_FALSE_TOP_NIL
         2, // JUMP_ON_TRUE_POP
         2, // JUMP_ON_FALSE_POP
+        2, // JUMP_BACKWARDS
 
         2, // Q_PUSH_GLOBAL
         2, // Q_SEND

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -63,13 +63,22 @@ public class Bytecodes {
   public static final byte JUMP_ON_FALSE_POP     = 25;
   public static final byte JUMP_BACKWARDS        = 26;
 
-  public static final byte Q_PUSH_GLOBAL = 27;
-  public static final byte Q_SEND        = 28;
-  public static final byte Q_SEND_1      = 29;
-  public static final byte Q_SEND_2      = 30;
-  public static final byte Q_SEND_3      = 31;
+  public static final byte JUMP2                  = 27;
+  public static final byte JUMP2_ON_TRUE_TOP_NIL  = 28;
+  public static final byte JUMP2_ON_FALSE_TOP_NIL = 29;
+  public static final byte JUMP2_ON_TRUE_POP      = 30;
+  public static final byte JUMP2_ON_FALSE_POP     = 31;
+  public static final byte JUMP2_BACKWARDS        = 32;
+
+  public static final byte Q_PUSH_GLOBAL = 33;
+  public static final byte Q_SEND        = 34;
+  public static final byte Q_SEND_1      = 35;
+  public static final byte Q_SEND_2      = 36;
+  public static final byte Q_SEND_3      = 37;
 
   public static final byte INVALID = -1;
+
+  public static final byte NUM_JUMP_BYTECODES = 6;
 
   private static final String[] PADDED_BYTECODE_NAMES;
   private static final String[] BYTECODE_NAMES;
@@ -125,6 +134,13 @@ public class Bytecodes {
         "JUMP_ON_FALSE_POP",
         "JUMP_BACKWARDS  ",
 
+        "JUMP2           ",
+        "JUMP2_ON_TRUE_TOP_NIL",
+        "JUMP2_ON_FALSE_TOP_NIL",
+        "JUMP2_ON_TRUE_POP",
+        "JUMP2_ON_FALSE_POP",
+        "JUMP2_BACKWARDS ",
+
         "Q_PUSH_GLOBAL   ",
         "Q_SEND          ",
         "Q_SEND_1        ",
@@ -161,12 +177,19 @@ public class Bytecodes {
         3, // INC_FIELD
         3, // INC_FIELD_PUSH
 
-        2, // JUMP
-        2, // JUMP_ON_TRUE_TOP_NIL
-        2, // JUMP_ON_FALSE_TOP_NIL
-        2, // JUMP_ON_TRUE_POP
-        2, // JUMP_ON_FALSE_POP
-        2, // JUMP_BACKWARDS
+        3, // JUMP
+        3, // JUMP_ON_TRUE_TOP_NIL
+        3, // JUMP_ON_FALSE_TOP_NIL
+        3, // JUMP_ON_TRUE_POP
+        3, // JUMP_ON_FALSE_POP
+        3, // JUMP_BACKWARDS
+
+        3, // JUMP2
+        3, // JUMP2_ON_TRUE_TOP_NIL
+        3, // JUMP2_ON_FALSE_TOP_NIL
+        3, // JUMP2_ON_TRUE_POP
+        3, // JUMP2_ON_FALSE_POP
+        3, // JUMP2_BACKWARDS
 
         2, // Q_PUSH_GLOBAL
         2, // Q_SEND

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -74,6 +74,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.ExplodeLoop.LoopExplosionKind;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.inlining.ScopeAdaptationVisitor;
@@ -1253,5 +1254,14 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
       assert ctx >= 0;
       bytecodes[i + 2] = ctx;
     }
+  }
+
+  @Override
+  public String toString() {
+    RootNode root = getRootNode();
+    if (root == null) {
+      return super.toString();
+    }
+    return getClass().getSimpleName() + "(" + root.getName() + ")";
   }
 }

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -66,6 +66,7 @@ import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.ExplodeLoop.LoopExplosionKind;
+import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.profiles.ValueProfile;
@@ -190,6 +191,8 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
     Object[] stack = new Object[maxStackDepth];
     int stackPointer = -1;
     int bytecodeIndex = 0;
+
+    int backBranchesTaken = 0;
 
     while (true) {
       byte bytecode = bytecodes[bytecodeIndex];
@@ -496,10 +499,13 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         }
 
         case RETURN_LOCAL: {
+          LoopNode.reportLoopCount(this, backBranchesTaken);
           return stack[stackPointer];
         }
 
         case RETURN_NON_LOCAL: {
+          LoopNode.reportLoopCount(this, backBranchesTaken);
+
           Object result = stack[stackPointer];
           // stackPointer -= 1;
           doReturnNonLocal(frame, bytecodeIndex, result);
@@ -507,6 +513,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         }
 
         case RETURN_SELF: {
+          LoopNode.reportLoopCount(this, backBranchesTaken);
           return frame.getArguments()[0];
         }
 

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -11,6 +11,7 @@ import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMPONFALSEPOP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMPONFALSETOPNIL;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMPONTRUEPOP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitJUMPONTRUETOPNIL;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitJumpBackwardsWithOffset;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOPARGUMENT;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOPFIELD;
@@ -30,6 +31,7 @@ import static trufflesom.interpreter.bc.Bytecodes.INC;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD;
 import static trufflesom.interpreter.bc.Bytecodes.INC_FIELD_PUSH;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_POP;
@@ -679,6 +681,12 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
           break;
         }
 
+        case JUMP_BACKWARDS: {
+          int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
+          nextBytecodeIndex = bytecodeIndex - offset;
+          break;
+        }
+
         case Q_PUSH_GLOBAL: {
           stackPointer += 1;
           stack[stackPointer] = ((GlobalNode) quickened[bytecodeIndex]).executeGeneric(frame);
@@ -1090,6 +1098,12 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
           break;
         }
 
+        case JUMP_BACKWARDS: {
+          byte offset = bytecodes[i + 1];
+          emitJumpBackwardsWithOffset(mgenc, offset);
+          break;
+        }
+
         default:
           throw new NotYetImplementedException(
               "Support for bytecode " + getBytecodeName(bytecode) + " has not yet been added");
@@ -1213,7 +1227,8 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case JUMP_ON_TRUE_TOP_NIL:
         case JUMP_ON_FALSE_TOP_NIL:
         case JUMP_ON_TRUE_POP:
-        case JUMP_ON_FALSE_POP: {
+        case JUMP_ON_FALSE_POP:
+        case JUMP_BACKWARDS: {
           break;
         }
 


### PR DESCRIPTION
This PR introduces inlining of basic while loops.
It directly inlines the blocks if and only if they are lexical blocks.

This needs a new backwards jump bytecode and, because much more inlining happens now, it needs a new set of jump bytecodes that take two bytes for the jump offset.

Originally, I only introduced the backwards jump to save one bit of address range, and don't have to deal with negative jumps.
This still seems beneficial, and a useful tactic, also to identify bugs.

Thus, I added the JUMP2* bytecodes, which use two bytes for address, essentially an unsigned short.
Though, because we don't know before writing the offset how long it is going to be, I gave all jump bytecodes length 3.
This means, I don't need to deal with shifting things around.
At run-time, the normal JUMP bytecodes simply don't read the extra byte, and it should be 0 anyway.