### PR TITLE
Update core-lib and fix super sends and #unknownGlobals/#escapedBlock handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download Eclipse
         run: |
           export ECLIPSE_TAR=eclipse.tar.gz
-          export ECLIPSE_URL=https://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.17-202009021800/eclipse-SDK-4.17-linux-gtk-x86_64.tar.gz
+          export ECLIPSE_URL=https://ftp.snt.utwente.nl/pub/software/eclipse/eclipse/downloads/drops4/R-4.19-202103031800/eclipse-SDK-4.19-linux-gtk-x86_64.tar.gz
           curl ${ECLIPSE_URL} -o ${ECLIPSE_TAR}
           tar -C ${GITHUB_WORKSPACE}/.. -xzf ${ECLIPSE_TAR}
 

--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -129,7 +129,7 @@ public class MethodGenerationContext
     this.universe = universe;
   }
 
-  protected void markAccessingOuterScopes() {
+  public void markAccessingOuterScopes() {
     MethodGenerationContext context = this;
     while (context != null) {
       context.accessesVariablesOfOuterScope = true;

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -660,7 +660,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     }
 
     // and finally assume it is a global
-    return GlobalNode.create(variableName, universe).initialize(source);
+    return GlobalNode.create(variableName, universe, mgenc).initialize(source);
   }
 
   private void getSymbolFromLexer() {

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -191,7 +191,6 @@ public class ParserAst extends Parser<MethodGenerationContext> {
 
       while (isIdentifier(sym)) {
         msg = unaryMessage(mgenc, msg);
-        superSend = false;
       }
 
       while (sym == OperatorSequence || symIn(binaryOpSyms)) {
@@ -203,7 +202,6 @@ public class ParserAst extends Parser<MethodGenerationContext> {
       }
     } else if (sym == OperatorSequence || symIn(binaryOpSyms)) {
       msg = binaryMessage(mgenc, receiver);
-      superSend = false;
 
       while (sym == OperatorSequence || symIn(binaryOpSyms)) {
         msg = binaryMessage(mgenc, msg);
@@ -296,6 +294,8 @@ public class ParserAst extends Parser<MethodGenerationContext> {
     while (sym == OperatorSequence || symIn(binaryOpSyms)) {
       operand = binaryMessage(mgenc, operand);
     }
+
+    superSend = false;
     return operand;
   }
 

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -102,7 +102,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
   private ExpressionNode createSequenceNode(final SourceCoordinate coord,
       final List<ExpressionNode> expressions) {
     if (expressions.size() == 0) {
-      return GlobalNode.create(universe.symNil, universe).initialize(getSource(coord));
+      return GlobalNode.create(universe.symNil, universe, null).initialize(getSource(coord));
     } else if (expressions.size() == 1) {
       return expressions.get(0);
     }

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -313,6 +313,8 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     while (sym == OperatorSequence || symIn(binaryOpSyms)) {
       binaryMessage(mgenc);
     }
+
+    superSend = false;
   }
 
   private void literal(final BytecodeMethodGenContext mgenc) throws ParseError {
@@ -438,8 +440,6 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     while (sym == Identifier) {
       unaryMessage(mgenc);
     }
-
-    superSend = false;
   }
 
   @Override

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -57,6 +57,7 @@ import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 
 import trufflesom.compiler.Parser.ParseError;
 import trufflesom.compiler.ParserBc;
+import trufflesom.interpreter.nodes.GlobalNode;
 import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
@@ -148,6 +149,9 @@ public final class BytecodeGenerator {
 
   public static void emitPUSHGLOBAL(final BytecodeMethodGenContext mgenc,
       final SSymbol global) {
+    if (GlobalNode.isPotentiallyUnknown(global, mgenc.getUniverse())) {
+      mgenc.markAccessingOuterScopes();
+    }
     emit2(mgenc, PUSH_GLOBAL, mgenc.findLiteralIndex(global));
   }
 

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -514,7 +514,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     byte constantIdx = getIndex(1);
     SSymbol literal = (SSymbol) literals.get(constantIdx);
-    return GlobalNode.create(literal, universe);
+    return GlobalNode.create(literal, universe, this);
   }
 
   private FieldReadNode optimizeFieldGetter() {
@@ -898,5 +898,9 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
   ArrayList<Byte> getBytecodes() {
     return bytecode;
+  }
+
+  public Universe getUniverse() {
+    return universe;
   }
 }

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -96,6 +96,11 @@ public abstract class GlobalNode extends ExpressionNode
     return executeGeneric(frame);
   }
 
+  @Override
+  public final String toString() {
+    return getClass().getSimpleName() + "(" + globalName.getString() + ")";
+  }
+
   private abstract static class AbstractUninitializedGlobalReadNode extends GlobalNode {
     protected final Universe universe;
 

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -321,7 +321,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
           SSymbol globalName = (SSymbol) literalsAndConstants[literalIdx];
 
           GlobalNode quickened =
-              GlobalNode.create(globalName, universe).initialize(sourceSection);
+              GlobalNode.create(globalName, universe, null).initialize(sourceSection);
           quickenBytecode(bytecodeIndex, Q_PUSH_GLOBAL, quickened);
 
           // TODO: what's the correct semantics here? the outer or the closed self? normally,

--- a/src/trufflesom/primitives/arithmetic/AdditionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/AdditionPrim.java
@@ -23,8 +23,8 @@ public abstract class AdditionPrim extends ArithmeticPrim {
 
   @Specialization
   @TruffleBoundary
-  public final BigInteger doLongWithOverflow(final long left, final long argument) {
-    return BigInteger.valueOf(left).add(BigInteger.valueOf(argument));
+  public final Object doLongWithOverflow(final long left, final long argument) {
+    return reduceToLongIfPossible(BigInteger.valueOf(left).add(BigInteger.valueOf(argument)));
   }
 
   @Specialization

--- a/src/trufflesom/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/trufflesom/primitives/arithmetic/MultiplicationPrim.java
@@ -22,7 +22,8 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   @Specialization
   @TruffleBoundary
   public final Object doLongWithOverflow(final long left, final long right) {
-    return BigInteger.valueOf(left).multiply(BigInteger.valueOf(right));
+    return reduceToLongIfPossible(
+        BigInteger.valueOf(left).multiply(BigInteger.valueOf(right)));
   }
 
   @Specialization

--- a/src/trufflesom/primitives/arithmetic/SubtractionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/SubtractionPrim.java
@@ -21,8 +21,9 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
 
   @Specialization
   @TruffleBoundary
-  public final BigInteger doLongWithOverflow(final long left, final long right) {
-    return BigInteger.valueOf(left).subtract(BigInteger.valueOf(right));
+  public final Object doLongWithOverflow(final long left, final long right) {
+    return reduceToLongIfPossible(
+        BigInteger.valueOf(left).subtract(BigInteger.valueOf(right)));
   }
 
   @Specialization


### PR DESCRIPTION
This PR updates the core-lib with various new tests.

It fixes super semantics where the parser was still being buggy.
If makes sure that the AST interpreter sends `#unknownGlobal:` and `#escapedBlock:` to the outer self.

And it makes sure we return long values from arithmetic operations even after an overflow, because otherwise things like `Array>>#new:` break in unexpected ways.

It also updates the URL for Eclipse so that GitHub actions are green again.