### PR TITLE
Add AWFY Test runs to CI, add Stack Trace support, and bytecode dumping, and fix incorrect setter optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,16 @@ jobs:
         run: |
           export ECLIPSE_EXE=${GITHUB_WORKSPACE}/../eclipse/eclipse
           ant -e eclipseformat
+
+      - name: Checkout AWFY
+        uses: actions/checkout@v2
+        with:
+          repository: smarr/are-we-fast-yet
+          path: are-we-fast-yet
+      
+      - name: AWFY Test Run
+        run: |
+          pwd
+          export JAVA_HOME=$JAVA_HOME_8_X64
+          pip install ReBench
+          rebench awfy-test.conf

--- a/awfy-test.conf
+++ b/awfy-test.conf
@@ -1,0 +1,68 @@
+# -*- mode: yaml -*-
+# Config file for ReBench
+default_experiment: all
+default_data_file: 'benchmark.data'
+
+runs:
+    iterations: 1
+    invocations: 1
+
+# definition of benchmark suites
+benchmark_suites:
+    test-som:
+        gauge_adapter: RebenchLog
+        command: " -cp .:Core:CD:DeltaBlue:Havlak:Json:NBody:Richards:../../../core-lib/Smalltalk Harness.som  %(benchmark)s 1 "
+        location: are-we-fast-yet/benchmarks/SOM
+        max_invocation_time: 240
+        benchmarks: &BENCHMARKS
+            - DeltaBlue:
+                extra_args: 1
+            - Richards:
+                extra_args: 1
+            - Json:
+                extra_args: 1
+            - CD:
+                extra_args: 10
+            - Havlak:
+                extra_args: 1
+            
+            - Bounce:
+                extra_args: 1
+            - List:
+                extra_args: 1
+            - Mandelbrot:
+                extra_args: 1
+            - NBody:
+                extra_args: 1
+            - Permute:
+                extra_args: 1
+            - Queens:
+                extra_args: 1
+            - Sieve:
+                extra_args: 1
+            - Storage:
+                extra_args: 1
+            - Towers:
+                extra_args: 1
+
+executors:
+    SOM-interp-ast:
+      path: .
+      executable: som
+      args: -G -Dsom.interp=AST
+    
+    SOM-interp-bc:
+      path: .
+      executable: som
+      args: -G -Dsom.interp=BC
+      
+experiments:
+    test-awfy:
+      description: |
+        This is a test run of the Are We Fast Yet benchmarks.
+        It's expected that the repository is located in the are-we-fast-yet folder.
+      suites:
+        - test-som
+      executions:
+        - SOM-interp-ast
+        - SOM-interp-bc

--- a/som
+++ b/som
@@ -21,6 +21,8 @@ parser.add_argument('-d', '--debug', help='wait for debugger to attach',
                     dest='debug', action='store_true', default=False)
 parser.add_argument('-t', '--num-threads', help='number of threads to be used',
                     dest='threads', default=None)
+parser.add_argument('-dnu', '--stack-trace-on-dnu', help='Print a stack trace on #doesNotUnderstand:',
+                    dest='som_dnu', action='store_true', default=False)
 
 explore = parser.add_argument_group('Explore', 'Investigate Execution')
 explore.add_argument('-i', '--igv', help='dump compilation details to IGV',
@@ -215,6 +217,9 @@ else:
   flags += GRAAL_JVMCI_FLAGS
   if args.embedded_graal:
     flags += GRAAL_EMBEDDED_FLAGS
+
+if args.som_dnu:
+    flags += ['-Dsom.printStackTraceOnDNU=true']
 
 # Handle executable names
 if sys.argv[0].endswith('fast'):

--- a/som
+++ b/som
@@ -23,6 +23,9 @@ parser.add_argument('-t', '--num-threads', help='number of threads to be used',
                     dest='threads', default=None)
 parser.add_argument('-dnu', '--stack-trace-on-dnu', help='Print a stack trace on #doesNotUnderstand:',
                     dest='som_dnu', action='store_true', default=False)
+parser.add_argument('-di', '--dump-ir', help='Dump the IR, i.e., the AST or bytecode of a method',
+                    dest='dump_ir', action='store_true', default=False)
+
 
 explore = parser.add_argument_group('Explore', 'Investigate Execution')
 explore.add_argument('-i', '--igv', help='dump compilation details to IGV',
@@ -165,7 +168,7 @@ if args.use_libgraal:
 ##
 
 CLASSPATH = (BASE_DIR + '/build/classes:'
-           + BASE_DIR + '/libs/black-diamonds/build/classes:')
+           + BASE_DIR + '/libs/black-diamonds/build/classes')
 
 BOOT_CLASSPATH = ('-Xbootclasspath/a:'
              + TRUFFLE_DIR + '/sdk/mxbuild/dists/jdk1.8/graal-sdk.jar:'
@@ -210,6 +213,9 @@ if not args.interpreter and GRAAL_FLAGS:
     flags = shlex.split(str.strip(GRAAL_FLAGS))
 else:
     flags = []
+
+if args.dump_ir:
+    SOM_ARGS += ['-di']
 
 if args.interpreter:
     flags += ['-Dtruffle.TruffleRuntime=com.oracle.truffle.api.impl.DefaultTruffleRuntime']

--- a/som
+++ b/som
@@ -305,6 +305,12 @@ if args.java_properties:
 if args.java_args:
     JAVA_ARGS += ['-' + property for property in args.java_args]
 
+# HACK: Havlak needs a lot of stack to run reliably...
+if 'Havlak' in args.args:
+  # double the standard stack size
+  # we don't do it always, because...
+  JAVA_ARGS += ['-Xss2048k']
+  
 all_args = JAVA_ARGS + ['-classpath', CLASSPATH] + [BOOT_CLASSPATH] + flags + SOM_ARGS + unknown_args + args.args
 
 if args.verbose:

--- a/src/trufflesom/compiler/Disassembler.java
+++ b/src/trufflesom/compiler/Disassembler.java
@@ -25,11 +25,14 @@
 
 package trufflesom.compiler;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 import trufflesom.vm.Universe;
+import trufflesom.vm.VmSettings;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
-
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import trufflesom.vmobjects.SInvokable.SMethod;
+import trufflesom.vmobjects.SInvokable.SPrimitive;
 
 
 public final class Disassembler {
@@ -43,8 +46,16 @@ public final class Disassembler {
       Universe.errorPrint(cl.getName().toString() + ">>"
           + inv.getSignature().toString() + " = ");
 
-      // output actual method
-      dumpMethod(inv, "\t");
+      if (inv instanceof SPrimitive) {
+        Universe.errorPrintln("<primitive>");
+        continue;
+      }
+
+      if (VmSettings.UseAstInterp) {
+        dumpMethod(inv, "\t");
+      } else {
+        trufflesom.compiler.bc.Disassembler.dumpMethod((SMethod) inv, "\t");
+      }
     }
   }
 

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -481,7 +481,15 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     return new FieldReadNode(new LocalArgumentReadNode(arguments.get(universe.symSelf)), idx);
   }
 
+  private static int expectedSetterMethodLength =
+      Bytecodes.getBytecodeLength(PUSH_ARGUMENT) + Bytecodes.getBytecodeLength(DUP)
+          + Bytecodes.getBytecodeLength(POP_FIELD) + Bytecodes.getBytecodeLength(RETURN_SELF);
+
   private ExpressionNode optimizeFieldSetter() {
+    if (bytecode.size() != expectedSetterMethodLength) {
+      return null;
+    }
+
     // example sequence: PUSH_ARG1 DUP POP_FIELD_1 RETURN_SELF
     final byte pushCandidate = lastBytecodeIs(3, PUSH_ARGUMENT);
     if (pushCandidate == INVALID) {

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -66,30 +66,11 @@ import trufflesom.interpreter.nodes.SOMNode;
 import trufflesom.interpreter.nodes.bc.BytecodeLoopNode;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SClass;
-import trufflesom.vmobjects.SInvokable;
 import trufflesom.vmobjects.SInvokable.SMethod;
-import trufflesom.vmobjects.SInvokable.SPrimitive;
 import trufflesom.vmobjects.SSymbol;
 
 
 public class Disassembler {
-
-  public static void dump(final SClass cl) {
-    for (int i = 0; i < cl.getNumberOfInstanceInvokables(); i++) {
-      SInvokable inv = cl.getInstanceInvokable(i);
-
-      // output header and skip if the Invokable is a Primitive
-      Universe.errorPrint(cl.getName().toString() + ">>"
-          + inv.getSignature().toString() + " = ");
-
-      if (inv instanceof SPrimitive) {
-        Universe.errorPrintln("<primitive>");
-        continue;
-      }
-      // output actual method
-      dumpMethod((SMethod) inv, "\t");
-    }
-  }
 
   private static BytecodeLoopNode getBytecodeNode(final SMethod m) {
     RootNode i = m.getInvokable();
@@ -119,6 +100,10 @@ public class Disassembler {
 
   public static void dumpMethod(final SMethod method, final String indent) {
     BytecodeLoopNode m = getBytecodeNode(method);
+    if (m == null) {
+      Universe.errorPrintln("( disassemling not yet supported )");
+      return;
+    }
     dumpMethod(m, indent);
   }
 

--- a/src/trufflesom/interpreter/nodes/dispatch/CachedDnuNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/CachedDnuNode.java
@@ -6,8 +6,12 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
 import trufflesom.interpreter.SArguments;
+import trufflesom.interpreter.SomLanguage;
+import trufflesom.interpreter.Types;
 import trufflesom.interpreter.nodes.dispatch.AbstractDispatchNode.AbstractCachedDispatchNode;
+import trufflesom.primitives.basics.SystemPrims.PrintStackTracePrim;
 import trufflesom.vm.Universe;
+import trufflesom.vm.VmSettings;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SSymbol;
 
@@ -45,6 +49,13 @@ public final class CachedDnuNode extends AbstractCachedDispatchNode {
   }
 
   protected Object performDnu(final Object[] arguments, final Object rcvr) {
+    if (VmSettings.PrintStackTraceOnDNU) {
+      CompilerDirectives.transferToInterpreter();
+      PrintStackTracePrim.printStackTrace(0, getSourceSection());
+      Universe.errorPrintln("Lookup of " + selector + " failed in "
+          + Types.getClassOf(rcvr, SomLanguage.getCurrentContext()).getName().getString());
+    }
+
     Object[] argsArr = new Object[] {
         rcvr, selector, SArguments.getArgumentsWithoutReceiver(arguments)};
     return cachedMethod.call(argsArr);

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -236,8 +236,8 @@ public final class Universe implements IdProvider<SSymbol> {
         ++i; // skip class path
         // Checkstyle: resume
         gotClasspath = true;
-      } else if (arguments[i].equals("-d") && !sawOthers) {
-        printAST = true;
+      } else if (arguments[i].equals("-di") && !sawOthers) {
+        printIR += 1;
       } else {
         sawOthers = true;
         remainingArgs.add(arguments[i]);
@@ -331,7 +331,7 @@ public final class Universe implements IdProvider<SSymbol> {
     println("where options include:                                   ");
     println("    -cp <directories separated by " + File.pathSeparator + ">");
     println("                  set search path for application classes");
-    println("    -d            enable disassembling");
+    println("    -di           enable disassembling, dumping the IR");
 
     // Exit
     System.exit(0);
@@ -634,7 +634,7 @@ public final class Universe implements IdProvider<SSymbol> {
         // Load the class from a file and return the loaded class
         SClass result =
             compiler.compileClass(cpEntry, name.getString(), systemClass, systemClassProbe);
-        if (printAST) {
+        if (printIR > 0) {
           Disassembler.dump(result.getSOMClass(this));
           Disassembler.dump(result);
         }
@@ -656,7 +656,7 @@ public final class Universe implements IdProvider<SSymbol> {
     try {
       // Load the class from a stream and return the loaded class
       SClass result = compiler.compileClass(stmt, null, null);
-      if (printAST) {
+      if (printIR > 0) {
         Disassembler.dump(result);
       }
       return result;
@@ -764,8 +764,8 @@ public final class Universe implements IdProvider<SSymbol> {
 
   private final HashMap<SSymbol, Association> globals;
 
-  private String[]                  classPath;
-  @CompilationFinal private boolean printAST;
+  private String[]              classPath;
+  @CompilationFinal private int printIR;
 
   /**
    * A {@link StructuralProbe} that is used when loading the system classes.

--- a/src/trufflesom/vm/VmSettings.java
+++ b/src/trufflesom/vm/VmSettings.java
@@ -8,6 +8,7 @@ public class VmSettings implements Settings {
   public static final boolean UseAstInterp;
   public static final boolean UseBcInterp;
   public static final boolean UseJitCompiler;
+  public static final boolean PrintStackTraceOnDNU;
 
   static {
     String val = System.getProperty("som.interp", "AST").toUpperCase();
@@ -21,6 +22,9 @@ public class VmSettings implements Settings {
 
     val = System.getProperty("som.jitCompiler", "true");
     UseJitCompiler = "true".equals(val);
+
+    val = System.getProperty("som.printStackTraceOnDNU", "false");
+    PrintStackTraceOnDNU = "true".equals(val);
   }
 
   @Override


### PR DESCRIPTION
By adding the AWFY benchmarks to CI, I caught a few issues.

 - setter methods were optimized if the last thing was a field assignment, but anything before it was ignored (fixed)
 - Havlak would run out of stack with exceptions that are completely unrelated

To improve debugging, I added a few niceties:

- print stack trace on `#doesNotUnderstand:` using the `-dnu` option in the launcher
- print bytecode after parsing using the `-di` option on the launcher

The Havlak issue is fixed by giving the VM more stack when we assume that Havlak is run.
The size of stack change is only done for Havlak since I don't know what the impact is.
