### PR TITLE
Improve Array Storage strategies based on SOMns

### DIFF
--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -71,7 +71,7 @@ public final class Method extends Invokable {
 
   @Override
   public String toString() {
-    return getName() + " @" + Integer.toHexString(hashCode());
+    return getName();
   }
 
   public Method cloneAndAdaptAfterScopeChange(final BytecodeMethodGenContext mgenc,

--- a/src/trufflesom/interpreter/Primitive.java
+++ b/src/trufflesom/interpreter/Primitive.java
@@ -40,8 +40,7 @@ public final class Primitive extends Invokable {
 
   @Override
   public String toString() {
-    return expressionOrSequence.getClass().getSimpleName() + "@"
-        + Integer.toHexString(hashCode());
+    return expressionOrSequence.getClass().getSimpleName();
   }
 
   @Override

--- a/src/trufflesom/primitives/arrays/AtPrim.java
+++ b/src/trufflesom/primitives/arrays/AtPrim.java
@@ -1,53 +1,47 @@
 package trufflesom.primitives.arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @Primitive(className = "Array", primitive = "at:", selector = "at:",
     receiverType = SArray.class, inParser = false)
 public abstract class AtPrim extends BinaryExpressionNode {
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
-
-  @Specialization(guards = "isEmptyType(receiver)")
+  @Specialization(guards = "receiver.isEmptyType()")
   public final Object doEmptySArray(final SArray receiver, final long idx) {
     assert idx > 0;
-    assert idx <= receiver.getEmptyStorage(storageType);
+    assert idx <= receiver.getEmptyStorage();
     return Nil.nilObject;
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(receiver)")
+  @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final Object doPartiallyEmptySArray(final SArray receiver, final long idx) {
-    return receiver.getPartiallyEmptyStorage(storageType).get(idx - 1);
+    return receiver.getPartiallyEmptyStorage().get(idx - 1);
   }
 
-  @Specialization(guards = "isObjectType(receiver)")
+  @Specialization(guards = "receiver.isObjectType()")
   public final Object doObjectSArray(final SArray receiver, final long idx) {
-    return receiver.getObjectStorage(storageType)[(int) idx - 1];
+    return receiver.getObjectStorage()[(int) idx - 1];
   }
 
-  @Specialization(guards = "isLongType(receiver)")
+  @Specialization(guards = "receiver.isLongType()")
   public final long doLongSArray(final SArray receiver, final long idx) {
-    return receiver.getLongStorage(storageType)[(int) idx - 1];
+    return receiver.getLongStorage()[(int) idx - 1];
   }
 
-  @Specialization(guards = "isDoubleType(receiver)")
+  @Specialization(guards = "receiver.isDoubleType()")
   public final double doDoubleSArray(final SArray receiver, final long idx) {
-    return receiver.getDoubleStorage(storageType)[(int) idx - 1];
+    return receiver.getDoubleStorage()[(int) idx - 1];
   }
 
-  @Specialization(guards = "isBooleanType(receiver)")
+  @Specialization(guards = "receiver.isBooleanType()")
   public final boolean doBooleanSArray(final SArray receiver, final long idx) {
-    return receiver.getBooleanStorage(storageType)[(int) idx - 1];
+    return receiver.getBooleanStorage()[(int) idx - 1];
   }
 }

--- a/src/trufflesom/primitives/arrays/AtPutPrim.java
+++ b/src/trufflesom/primitives/arrays/AtPutPrim.java
@@ -1,25 +1,19 @@
 package trufflesom.primitives.arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.TernaryExpressionNode;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 import trufflesom.vmobjects.SArray.PartiallyEmptyArray;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @Primitive(className = "Array", primitive = "at:put:", selector = "at:put:",
     receiverType = SArray.class, inParser = false)
 public abstract class AtPutPrim extends TernaryExpressionNode {
-
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   protected static final boolean valueIsNil(final Object value) {
     return value == Nil.nilObject;
@@ -47,40 +41,40 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
         !(value instanceof Boolean);
   }
 
-  @Specialization(guards = {"isEmptyType(receiver)"})
+  @Specialization(guards = {"receiver.isEmptyType()"})
   public final long doEmptySArray(final SArray receiver, final long index,
       final long value) {
     long idx = index - 1;
     assert idx >= 0;
-    assert idx < receiver.getEmptyStorage(storageType);
+    assert idx < receiver.getEmptyStorage();
 
     receiver.transitionFromEmptyToPartiallyEmptyWith(idx, value);
     return value;
   }
 
-  @Specialization(guards = {"isEmptyType(receiver)"})
+  @Specialization(guards = {"receiver.isEmptyType()"})
   public final Object doEmptySArray(final SArray receiver, final long index,
       final double value) {
     long idx = index - 1;
     assert idx >= 0;
-    assert idx < receiver.getEmptyStorage(storageType);
+    assert idx < receiver.getEmptyStorage();
 
     receiver.transitionFromEmptyToPartiallyEmptyWith(idx, value);
     return value;
   }
 
-  @Specialization(guards = {"isEmptyType(receiver)"})
+  @Specialization(guards = {"receiver.isEmptyType()"})
   public final Object doEmptySArray(final SArray receiver, final long index,
       final boolean value) {
     long idx = index - 1;
     assert idx >= 0;
-    assert idx < receiver.getEmptyStorage(storageType);
+    assert idx < receiver.getEmptyStorage();
 
     receiver.transitionFromEmptyToPartiallyEmptyWith(idx, value);
     return value;
   }
 
-  @Specialization(guards = {"isEmptyType(receiver)", "valueIsNotNil(value)",
+  @Specialization(guards = {"receiver.isEmptyType()", "valueIsNotNil(value)",
       "valueNotLongDoubleBoolean(value)"})
   public final Object doEmptySArray(final SArray receiver, final long index,
       final Object value) {
@@ -92,12 +86,12 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = {"isEmptyType(receiver)", "valueIsNil(value)"})
+  @Specialization(guards = {"receiver.isEmptyType()", "valueIsNil(value)"})
   public final Object doEmptySArrayWithNil(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
     assert idx >= 0;
-    assert idx < receiver.getEmptyStorage(storageType);
+    assert idx < receiver.getEmptyStorage();
     return value;
   }
 
@@ -112,7 +106,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     storage.set(idx, value);
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(receiver)")
+  @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final long doPartiallyEmptySArray(final SArray receiver,
       final long index, final long value) {
     long idx = index - 1;
@@ -126,7 +120,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(receiver)")
+  @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final double doPartiallyEmptySArray(final SArray receiver,
       final long index, final double value) {
     long idx = index - 1;
@@ -139,7 +133,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(receiver)")
+  @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final boolean doPartiallyEmptySArray(final SArray receiver,
       final long index, final boolean value) {
     long idx = index - 1;
@@ -152,11 +146,11 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = {"isPartiallyEmptyType(receiver)", "valueIsNil(value)"})
+  @Specialization(guards = {"receiver.isPartiallyEmptyType()", "valueIsNil(value)"})
   public final Object doPartiallyEmptySArrayWithNil(final SArray receiver,
       final long index, final Object value) {
     long idx = index - 1;
-    PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage(storageType);
+    PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage();
     assert idx >= 0;
     assert idx < storage.getLength();
 
@@ -167,7 +161,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = {"isPartiallyEmptyType(receiver)", "valueIsNotNil(value)"})
+  @Specialization(guards = {"receiver.isPartiallyEmptyType()", "valueIsNotNil(value)"})
   public final Object doPartiallyEmptySArray(final SArray receiver,
       final long index, final Object value) {
     long idx = index - 1;
@@ -178,28 +172,28 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = "isObjectType(receiver)")
+  @Specialization(guards = "receiver.isObjectType()")
   public final Object doObjectSArray(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
-    receiver.getObjectStorage(storageType)[(int) idx] = value;
+    receiver.getObjectStorage()[(int) idx] = value;
     return value;
   }
 
-  @Specialization(guards = "isLongType(receiver)")
+  @Specialization(guards = "receiver.isLongType()")
   public final Object doObjectSArray(final SArray receiver, final long index,
       final long value) {
     long idx = index - 1;
-    receiver.getLongStorage(storageType)[(int) idx] = value;
+    receiver.getLongStorage()[(int) idx] = value;
     return value;
   }
 
-  @Specialization(guards = {"isLongType(receiver)", "valueIsNotLong(value)"})
+  @Specialization(guards = {"receiver.isLongType()", "valueIsNotLong(value)"})
   public final Object doLongSArray(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
 
-    long[] storage = receiver.getLongStorage(storageType);
+    long[] storage = receiver.getLongStorage();
     Object[] newStorage = new Object[storage.length];
     for (int i = 0; i < storage.length; i++) {
       newStorage[i] = storage[i];
@@ -210,20 +204,20 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = "isDoubleType(receiver)")
+  @Specialization(guards = "receiver.isDoubleType()")
   public final Object doDoubleSArray(final SArray receiver, final long index,
       final double value) {
     long idx = index - 1;
-    receiver.getDoubleStorage(storageType)[(int) idx] = value;
+    receiver.getDoubleStorage()[(int) idx] = value;
     return value;
   }
 
-  @Specialization(guards = {"isDoubleType(receiver)", "valueIsNotDouble(value)"})
+  @Specialization(guards = {"receiver.isDoubleType()", "valueIsNotDouble(value)"})
   public final Object doDoubleSArray(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
 
-    double[] storage = receiver.getDoubleStorage(storageType);
+    double[] storage = receiver.getDoubleStorage();
     Object[] newStorage = new Object[storage.length];
     for (int i = 0; i < storage.length; i++) {
       newStorage[i] = storage[i];
@@ -234,20 +228,20 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  @Specialization(guards = "isBooleanType(receiver)")
+  @Specialization(guards = "receiver.isBooleanType()")
   public final Object doBooleanSArray(final SArray receiver, final long index,
       final boolean value) {
     long idx = index - 1;
-    receiver.getBooleanStorage(storageType)[(int) idx] = value;
+    receiver.getBooleanStorage()[(int) idx] = value;
     return value;
   }
 
-  @Specialization(guards = {"isBooleanType(receiver)", "valueIsNotBoolean(value)"})
+  @Specialization(guards = {"receiver.isBooleanType()", "valueIsNotBoolean(value)"})
   public final Object doBooleanSArray(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
 
-    boolean[] storage = receiver.getBooleanStorage(storageType);
+    boolean[] storage = receiver.getBooleanStorage();
     Object[] newStorage = new Object[storage.length];
     for (int i = 0; i < storage.length; i++) {
       newStorage[i] = storage[i];

--- a/src/trufflesom/primitives/arrays/AtPutPrim.java
+++ b/src/trufflesom/primitives/arrays/AtPutPrim.java
@@ -1,5 +1,7 @@
 package trufflesom.primitives.arrays;
 
+import java.util.Arrays;
+
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -78,11 +80,17 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
       "valueNotLongDoubleBoolean(value)"})
   public final Object doEmptySArray(final SArray receiver, final long index,
       final Object value) {
-    long idx = index - 1;
+    int idx = (int) index - 1;
     assert idx >= 0;
-    assert idx < receiver.getEmptyStorage(storageType);
+    int size = receiver.getEmptyStorage();
+    assert idx < size;
 
-    receiver.transitionFromEmptyToPartiallyEmptyWith(idx, value);
+    // if the value is an object, we transition directly to an Object array
+    Object[] newStorage = new Object[size];
+    Arrays.fill(newStorage, Nil.nilObject);
+
+    newStorage[idx] = value;
+    receiver.transitionTo(newStorage);
     return value;
   }
 

--- a/src/trufflesom/primitives/arrays/AtPutPrim.java
+++ b/src/trufflesom/primitives/arrays/AtPutPrim.java
@@ -145,7 +145,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
 
     if (storage.get(idx) != Nil.nilObject) {
       storage.incEmptyElements();
-      setValue(idx, Nil.nilObject, storage);
+      storage.set(idx, Nil.nilObject);
     }
     return value;
   }

--- a/src/trufflesom/primitives/arrays/CopyPrim.java
+++ b/src/trufflesom/primitives/arrays/CopyPrim.java
@@ -1,50 +1,44 @@
 package trufflesom.primitives.arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @Primitive(className = "Array", primitive = "copy")
 public abstract class CopyPrim extends UnaryExpressionNode {
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
-
-  @Specialization(guards = "isEmptyType(receiver)")
+  @Specialization(guards = "receiver.isEmptyType()")
   public final SArray doEmptyArray(final SArray receiver) {
-    return new SArray(receiver.getEmptyStorage(storageType));
+    return new SArray(receiver.getEmptyStorage());
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(receiver)")
+  @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final SArray doPartiallyEmptyArray(final SArray receiver) {
-    return new SArray(ArrayType.PARTIAL_EMPTY,
-        receiver.getPartiallyEmptyStorage(storageType).copy());
+    return new SArray(
+        receiver.getPartiallyEmptyStorage().copy());
   }
 
-  @Specialization(guards = "isObjectType(receiver)")
+  @Specialization(guards = "receiver.isObjectType()")
   public final SArray doObjectArray(final SArray receiver) {
-    return SArray.create(receiver.getObjectStorage(storageType).clone());
+    return SArray.create(receiver.getObjectStorage().clone());
   }
 
-  @Specialization(guards = "isLongType(receiver)")
+  @Specialization(guards = "receiver.isLongType()")
   public final SArray doLongArray(final SArray receiver) {
-    return SArray.create(receiver.getLongStorage(storageType).clone());
+    return SArray.create(receiver.getLongStorage().clone());
   }
 
-  @Specialization(guards = "isDoubleType(receiver)")
+  @Specialization(guards = "receiver.isDoubleType()")
   public final SArray doDoubleArray(final SArray receiver) {
-    return SArray.create(receiver.getDoubleStorage(storageType).clone());
+    return SArray.create(receiver.getDoubleStorage().clone());
   }
 
-  @Specialization(guards = "isBooleanType(receiver)")
+  @Specialization(guards = "receiver.isBooleanType()")
   public final SArray doBooleanArray(final SArray receiver) {
-    return SArray.create(receiver.getBooleanStorage(storageType).clone());
+    return SArray.create(receiver.getBooleanStorage().clone());
   }
 }

--- a/src/trufflesom/primitives/arrays/DoPrim.java
+++ b/src/trufflesom/primitives/arrays/DoPrim.java
@@ -3,12 +3,10 @@ package trufflesom.primitives.arrays;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.Invokable;
@@ -17,23 +15,20 @@ import trufflesom.primitives.basics.BlockPrims.ValueOnePrim;
 import trufflesom.primitives.basics.BlockPrimsFactory.ValueOnePrimFactory;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 import trufflesom.vmobjects.SArray.PartiallyEmptyArray;
 import trufflesom.vmobjects.SBlock;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @Primitive(className = "Array", primitive = "do:", selector = "do:",
     receiverType = SArray.class, disabled = true)
 public abstract class DoPrim extends BinaryExpressionNode {
-  @Child private ValueOnePrim block       = ValueOnePrimFactory.create(null, null);
-  private final ValueProfile  storageType = ValueProfile.createClassProfile();
+  @Child private ValueOnePrim block = ValueOnePrimFactory.create(null, null);
 
-  @Specialization(guards = "isEmptyType(arr)")
+  @Specialization(guards = "arr.isEmptyType()")
   public final SArray doEmptyArray(final VirtualFrame frame,
       final SArray arr, final SBlock block) {
-    int length = arr.getEmptyStorage(storageType);
+    int length = arr.getEmptyStorage();
     try {
       if (SArray.FIRST_IDX < length) {
         this.block.executeEvaluated(block, Nil.nilObject);
@@ -49,10 +44,10 @@ public abstract class DoPrim extends BinaryExpressionNode {
     return arr;
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(arr)")
+  @Specialization(guards = "arr.isPartiallyEmptyType()")
   public final SArray doPartiallyEmptyArray(final VirtualFrame frame,
       final SArray arr, final SBlock block) {
-    PartiallyEmptyArray storage = arr.getPartiallyEmptyStorage(storageType);
+    PartiallyEmptyArray storage = arr.getPartiallyEmptyStorage();
     int length = storage.getLength();
     try {
       if (SArray.FIRST_IDX < length) {
@@ -69,10 +64,10 @@ public abstract class DoPrim extends BinaryExpressionNode {
     return arr;
   }
 
-  @Specialization(guards = "isObjectType(arr)")
+  @Specialization(guards = "arr.isObjectType()")
   public final SArray doObjectArray(final VirtualFrame frame,
       final SArray arr, final SBlock block) {
-    Object[] storage = arr.getObjectStorage(storageType);
+    Object[] storage = arr.getObjectStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {
@@ -89,10 +84,10 @@ public abstract class DoPrim extends BinaryExpressionNode {
     return arr;
   }
 
-  @Specialization(guards = "isLongType(arr)")
+  @Specialization(guards = "arr.isLongType()")
   public final SArray doLongArray(final VirtualFrame frame,
       final SArray arr, final SBlock block) {
-    long[] storage = arr.getLongStorage(storageType);
+    long[] storage = arr.getLongStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {
@@ -109,10 +104,10 @@ public abstract class DoPrim extends BinaryExpressionNode {
     return arr;
   }
 
-  @Specialization(guards = "isDoubleType(arr)")
+  @Specialization(guards = "arr.isDoubleType()")
   public final SArray doDoubleArray(final VirtualFrame frame,
       final SArray arr, final SBlock block) {
-    double[] storage = arr.getDoubleStorage(storageType);
+    double[] storage = arr.getDoubleStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {
@@ -129,10 +124,10 @@ public abstract class DoPrim extends BinaryExpressionNode {
     return arr;
   }
 
-  @Specialization(guards = "isBooleanType(arr)")
+  @Specialization(guards = "arr.isBooleanType()")
   public final SArray doBooleanArray(final VirtualFrame frame,
       final SArray arr, final SBlock block) {
-    boolean[] storage = arr.getBooleanStorage(storageType);
+    boolean[] storage = arr.getBooleanStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {

--- a/src/trufflesom/primitives/arrays/PutAllNode.java
+++ b/src/trufflesom/primitives/arrays/PutAllNode.java
@@ -3,7 +3,6 @@ package trufflesom.primitives.arrays;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -19,13 +18,11 @@ import trufflesom.primitives.basics.LengthPrim;
 import trufflesom.primitives.basics.LengthPrimFactory;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 import trufflesom.vmobjects.SBlock;
 import trufflesom.vmobjects.SObject;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @Primitive(className = "Array", primitive = "putAll:", selector = "putAll:", disabled = true,
     extraChild = LengthPrimFactory.class)
 @NodeChild(value = "length", type = LengthPrim.class, executeWith = "receiver")
@@ -43,7 +40,7 @@ public abstract class PutAllNode extends BinaryExpressionNode {
         !(value instanceof SBlock);
   }
 
-  @Specialization(guards = {"isEmptyType(rcvr)", "valueIsNil(nil)"})
+  @Specialization(guards = {"rcvr.isEmptyType()", "valueIsNil(nil)"})
   public SArray doPutNilInEmptyArray(final SArray rcvr, final SObject nil,
       final long length) {
     // NO OP
@@ -99,22 +96,22 @@ public abstract class PutAllNode extends BinaryExpressionNode {
         long[] newStorage = new long[(int) length];
         newStorage[0] = (long) result;
         evalBlockForRemaining(frame, block, length, newStorage);
-        rcvr.transitionTo(ArrayType.LONG, newStorage);
+        rcvr.transitionTo(newStorage);
       } else if (result instanceof Double) {
         double[] newStorage = new double[(int) length];
         newStorage[0] = (double) result;
         evalBlockForRemaining(frame, block, length, newStorage);
-        rcvr.transitionTo(ArrayType.DOUBLE, newStorage);
+        rcvr.transitionTo(newStorage);
       } else if (result instanceof Boolean) {
         boolean[] newStorage = new boolean[(int) length];
         newStorage[0] = (boolean) result;
         evalBlockForRemaining(frame, block, length, newStorage);
-        rcvr.transitionTo(ArrayType.BOOLEAN, newStorage);
+        rcvr.transitionTo(newStorage);
       } else {
         Object[] newStorage = new Object[(int) length];
         newStorage[0] = result;
         evalBlockForRemaining(frame, block, length, newStorage);
-        rcvr.transitionTo(ArrayType.OBJECT, newStorage);
+        rcvr.transitionTo(newStorage);
       }
     } finally {
       if (CompilerDirectives.inInterpreter()) {

--- a/src/trufflesom/primitives/arrays/ToArgumentsArrayNode.java
+++ b/src/trufflesom/primitives/arrays/ToArgumentsArrayNode.java
@@ -3,27 +3,21 @@ package trufflesom.primitives.arrays;
 import java.util.Arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import trufflesom.interpreter.SArguments;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @NodeChildren({
     @NodeChild("somArray"),
     @NodeChild("receiver")})
 public abstract class ToArgumentsArrayNode extends ExpressionNode {
-
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   public static final boolean isNull(final Object somArray) {
     return somArray == null;
@@ -40,9 +34,9 @@ public abstract class ToArgumentsArrayNode extends ExpressionNode {
     return new Object[] {rcvr};
   }
 
-  @Specialization(guards = "isEmptyType(somArray)")
+  @Specialization(guards = "somArray.isEmptyType()")
   public final Object[] doEmptyArray(final SArray somArray, final Object rcvr) {
-    Object[] result = new Object[somArray.getEmptyStorage(storageType) + 1];
+    Object[] result = new Object[somArray.getEmptyStorage() + 1];
     Arrays.fill(result, Nil.nilObject);
     result[SArguments.RCVR_IDX] = rcvr;
     return result;
@@ -55,23 +49,23 @@ public abstract class ToArgumentsArrayNode extends ExpressionNode {
     return argsArray;
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(somArray)")
+  @Specialization(guards = "somArray.isPartiallyEmptyType()")
   public final Object[] doPartiallyEmptyArray(final SArray somArray,
       final Object rcvr) {
     return addRcvrToObjectArray(
-        rcvr, somArray.getPartiallyEmptyStorage(storageType).getStorage());
+        rcvr, somArray.getPartiallyEmptyStorage().getStorage());
   }
 
-  @Specialization(guards = "isObjectType(somArray)")
+  @Specialization(guards = "somArray.isObjectType()")
   public final Object[] doObjectArray(final SArray somArray,
       final Object rcvr) {
-    return addRcvrToObjectArray(rcvr, somArray.getObjectStorage(storageType));
+    return addRcvrToObjectArray(rcvr, somArray.getObjectStorage());
   }
 
-  @Specialization(guards = "isLongType(somArray)")
+  @Specialization(guards = "somArray.isLongType()")
   public final Object[] doLongArray(final SArray somArray,
       final Object rcvr) {
-    long[] arr = somArray.getLongStorage(storageType);
+    long[] arr = somArray.getLongStorage();
     Object[] args = new Object[arr.length + 1];
     args[0] = rcvr;
     for (int i = 0; i < arr.length; i++) {
@@ -80,10 +74,10 @@ public abstract class ToArgumentsArrayNode extends ExpressionNode {
     return args;
   }
 
-  @Specialization(guards = "isDoubleType(somArray)")
+  @Specialization(guards = "somArray.isDoubleType()")
   public final Object[] doDoubleArray(final SArray somArray,
       final Object rcvr) {
-    double[] arr = somArray.getDoubleStorage(storageType);
+    double[] arr = somArray.getDoubleStorage();
     Object[] args = new Object[arr.length + 1];
     args[0] = rcvr;
     for (int i = 0; i < arr.length; i++) {
@@ -92,10 +86,10 @@ public abstract class ToArgumentsArrayNode extends ExpressionNode {
     return args;
   }
 
-  @Specialization(guards = "isBooleanType(somArray)")
+  @Specialization(guards = "somArray.isBooleanType()")
   public final Object[] doBooleanArray(final SArray somArray,
       final Object rcvr) {
-    boolean[] arr = somArray.getBooleanStorage(storageType);
+    boolean[] arr = somArray.getBooleanStorage();
     Object[] args = new Object[arr.length + 1];
     args[0] = rcvr;
     for (int i = 0; i < arr.length; i++) {

--- a/src/trufflesom/primitives/arrays/ToArgumentsArrayNode.java
+++ b/src/trufflesom/primitives/arrays/ToArgumentsArrayNode.java
@@ -19,17 +19,13 @@ import trufflesom.vmobjects.SArray;
     @NodeChild("receiver")})
 public abstract class ToArgumentsArrayNode extends ExpressionNode {
 
-  public static final boolean isNull(final Object somArray) {
-    return somArray == null;
-  }
-
   public abstract Object[] executedEvaluated(SArray somArray, Object rcvr);
 
   public final Object[] executedEvaluated(final Object somArray, final Object rcvr) {
     return executedEvaluated((SArray) somArray, rcvr);
   }
 
-  @Specialization(guards = "isNull(somArray)")
+  @Specialization(guards = "somArray == null")
   public final Object[] doNoArray(final Object somArray, final Object rcvr) {
     return new Object[] {rcvr};
   }

--- a/src/trufflesom/primitives/basics/LengthPrim.java
+++ b/src/trufflesom/primitives/basics/LengthPrim.java
@@ -1,54 +1,48 @@
 package trufflesom.primitives.basics;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
 import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SArray.ArrayType;
 import trufflesom.vmobjects.SSymbol;
 
 
 @GenerateNodeFactory
-@ImportStatic(ArrayType.class)
 @Primitive(className = "Array", primitive = "length")
 @Primitive(className = "String", primitive = "length")
 @Primitive(selector = "length", receiverType = String.class, inParser = false)
 public abstract class LengthPrim extends UnaryExpressionNode {
 
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
-
-  @Specialization(guards = "isEmptyType(receiver)")
+  @Specialization(guards = "receiver.isEmptyType()")
   public final long doEmptySArray(final SArray receiver) {
-    return receiver.getEmptyStorage(storageType);
+    return receiver.getEmptyStorage();
   }
 
-  @Specialization(guards = "isPartiallyEmptyType(receiver)")
+  @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final long doPartialEmptySArray(final SArray receiver) {
-    return receiver.getPartiallyEmptyStorage(storageType).getLength();
+    return receiver.getPartiallyEmptyStorage().getLength();
   }
 
-  @Specialization(guards = "isObjectType(receiver)")
+  @Specialization(guards = "receiver.isObjectType()")
   public final long doObjectSArray(final SArray receiver) {
-    return receiver.getObjectStorage(storageType).length;
+    return receiver.getObjectStorage().length;
   }
 
-  @Specialization(guards = "isLongType(receiver)")
+  @Specialization(guards = "receiver.isLongType()")
   public final long doLongSArray(final SArray receiver) {
-    return receiver.getLongStorage(storageType).length;
+    return receiver.getLongStorage().length;
   }
 
-  @Specialization(guards = "isDoubleType(receiver)")
+  @Specialization(guards = "receiver.isDoubleType()")
   public final long doDoubleSArray(final SArray receiver) {
-    return receiver.getDoubleStorage(storageType).length;
+    return receiver.getDoubleStorage().length;
   }
 
-  @Specialization(guards = "isBooleanType(receiver)")
+  @Specialization(guards = "receiver.isBooleanType()")
   public final long doBooleanSArray(final SArray receiver) {
-    return receiver.getBooleanStorage(storageType).length;
+    return receiver.getBooleanStorage().length;
   }
 
   public abstract long executeEvaluated(SArray receiver);

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -365,11 +365,13 @@ public final class Universe implements IdProvider<SSymbol> {
       return shell.start();
     }
 
+    Object[] arrStorage = Arrays.copyOfRange(arguments, 0, arguments.length, Object[].class);
+
     // Lookup the initialize invokable on the system class
     SInvokable initialize = systemClass.lookupInvokable(symbolFor("initialize:"));
 
     return initialize.invoke(new Object[] {systemObject,
-        SArray.create(arguments)});
+        SArray.create(arrStorage)});
   }
 
   @TruffleBoundary

--- a/src/trufflesom/vmobjects/SArray.java
+++ b/src/trufflesom/vmobjects/SArray.java
@@ -10,7 +10,7 @@ import trufflesom.vm.constants.Nil;
 
 /**
  * SArrays are implemented using a Strategy-like approach.
- * The SArray objects are 'tagged' with a type, and the strategy behavior
+ * The storage identifies the strategy behavior, which
  * is implemented directly in the AST nodes.
  *
  * @author smarr
@@ -93,10 +93,6 @@ public final class SArray extends SAbstractObject {
 
   public boolean isBooleanType() {
     return storage.getClass() == boolean[].class;
-  }
-
-  public boolean isSomePrimitiveType() {
-    return isLongType() || isDoubleType() || isBooleanType();
   }
 
   /**
@@ -197,18 +193,18 @@ public final class SArray extends SAbstractObject {
     PartiallyEmptyArray arr = getPartiallyEmptyStorage();
 
     if (arr.isFull()) {
-      if (arr.getType() == PartiallyEmptyArray.Type.LONG) {
+      if (arr.type == PartiallyEmptyArray.Type.LONG) {
         storage = createLong(arr.getStorage());
-      } else if (arr.getType() == PartiallyEmptyArray.Type.DOUBLE) {
+      } else if (arr.type == PartiallyEmptyArray.Type.DOUBLE) {
         storage = createDouble(arr.getStorage());
-      } else if (arr.getType() == PartiallyEmptyArray.Type.BOOLEAN) {
+      } else if (arr.type == PartiallyEmptyArray.Type.BOOLEAN) {
         storage = createBoolean(arr.getStorage());
       } else {
         storage = arr.getStorage();
       }
       return;
     }
-    if (arr.getType() == PartiallyEmptyArray.Type.OBJECT) {
+    if (arr.type == PartiallyEmptyArray.Type.OBJECT) {
       storage = arr.getStorage();
     }
   }

--- a/src/trufflesom/vmobjects/SArray.java
+++ b/src/trufflesom/vmobjects/SArray.java
@@ -123,10 +123,6 @@ public final class SArray extends SAbstractObject {
   /**
    * Transition from the Empty, to the PartiallyEmpty state/strategy.
    */
-  public void transitionFromEmptyToPartiallyEmptyWith(final long idx, final Object val) {
-    fromEmptyToParticalWithType(ArrayType.OBJECT, idx, val);
-  }
-
   public void transitionFromEmptyToPartiallyEmptyWith(final long idx, final long val) {
     fromEmptyToParticalWithType(PartiallyEmptyArray.Type.LONG, idx, val);
   }
@@ -197,8 +193,8 @@ public final class SArray extends SAbstractObject {
     return storage;
   }
 
-  public void ifFullTransitionPartiallyEmpty() {
-    PartiallyEmptyArray arr = getPartiallyEmptyStorage(partialStorageType);
+  public void ifFullOrObjectTransitionPartiallyEmpty() {
+    PartiallyEmptyArray arr = getPartiallyEmptyStorage();
 
     if (arr.isFull()) {
       if (arr.getType() == PartiallyEmptyArray.Type.LONG) {
@@ -210,6 +206,10 @@ public final class SArray extends SAbstractObject {
       } else {
         storage = arr.getStorage();
       }
+      return;
+    }
+    if (arr.getType() == PartiallyEmptyArray.Type.OBJECT) {
+      storage = arr.getStorage();
     }
   }
 

--- a/src/trufflesom/vmobjects/SArray.java
+++ b/src/trufflesom/vmobjects/SArray.java
@@ -192,6 +192,11 @@ public final class SArray extends SAbstractObject {
   public void ifFullOrObjectTransitionPartiallyEmpty() {
     PartiallyEmptyArray arr = getPartiallyEmptyStorage();
 
+    if (arr.type == PartiallyEmptyArray.Type.OBJECT) {
+      storage = arr.getStorage();
+      return;
+    }
+
     if (arr.isFull()) {
       if (arr.type == PartiallyEmptyArray.Type.LONG) {
         storage = createLong(arr.getStorage());
@@ -202,10 +207,6 @@ public final class SArray extends SAbstractObject {
       } else {
         storage = arr.getStorage();
       }
-      return;
-    }
-    if (arr.type == PartiallyEmptyArray.Type.OBJECT) {
-      storage = arr.getStorage();
     }
   }
 

--- a/src/trufflesom/vmobjects/SArray.java
+++ b/src/trufflesom/vmobjects/SArray.java
@@ -72,11 +72,11 @@ public final class SArray extends SAbstractObject {
   }
 
   public boolean isEmptyType() {
-    return storage instanceof Integer;
+    return storage.getClass() == Integer.class;
   }
 
   public boolean isPartiallyEmptyType() {
-    return storage instanceof PartiallyEmptyArray;
+    return storage.getClass() == PartiallyEmptyArray.class;
   }
 
   public boolean isObjectType() {

--- a/src/trufflesom/vmobjects/SArray.java
+++ b/src/trufflesom/vmobjects/SArray.java
@@ -45,33 +45,33 @@ public final class SArray extends SAbstractObject {
     return type;
   }
 
-  public int getEmptyStorage(final ValueProfile storageType) {
-    assert type == ArrayType.EMPTY;
+  public int getEmptyStorage() {
+    assert isEmptyType();
     return (int) storage;
   }
 
-  public PartiallyEmptyArray getPartiallyEmptyStorage(final ValueProfile storageType) {
-    assert type == ArrayType.PARTIAL_EMPTY;
+  public PartiallyEmptyArray getPartiallyEmptyStorage() {
+    assert isPartiallyEmptyType();
     return (PartiallyEmptyArray) storage;
   }
 
-  public Object[] getObjectStorage(final ValueProfile storageType) {
-    assert type == ArrayType.OBJECT;
-    return (Object[]) storage;
+  public Object[] getObjectStorage() {
+    assert isObjectType();
+    return CompilerDirectives.castExact(storage, Object[].class);
   }
 
-  public long[] getLongStorage(final ValueProfile storageType) {
-    assert type == ArrayType.LONG;
+  public long[] getLongStorage() {
+    assert isLongType();
     return (long[]) storage;
   }
 
-  public double[] getDoubleStorage(final ValueProfile storageType) {
-    assert type == ArrayType.DOUBLE;
+  public double[] getDoubleStorage() {
+    assert isDoubleType();
     return (double[]) storage;
   }
 
-  public boolean[] getBooleanStorage(final ValueProfile storageType) {
-    assert type == ArrayType.BOOLEAN;
+  public boolean[] getBooleanStorage() {
+    assert isBooleanType();
     return (boolean[]) storage;
   }
 

--- a/src/trufflesom/vmobjects/SClass.java
+++ b/src/trufflesom/vmobjects/SClass.java
@@ -36,7 +36,6 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import trufflesom.compiler.Field;
@@ -45,8 +44,6 @@ import trufflesom.vm.constants.Nil;
 
 
 public final class SClass extends SObject {
-
-  private static final ValueProfile storageType = ValueProfile.createClassProfile();
 
   private SourceSection sourceSection;
   private boolean       hasPrimitives;
@@ -225,11 +222,11 @@ public final class SClass extends SObject {
   }
 
   public SSymbol getInstanceFieldName(final int index) {
-    return (SSymbol) instanceFields.getObjectStorage(storageType)[index];
+    return (SSymbol) instanceFields.getObjectStorage()[index];
   }
 
   public int getNumberOfInstanceFields() {
-    return instanceFields.getObjectStorage(storageType).length;
+    return instanceFields.getObjectStorage().length;
   }
 
   public boolean hasPrimitives() {


### PR DESCRIPTION
This PR ports fixes and improvements of storage strategy handling from SOMns to TruffleSOM.

There are also a few improvements here.

Main improvements:
 - use storage directly to determine storage type. This could have potentially the drawback of more complex guards, because there's an extra read of the class of the storage. And it indeed seems to hurt startup performance a little.
 - more eagerly transition to object storage if it looks like that's the best option (avoids sticking too long with a partially empty strategy)
 - order checks so that we transition to object storage as soon as there's no other option left

Generic maintenance:
 - remove hash from primitive and method names
 - reduce some of the code duplication in AtPutPrim

@fniephaus this fixes my performance issues, I believe :satisfied:


/cc @sophie-kaleba this is another style of optimization, thought might be worth pointing you at