### PR TITLE
Add tests from PySOM and various minor fixes

### DIFF
--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -540,10 +540,10 @@ public class MethodGenerationContext
     String outerMethodName =
         stripColonsAndSourceLocation(outerGenc.getSignature().getString());
 
-    int argSize = getNumberOfArguments();
+    int numArgs = getNumberOfArguments();
     String blockSig = "λ" + outerMethodName + "@" + coord.startLine + "@" + coord.startColumn;
 
-    for (int i = 1; i < argSize; i++) {
+    for (int i = 1; i < numArgs; i++) {
       blockSig += ":";
     }
 

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -101,11 +101,11 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
 
   static {
     for (Symbol s : new Symbol[] {Not, And, Or, Star, Div, Mod, Plus, Equal,
-        More, Less, Comma, At, Per, NONE}) {
+        More, Less, Comma, At, Per}) {
       singleOpSyms.add(s);
     }
     for (Symbol s : new Symbol[] {Or, Comma, Minus, Equal, Not, And, Or, Star,
-        Div, Mod, Plus, Equal, More, Less, Comma, At, Per, NONE}) {
+        Div, Mod, Plus, Equal, More, Less, Comma, At, Per}) {
       binaryOpSyms.add(s);
     }
     for (Symbol s : new Symbol[] {Keyword, KeywordSequence}) {

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -201,17 +201,18 @@ public final class BytecodeGenerator {
     emit2(mgenc, PUSH_CONSTANT, literalIndex);
   }
 
-  public static int emitJumpOnTrueWithDummyOffset(final BytecodeMethodGenContext mgenc,
-      final boolean needsPop) {
-    emit1(mgenc, needsPop ? JUMP_ON_TRUE_POP : JUMP_ON_TRUE_TOP_NIL);
-    int idx = mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
-    mgenc.addBytecodeArgument((byte) 0);
-    return idx;
-  }
+  public static int emitJumpOnBoolWithDummyOffset(final BytecodeMethodGenContext mgenc,
+      final boolean isIfTrue, final boolean needsPop) {
+    // Remember: true and false seem flipped here
+    // this is because if the test passes, the block is inlined directly.
+    // if the test fails, we need to jump.
+    // Thus, an #ifTrue: needs to generated a JUMP_ON_FALSE.
+    if (isIfTrue) {
 
-  public static int emitJumpOnFalseWithDummyOffset(final BytecodeMethodGenContext mgenc,
-      final boolean needsPop) {
-    emit1(mgenc, needsPop ? JUMP_ON_FALSE_POP : JUMP_ON_FALSE_TOP_NIL);
+      emit1(mgenc, needsPop ? JUMP_ON_FALSE_POP : JUMP_ON_FALSE_TOP_NIL);
+    } else {
+      emit1(mgenc, needsPop ? JUMP_ON_TRUE_POP : JUMP_ON_TRUE_TOP_NIL);
+    }
     int idx = mgenc.addBytecodeArgumentAndGetIndex((byte) 0);
     mgenc.addBytecodeArgument((byte) 0);
     return idx;

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -115,6 +115,10 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     last4Bytecodes = new byte[4];
   }
 
+  public Object getConstant(final int bytecodeIdx) {
+    return literals.get(bytecode.get(bytecodeIdx + 1));
+  }
+
   public byte getMaxContextLevel() {
     if (outerGenc != null) {
       return (byte) (1 + ((BytecodeMethodGenContext) outerGenc).getMaxContextLevel());

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -896,15 +896,17 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
         case JUMP:
         case JUMP_ON_TRUE_TOP_NIL:
         case JUMP_ON_FALSE_TOP_NIL:
-        case JUMP_ON_TRUE_POP:
-        case JUMP_ON_FALSE_POP:
         case JUMP_BACKWARDS:
         case JUMP2:
         case JUMP2_ON_TRUE_TOP_NIL:
         case JUMP2_ON_FALSE_TOP_NIL:
+        case JUMP2_BACKWARDS:
+          break;
+        case JUMP_ON_TRUE_POP:
+        case JUMP_ON_FALSE_POP:
         case JUMP2_ON_TRUE_POP:
         case JUMP2_ON_FALSE_POP:
-        case JUMP2_BACKWARDS:
+          depth--;
           break;
         default:
           throw new IllegalStateException("Illegal bytecode "

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -785,21 +785,23 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     byte block2LiteralIdx = bytecode.get(bytecode.size() - 1);
 
     // grab block's method, and inline it
-    SMethod toBeInlined1 = (SMethod) literals.get(block1LiteralIdx);
-    SMethod toBeInlined2 = (SMethod) literals.get(block2LiteralIdx);
+    SMethod condMethod = (SMethod) literals.get(block1LiteralIdx);
+    SMethod bodyMethod = (SMethod) literals.get(block2LiteralIdx);
 
     removeLastBytecodes(2); // remove the PUSH_BLOCK bytecodes
 
     int loopBeginIdx = offsetOfNextInstruction();
 
     isCurrentlyInliningBlock = true;
-    toBeInlined1.getInvokable().inline(this, toBeInlined1);
+    condMethod.getInvokable().inline(this, condMethod);
 
     int jumpOffsetIdxToSkipLoopBody = emitJumpOnBoolWithDummyOffset(this, isWhileTrue, true);
 
-    toBeInlined2.getInvokable().inline(this, toBeInlined2);
+    bodyMethod.getInvokable().inline(this, bodyMethod);
 
     completeJumpsAndEmitReturningNil(parser, loopBeginIdx, jumpOffsetIdxToSkipLoopBody);
+
+    isCurrentlyInliningBlock = false;
     return true;
   }
 
@@ -825,8 +827,6 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     addLiteralIfAbsent(Nil.nilObject, parser);
     emitPUSHCONSTANT(this, Nil.nilObject);
-
-    isCurrentlyInliningBlock = false;
 
     resetLastBytecodeBuffer();
   }

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -1,8 +1,7 @@
 package trufflesom.compiler.bc;
 
 import static trufflesom.compiler.bc.BytecodeGenerator.emitJumpBackwardsWithOffset;
-import static trufflesom.compiler.bc.BytecodeGenerator.emitJumpOnFalseWithDummyOffset;
-import static trufflesom.compiler.bc.BytecodeGenerator.emitJumpOnTrueWithDummyOffset;
+import static trufflesom.compiler.bc.BytecodeGenerator.emitJumpOnBoolWithDummyOffset;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitJumpWithDummyOffset;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPOP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emitPUSHCONSTANT;
@@ -717,12 +716,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     removeLastBytecodeAt(0); // remove the PUSH_BLOCK
 
-    int jumpOffsetIdxToSkipTrueBranch;
-    if (ifTrue) {
-      jumpOffsetIdxToSkipTrueBranch = emitJumpOnFalseWithDummyOffset(this, false);
-    } else {
-      jumpOffsetIdxToSkipTrueBranch = emitJumpOnTrueWithDummyOffset(this, false);
-    }
+    int jumpOffsetIdxToSkipTrueBranch = emitJumpOnBoolWithDummyOffset(this, ifTrue, false);
 
     // grab block's method, and inline it
     SMethod toBeInlined = (SMethod) literals.get(blockLiteralIdx);
@@ -759,12 +753,8 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     removeLastBytecodes(2); // remove the PUSH_BLOCK bytecodes
 
-    int jumpOffsetIdxToSkipTrueBranch;
-    if (isIfTrueIfFalse) {
-      jumpOffsetIdxToSkipTrueBranch = emitJumpOnFalseWithDummyOffset(this, true);
-    } else {
-      jumpOffsetIdxToSkipTrueBranch = emitJumpOnTrueWithDummyOffset(this, true);
-    }
+    int jumpOffsetIdxToSkipTrueBranch =
+        emitJumpOnBoolWithDummyOffset(this, isIfTrueIfFalse, true);
 
     isCurrentlyInliningBlock = true;
     toBeInlined1.getInvokable().inline(this, toBeInlined1);
@@ -805,12 +795,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     isCurrentlyInliningBlock = true;
     toBeInlined1.getInvokable().inline(this, toBeInlined1);
 
-    int jumpOffsetIdxToSkipLoopBody;
-    if (isWhileTrue) {
-      jumpOffsetIdxToSkipLoopBody = emitJumpOnFalseWithDummyOffset(this, true);
-    } else {
-      jumpOffsetIdxToSkipLoopBody = emitJumpOnTrueWithDummyOffset(this, true);
-    }
+    int jumpOffsetIdxToSkipLoopBody = emitJumpOnBoolWithDummyOffset(this, isWhileTrue, true);
 
     toBeInlined2.getInvokable().inline(this, toBeInlined2);
 

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -248,7 +248,7 @@ public class Disassembler {
           int offset1 = Byte.toUnsignedInt(bytecodes.get(b + 1));
           int offset2 = Byte.toUnsignedInt(bytecodes.get(b + 2));
 
-          int offset = offset2 << 8 + offset1;
+          int offset = (offset2 << 8) + offset1;
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b + offset) + ")");

--- a/src/trufflesom/interpreter/nodes/ArgumentReadNode.java
+++ b/src/trufflesom/interpreter/nodes/ArgumentReadNode.java
@@ -13,7 +13,8 @@ public abstract class ArgumentReadNode {
 
   public static class LocalArgumentReadNode extends ExpressionNode
       implements Invocation<SSymbol> {
-    protected final int      argumentIndex;
+    public final int argumentIndex;
+
     protected final Argument arg;
 
     public LocalArgumentReadNode(final Argument arg) {

--- a/src/trufflesom/interpreter/nodes/FieldNode.java
+++ b/src/trufflesom/interpreter/nodes/FieldNode.java
@@ -42,7 +42,7 @@ import trufflesom.vmobjects.SObject;
 
 public abstract class FieldNode extends ExpressionNode {
 
-  protected abstract ExpressionNode getSelf();
+  public abstract ExpressionNode getSelf();
 
   public static final class FieldReadNode extends FieldNode
       implements PreevaluatedExpression {
@@ -59,7 +59,7 @@ public abstract class FieldNode extends ExpressionNode {
     }
 
     @Override
-    protected ExpressionNode getSelf() {
+    public ExpressionNode getSelf() {
       return self;
     }
 
@@ -193,7 +193,7 @@ public abstract class FieldNode extends ExpressionNode {
     }
 
     @Override
-    protected ExpressionNode getSelf() {
+    public ExpressionNode getSelf() {
       return self;
     }
 
@@ -238,7 +238,7 @@ public abstract class FieldNode extends ExpressionNode {
     }
 
     @Override
-    protected ExpressionNode getSelf() {
+    public ExpressionNode getSelf() {
       return self;
     }
 

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -126,7 +126,7 @@ public abstract class GlobalNode extends ExpressionNode
     }
   }
 
-  private static final class UninitializedGlobalReadNode
+  public static final class UninitializedGlobalReadNode
       extends AbstractUninitializedGlobalReadNode {
     UninitializedGlobalReadNode(final SSymbol globalName, final Universe universe) {
       super(globalName, universe);

--- a/src/trufflesom/interpreter/nodes/ReturnNonLocalNode.java
+++ b/src/trufflesom/interpreter/nodes/ReturnNonLocalNode.java
@@ -104,7 +104,7 @@ public final class ReturnNonLocalNode extends ContextualNode {
    *
    * @author Stefan Marr
    */
-  private static final class ReturnLocalNode extends ExpressionNode {
+  public static final class ReturnLocalNode extends ExpressionNode {
     @Child private ExpressionNode expression;
 
     private final Internal  onStackMarkerVar;

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -974,6 +974,10 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
     return list;
   }
 
+  public byte[] getBytecodeArray() {
+    return bytecodes;
+  }
+
   public Object getConstant(final int idx) {
     return literalsAndConstants[idx];
   }

--- a/src/trufflesom/interpreter/nodes/specialized/IntToDoInlinedLiteralsNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IntToDoInlinedLiteralsNode.java
@@ -39,6 +39,10 @@ public abstract class IntToDoInlinedLiteralsNode extends ExpressionNode {
 
   public abstract ExpressionNode getTo();
 
+  public String getIndexName() {
+    return loopIdxVar.getName().getString();
+  }
+
   public IntToDoInlinedLiteralsNode(final ExpressionNode originalBody,
       final ExpressionNode body, final Local loopIdxVar) {
     this.body = body;

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -1,0 +1,559 @@
+package trufflesom.tests;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Context.Builder;
+import org.junit.Test;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.Source;
+
+import bd.basic.ProgramDefinitionError;
+import bd.tools.structure.StructuralProbe;
+import trufflesom.compiler.ClassGenerationContext;
+import trufflesom.compiler.Field;
+import trufflesom.compiler.MethodGenerationContext;
+import trufflesom.compiler.ParserAst;
+import trufflesom.compiler.Variable;
+import trufflesom.interpreter.SomLanguage;
+import trufflesom.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
+import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalArgumentReadNode;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
+import trufflesom.interpreter.nodes.FieldNode.FieldWriteNode;
+import trufflesom.interpreter.nodes.GlobalNode.UninitializedGlobalReadNode;
+import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableWriteNode;
+import trufflesom.interpreter.nodes.NonLocalVariableNode.NonLocalVariableReadNode;
+import trufflesom.interpreter.nodes.NonLocalVariableNode.NonLocalVariableWriteNode;
+import trufflesom.interpreter.nodes.ReturnNonLocalNode.ReturnLocalNode;
+import trufflesom.interpreter.nodes.SequenceNode;
+import trufflesom.interpreter.nodes.literals.BlockNode;
+import trufflesom.interpreter.nodes.literals.BlockNode.BlockNodeWithContext;
+import trufflesom.interpreter.nodes.literals.DoubleLiteralNode;
+import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
+import trufflesom.interpreter.nodes.literals.LiteralNode;
+import trufflesom.interpreter.nodes.literals.StringLiteralNode;
+import trufflesom.interpreter.nodes.literals.SymbolLiteralNode;
+import trufflesom.interpreter.nodes.nary.EagerBinaryPrimitiveNode;
+import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.AndInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.OrInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode;
+import trufflesom.interpreter.nodes.specialized.IntToDoInlinedLiteralsNode;
+import trufflesom.interpreter.nodes.specialized.whileloops.WhileInlinedLiteralsNode;
+import trufflesom.interpreter.objectstorage.StorageAnalyzer;
+import trufflesom.vm.Universe;
+import trufflesom.vmobjects.SClass;
+import trufflesom.vmobjects.SInvokable;
+import trufflesom.vmobjects.SSymbol;
+
+
+public class AstInliningTests {
+
+  protected final ClassGenerationContext cgenc;
+  protected MethodGenerationContext      mgenc;
+
+  protected final Universe universe;
+
+  protected final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe;
+
+  private static Universe getUniverse() {
+    return SomLanguage.getCurrent().getUniverse();
+  }
+
+  public AstInliningTests() {
+    universe = getUniverse();
+    probe = null;
+
+    cgenc = new ClassGenerationContext(universe, null);
+    cgenc.setName(universe.symbolFor("Test"));
+
+    initMgenc();
+  }
+
+  private void initMgenc() {
+    mgenc = new MethodGenerationContext(cgenc, probe);
+    mgenc.addArgumentIfAbsent(universe.symSelf, null);
+  }
+
+  private static void initTruffle() {
+    StorageAnalyzer.initAccessors();
+
+    Builder builder = Universe.createContextBuilder();
+    builder.logHandler(System.err);
+
+    Context context = builder.build();
+    context.eval(SomLanguage.INIT);
+
+    Universe u = getUniverse();
+    Source s = SomLanguage.getSyntheticSource("self", "self");
+    u.selfSource = s.createSection(1);
+  }
+
+  protected void addField(final String name) {
+    cgenc.addInstanceField(universe.symbolFor(name), null);
+  }
+
+  protected ExpressionNode parseMethod(final String source) {
+    Source s = SomLanguage.getSyntheticSource(source, "test");
+
+    ParserAst parser = new ParserAst(source, s, null, universe);
+    try {
+      return parser.method(mgenc);
+    } catch (ProgramDefinitionError e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void accessArgFromInlinedBlock(final String argName, final int argIdx) {
+    initMgenc();
+    SequenceNode seq =
+        (SequenceNode) parseMethod(
+            "test: arg1 and: arg2 = ( true ifTrue: [ " + argName + " ] )");
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 0);
+    LocalArgumentReadNode arg = read(ifNode, "bodyNode", LocalArgumentReadNode.class);
+
+    assertEquals(argName, arg.getInvocationIdentifier().getString());
+    assertEquals(argIdx, arg.argumentIndex);
+  }
+
+  @Test
+  public void testAccessArgFromInlinedBlock() {
+    accessArgFromInlinedBlock("arg1", 1);
+    accessArgFromInlinedBlock("arg2", 2);
+  }
+
+  @Test
+  public void testAccessSelfFromInlinedBlock() {
+    SequenceNode seq =
+        (SequenceNode) parseMethod(
+            "test: arg1 and: arg2 = ( true ifTrue: [ self ] )");
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 0);
+    LocalArgumentReadNode arg = read(ifNode, "bodyNode", LocalArgumentReadNode.class);
+
+    assertTrue(arg.isSelfRead());
+  }
+
+  @Test
+  public void testAccessBlockArgFromInlined() {
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test = ( [:arg |\n"
+            + "  arg.\n"
+            + "   true ifTrue: [ arg ] ] )");
+
+    BlockNode blockNode = (BlockNode) read(seq, "expressions", 0);
+    ExpressionNode[] blockExprs = getBlockExprs(blockNode);
+
+    LocalArgumentReadNode argRead = (LocalArgumentReadNode) blockExprs[0];
+    assertEquals(1, argRead.argumentIndex);
+    assertEquals("arg", argRead.getInvocationIdentifier().getString());
+
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) blockExprs[1];
+    LocalArgumentReadNode body = read(ifNode, "bodyNode", LocalArgumentReadNode.class);
+    assertEquals("arg", body.getInvocationIdentifier().getString());
+    assertEquals(1, body.argumentIndex);
+  }
+
+  private void literalTest(final String literalStr, final Class<?> cls) {
+    initMgenc();
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test = ( self method ifTrue: [ " + literalStr + " ]. )");
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 0);
+    Node literal = read(ifNode, "bodyNode");
+    assertThat(literal, instanceOf(cls));
+  }
+
+  @Test
+  public void testIfTrueWithLiteralReturn() {
+    literalTest("0", IntegerLiteralNode.class);
+    literalTest("1", IntegerLiteralNode.class);
+    literalTest("-10", IntegerLiteralNode.class);
+    literalTest("3333", IntegerLiteralNode.class);
+    literalTest("'str'", StringLiteralNode.class);
+    literalTest("#sym", SymbolLiteralNode.class);
+    literalTest("1.1", DoubleLiteralNode.class);
+    literalTest("-2342.234", DoubleLiteralNode.class);
+
+    // TODO: TruffleSOM and PySOM don't yet agree
+    literalTest("true", LiteralNode.class);
+    literalTest("false", LiteralNode.class);
+    literalTest("nil", LiteralNode.class);
+
+    literalTest("SomeGlobal", UninitializedGlobalReadNode.class);
+    literalTest("[]", BlockNode.class);
+    literalTest("[ self ]", BlockNodeWithContext.class);
+
+  }
+
+  private void ifArg(final String ifSelector, final boolean expected) {
+    initMgenc();
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = (\n"
+            + "#start.\n"
+            + "self method " + ifSelector + " [ arg ]. #end )");
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 1);
+    boolean actualExpectedBool = read(ifNode, "expectedBool", Boolean.class);
+    assertEquals(expected, actualExpectedBool);
+  }
+
+  @Test
+  public void testIfArg() {
+    ifArg("ifTrue:", true);
+    ifArg("ifFalse:", false);
+  }
+
+  @Test
+  public void testIfTrueAndIncField() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = (\n"
+            + "#start.\n"
+            + "(self key: 5) ifTrue: [ field := field + 1 ]. #end )");
+
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 1);
+
+    fail("TODO: PySOM doesn't match TruffleSOM. Inc node support not yet implemented in both");
+
+    FieldWriteNode fieldWrite = read(ifNode, "bodyNode", FieldWriteNode.class);
+    int fieldIdx = read(read(fieldWrite, "write"), "fieldIndex", Integer.class);
+    assertEquals(0, fieldIdx);
+
+    LocalArgumentReadNode selfNode = (LocalArgumentReadNode) fieldWrite.getSelf();
+    assertTrue(selfNode.isSelfRead());
+
+    ExpressionNode expr = fieldWrite.getValue();
+    fail("TODO: test that the right context level/field is accessed");
+  }
+
+  @Test
+  public void testIfTrueAndIncArg() {
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = (\n"
+            + "#start.\n"
+            + "(self key: 5) ifTrue: [ arg + 1 ]. #end )");
+
+    IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 1);
+
+    fail("TODO: PySOM doesn't match TruffleSOM. Inc node support not yet implemented in both");
+
+    Node add = read(ifNode, "bodyNode");
+
+    fail("TODO:  test that the right context level/arg is accessed");
+  }
+
+  @Test
+  public void testNestedIf() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = (\n"
+            + "  true ifTrue: [\n"
+            + "    false ifFalse: [\n"
+            + "      ^ field - arg ] ] )");
+
+    IfInlinedLiteralNode ifTrueNode = (IfInlinedLiteralNode) read(seq, "expressions", 0);
+    IfInlinedLiteralNode ifFalseNode =
+        read(ifTrueNode, "bodyNode", IfInlinedLiteralNode.class);
+    ReturnLocalNode returnNode = read(ifFalseNode, "bodyNode", ReturnLocalNode.class);
+
+    EagerBinaryPrimitiveNode subMsg =
+        read(returnNode, "expression", EagerBinaryPrimitiveNode.class);
+
+    FieldReadNode rcvr = read(subMsg, "receiver", FieldReadNode.class);
+    LocalArgumentReadNode selfRead = (LocalArgumentReadNode) rcvr.getSelf();
+    assertTrue(selfRead.isSelfRead());
+
+    LocalArgumentReadNode argNode = read(subMsg, "argument", LocalArgumentReadNode.class);
+    assertEquals("arg", argNode.getInvocationIdentifier().getString());
+    assertEquals(1, argNode.argumentIndex);
+  }
+
+  @Test
+  public void testNestedIfsAndLocals() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = (\n"
+            + "  | a b c d |\n"
+            + "  a := b.\n"
+            + "  true ifTrue: [\n"
+            + "    | e f g |\n"
+            + "    e := 2.\n"
+            + "    c := 3.\n"
+            + "    false ifFalse: [\n"
+            + "      | h i j |\n"
+            + "      h := 1.\n"
+            + "      ^ i - j - f - g - d ] ] )");
+    IfInlinedLiteralNode ifTrueNode = (IfInlinedLiteralNode) read(seq, "expressions", 1);
+
+    IfInlinedLiteralNode ifFalseNode =
+        (IfInlinedLiteralNode) read(read(ifTrueNode, "bodyNode"), "expressions", 2);
+
+    ExpressionNode[] body =
+        read(read(ifFalseNode, "bodyNode"), "expressions", ExpressionNode[].class);
+
+    LocalVariableWriteNode write = (LocalVariableWriteNode) body[0];
+    assertEquals("h", write.getInvocationIdentifier().getString());
+
+    assertThat((Object) body[1], instanceOf(ReturnLocalNode.class));
+  }
+
+  @Test
+  public void testNestedIfsAndNonInlinedBlocks() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = (\n"
+            + "  | a |\n"
+            + "  a := 1.\n"
+            + "  true ifTrue: [\n"
+            + "    | e |\n"
+            + "    e := 0.\n"
+            + "    [ a := 1. a ].\n"
+            + "    false ifFalse: [\n"
+            + "      | h |\n"
+            + "      h := 1.\n"
+            + "      [ h + a + e ].\n"
+            + "      ^ h ] ].\n"
+            + "  [ a ]\n"
+            + ")");
+    IfInlinedLiteralNode ifTrueNode = (IfInlinedLiteralNode) read(seq, "expressions", 1);
+
+    BlockNode blockNode =
+        (BlockNode) read(read(ifTrueNode, "bodyNode"), "expressions", 1);
+    NonLocalVariableWriteNode write = (NonLocalVariableWriteNode) read(
+        read(blockNode.getMethod().getInvokable(), "expressionOrSequence"), "expressions", 0);
+    assertEquals(1, write.getContextLevel());
+    assertEquals("a", write.getInvocationIdentifier().getString());
+
+    IfInlinedLiteralNode ifFalseNode =
+        (IfInlinedLiteralNode) read(read(ifTrueNode, "bodyNode"), "expressions", 2);
+    ExpressionNode[] body =
+        read(read(ifFalseNode, "bodyNode"), "expressions", ExpressionNode[].class);
+
+    LocalVariableWriteNode writeH = (LocalVariableWriteNode) body[0];
+    assertEquals("h", writeH.getInvocationIdentifier().getString());
+
+    assertThat((Object) body[2], instanceOf(ReturnLocalNode.class));
+  }
+
+  @Test
+  public void testNestedNonInlinedBlocks() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: a = ( | b |\n"
+            + " true ifFalse: [ | c |\n"
+            + "   a. b. c.\n"
+            + "   [:d |\n"
+            + "      a. b. c. d.\n"
+            + "      [:e |\n"
+            + "        a. b. c. d. e ] ] ]\n"
+            + ")");
+    IfInlinedLiteralNode ifFalseNode = (IfInlinedLiteralNode) read(seq, "expressions", 0);
+
+    BlockNode blockNode =
+        (BlockNode) read(read(ifFalseNode, "bodyNode"), "expressions", 3);
+    ExpressionNode[] blockExprs = getBlockExprs(blockNode);
+
+    NonLocalArgumentReadNode readA = (NonLocalArgumentReadNode) blockExprs[0];
+    assertEquals(1, readA.getContextLevel());
+    assertEquals("a", readA.getInvocationIdentifier().getString());
+    assertEquals(1, (int) read(readA, "argumentIndex", Integer.class));
+
+    NonLocalVariableReadNode readB = (NonLocalVariableReadNode) blockExprs[1];
+    assertEquals(1, readB.getContextLevel());
+    assertEquals("b", readB.getInvocationIdentifier().getString());
+
+    blockNode = (BlockNode) blockExprs[4];
+    blockExprs = getBlockExprs(blockNode);
+    readA = (NonLocalArgumentReadNode) blockExprs[0];
+    assertEquals(2, readA.getContextLevel());
+    assertEquals("a", readA.getInvocationIdentifier().getString());
+    assertEquals(1, (int) read(readA, "argumentIndex", Integer.class));
+
+    readB = (NonLocalVariableReadNode) blockExprs[1];
+    assertEquals(2, readB.getContextLevel());
+    assertEquals("b", readB.getInvocationIdentifier().getString());
+  }
+
+  private void ifTrueIfFalseReturn(final String sel1, final String sel2,
+      final boolean expectedBool) {
+    initMgenc();
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg1 with: arg2 = (\n"
+            + "   #start.\n"
+            + "   ^ self method " + sel1 + " [ ^ arg1 ] " + sel2 + " [ arg2 ]\n"
+            + "   )");
+
+    fail("TruffleSOM doesn't yet specialize both ifTrue:ifFalse: and ifFalse:ifTrue:");
+
+    IfTrueIfFalseInlinedLiteralsNode ifNode =
+        (IfTrueIfFalseInlinedLiteralsNode) read(seq, "expressions", 1);
+    assertEquals(expectedBool, read(ifNode, "expectedBool", Boolean.class));
+  }
+
+  @Test
+  public void testIfTrueIfFalseReturn() {
+    ifTrueIfFalseReturn("ifTrue:", "ifFalse:", true);
+    ifTrueIfFalseReturn("ifFalse:", "ifTrue:", false);
+  }
+
+  private void whileInlining(final String whileSel, final boolean expectedBool) {
+    initMgenc();
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg1 with: arg2 = (\n"
+            + "  [ arg1 ] " + whileSel + " [ arg2 ]\n"
+            + ")");
+
+    WhileInlinedLiteralsNode whileNode =
+        (WhileInlinedLiteralsNode) read(seq, "expressions", 0);
+    assertEquals(expectedBool, read(whileNode, "expectedBool", Boolean.class));
+  }
+
+  @Test
+  public void testWhileInlining() {
+    whileInlining("whileTrue:", true);
+    whileInlining("whileFalse:", false);
+  }
+
+  @Test
+  public void testBlockBlockInlinedSelf() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test = (\n"
+            + "[:a |\n"
+            + "  [:b |\n"
+            + "     b ifTrue: [ field := field + 1 ] ] ]\n"
+            + ")");
+
+    BlockNode blockNodeA = (BlockNode) read(seq, "expressions", 0);
+
+    BlockNode blockNodeB =
+        (BlockNode) read(blockNodeA.getMethod().getInvokable(), "expressionOrSequence");
+
+    IfInlinedLiteralNode blockBIfTrue =
+        (IfInlinedLiteralNode) read(blockNodeB.getMethod().getInvokable(),
+            "expressionOrSequence");
+
+    LocalArgumentReadNode readB =
+        read(blockBIfTrue, "conditionNode", LocalArgumentReadNode.class);
+    assertEquals("b", readB.getInvocationIdentifier().getString());
+    assertEquals(1, readB.argumentIndex);
+
+    fail(
+        "TODO: TruffleSOM and PySOM don't yet implement the same optimizations. Inc node missing in PySOM.");
+    read(blockBIfTrue, "bodyNode", FieldWriteNode.class);
+
+    fail("TODO: test that the self is at the correct level (ctx level 2)");
+  }
+
+  @Test
+  public void testToDoBlockBlockInlinedSelf() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod("test = (\n"
+        + "| l1 l2 |\n"
+        + "1 to: 2 do: [:a |\n"
+        + "  l1 do: [:b |\n"
+        + "    b ifTrue: [ l2 := l2 + 1 ] ] ]\n"
+        + ")");
+
+    IntToDoInlinedLiteralsNode toDo =
+        (IntToDoInlinedLiteralsNode) read(seq, "expressions", 0);
+
+    EagerBinaryPrimitiveNode doPrim = read(toDo, "body", EagerBinaryPrimitiveNode.class);
+    BlockNode blockA = read(doPrim, "argument", BlockNode.class);
+    IfInlinedLiteralNode blockBIfTrue =
+        read(blockA.getMethod().getInvokable(), "expressionOrSequence",
+            IfInlinedLiteralNode.class);
+
+    LocalArgumentReadNode readNode =
+        read(blockBIfTrue, "conditionNode", LocalArgumentReadNode.class);
+    assertEquals("b", readNode.getInvocationIdentifier().getString());
+    assertEquals(1, readNode.argumentIndex);
+
+    NonLocalVariableWriteNode writeNode =
+        read(blockBIfTrue, "bodyNode", NonLocalVariableWriteNode.class);
+    assertEquals(1, writeNode.getContextLevel());
+    assertEquals("l2", writeNode.getInvocationIdentifier().getString());
+    writeNode.getExp();
+
+    assertEquals(
+        "TODO: PySOM needs to add IncNode support like we have here, then we can fix this test",
+        true, false);
+
+  }
+
+  @Test
+  public void testFieldReadInlining() {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod("test = ( true and: [ field ] )");
+
+    AndInlinedLiteralNode and =
+        (AndInlinedLiteralNode) read(seq, "expressions", 0);
+    assertThat(read(and, "argumentNode"), instanceOf(FieldReadNode.class));
+  }
+
+  private Object inliningOf(final String selector) {
+    initMgenc();
+    SequenceNode seq = (SequenceNode) parseMethod("test = ( true " + selector + " [ #val ] )");
+    return read(seq, "expressions", 0);
+  }
+
+  @Test
+  public void testInliningOf() {
+    assertThat(inliningOf("or:"), instanceOf(OrInlinedLiteralNode.class));
+    assertThat(inliningOf("||"), instanceOf(OrInlinedLiteralNode.class));
+    assertThat(inliningOf("and:"), instanceOf(AndInlinedLiteralNode.class));
+    assertThat(inliningOf("&&"), instanceOf(AndInlinedLiteralNode.class));
+  }
+
+  @Test
+  public void testInliningOfToDo() {
+    SequenceNode seq = (SequenceNode) parseMethod("test = ( 1 to: 2 do: [:i | i ] )");
+    IntToDoInlinedLiteralsNode toDo =
+        (IntToDoInlinedLiteralsNode) read(seq, "expressions", 0);
+    assertEquals("i", toDo.getIndexName());
+  }
+
+  private java.lang.reflect.Field lookup(final Class<?> cls, final String fieldName) {
+    try {
+      return cls.getDeclaredField(fieldName);
+    } catch (NoSuchFieldException e) {
+      if (cls.getSuperclass() != null) {
+        return lookup(cls.getSuperclass(), fieldName);
+      }
+    } catch (SecurityException e) {
+      throw new RuntimeException(e);
+    }
+    throw new RuntimeException("Didn't find field: " + fieldName);
+  }
+
+  private Node read(final Object obj, final String fieldName) {
+    return read(obj, fieldName, Node.class);
+  }
+
+  private ExpressionNode read(final Object obj, final String fieldName, final int idx) {
+    return read(obj, fieldName, ExpressionNode[].class)[idx];
+  }
+
+  private ExpressionNode[] getBlockExprs(final BlockNode blockNode) {
+    return read(read(blockNode.getMethod().getInvokable(), "expressionOrSequence"),
+        "expressions", ExpressionNode[].class);
+  }
+
+  private <T> T read(final Object obj, final String fieldName, final Class<T> c) {
+    java.lang.reflect.Field field = lookup(obj.getClass(), fieldName);
+    field.setAccessible(true);
+    try {
+      return c.cast(field.get(obj));
+    } catch (IllegalAccessException | IllegalArgumentException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static {
+    initTruffle();
+  }
+}

--- a/tests/trufflesom/tests/BytecodeMethodTests.java
+++ b/tests/trufflesom/tests/BytecodeMethodTests.java
@@ -1,7 +1,14 @@
 package trufflesom.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.oracle.truffle.api.source.Source;
@@ -10,78 +17,213 @@ import bd.basic.ProgramDefinitionError;
 import trufflesom.compiler.ParserBc;
 import trufflesom.interpreter.SomLanguage;
 import trufflesom.interpreter.bc.Bytecodes;
+import trufflesom.interpreter.nodes.bc.BytecodeLoopNode;
+import trufflesom.vmobjects.SInvokable.SMethod;
 
 
 public class BytecodeMethodTests extends BytecodeTestSetup {
 
-  private byte[] methodToBytecodes(final String source)
-      throws ProgramDefinitionError {
+  private byte[] methodToBytecodes(final String source) {
     Source s = SomLanguage.getSyntheticSource(source, "test");
 
     ParserBc parser = new ParserBc(source, s, probe, universe);
-    parser.method(mgenc);
+    try {
+      parser.method(mgenc);
+    } catch (ProgramDefinitionError e) {
+      throw new RuntimeException(e);
+    }
     return mgenc.getBytecodeArray();
   }
 
+  private byte[] blockToBytecodes(final String source) {
+    initBgenc();
+    Source s = SomLanguage.getSyntheticSource(source, "test");
+
+    ParserBc parser = new ParserBc(source, s, probe, universe);
+    try {
+      parser.nestedBlock(bgenc);
+    } catch (ProgramDefinitionError e) {
+      throw new RuntimeException(e);
+    }
+    return bgenc.getBytecodeArray();
+  }
+
+  private static class BC {
+    final byte   bytecode;
+    final Byte   arg1;
+    final Byte   arg2;
+    final String note;
+
+    BC(final byte bytecode, final int arg1, final int arg2, final String note) {
+      this.bytecode = bytecode;
+      this.arg1 = (byte) arg1;
+      this.arg2 = (byte) arg2;
+      this.note = note;
+    }
+
+    BC(final byte bytecode, final int arg1) {
+      this.bytecode = bytecode;
+      this.arg1 = (byte) arg1;
+      arg2 = null;
+      note = null;
+    }
+
+    BC(final byte bytecode, final int arg1, final String note) {
+      this.bytecode = bytecode;
+      this.arg1 = (byte) arg1;
+      arg2 = null;
+      this.note = note;
+    }
+
+    BC(final byte bytecode, final int arg1, final int arg2) {
+      this.bytecode = bytecode;
+      this.arg1 = (byte) arg1;
+      this.arg2 = (byte) arg2;
+      note = null;
+    }
+  }
+
+  private Object[] t(final int idx, final Object bc) {
+    return new Object[] {idx, bc};
+  }
+
+  private void check(final byte[] actual, final Object... expected) {
+    Deque<Object> expectedQ = new ArrayDeque<>(Arrays.asList(expected));
+
+    int i = 0;
+
+    while (i < actual.length && !expectedQ.isEmpty()) {
+      byte actualBc = actual[i];
+
+      int bcLength = Bytecodes.getBytecodeLength(actualBc);
+
+      Object expectedBc = expectedQ.peek();
+      if (expectedBc instanceof Object[]) {
+        Object[] tuple = (Object[]) expectedBc;
+        if ((Integer) tuple[0] == i) {
+          expectedBc = tuple[1];
+        } else {
+          assertTrue(((Integer) tuple[0]) > i);
+          i += bcLength;
+          continue;
+        }
+      }
+
+      if (expectedBc instanceof BC) {
+        BC bc = (BC) expectedBc;
+
+        assertEquals("Bytecode " + i + " expected " + Bytecodes.getBytecodeName(bc.bytecode)
+            + " but got " + Bytecodes.getBytecodeName(actualBc), actualBc, bc.bytecode);
+
+        if (bc.arg1 != null) {
+          assertEquals("Bytecode " + i + " expected " + Bytecodes.getBytecodeName(bc.bytecode)
+              + "(" + bc.arg1 + ", " + bc.arg2 + ") but got "
+              + Bytecodes.getBytecodeName(actualBc) + "(" + actual[i + 1] + ", "
+              + actual[i + 2] + ")", actual[i + 1], (byte) bc.arg1);
+        }
+
+        if (bc.arg2 != null) {
+          assertEquals(actual[i + 2], (byte) bc.arg2);
+        }
+      } else {
+        assertEquals(
+            "Bytecode " + i + " expected " + Bytecodes.getBytecodeName((byte) expectedBc)
+                + " but got " + Bytecodes.getBytecodeName(actualBc),
+            (byte) expectedBc, actualBc);
+      }
+
+      expectedQ.remove();
+      i += bcLength;
+    }
+
+    assertTrue(expectedQ.isEmpty());
+  }
+
+  private void incDecBytecodes(final String op, final byte bytecode) {
+    initMgenc();
+    byte[] bytecodes = methodToBytecodes("test = ( 1 " + op + "  1 )");
+
+    assertEquals(4, bytecodes.length);
+    check(bytecodes, Bytecodes.PUSH_CONSTANT, bytecode, Bytecodes.RETURN_SELF);
+
+    fail(
+        "TODO: first BC should really be a PUSH_1 bytecode, but the optimization is not yet implemented");
+  }
+
+  @Ignore("TODO")
   @Test
-  public void testEmptyMethodReturnsSelf() throws ProgramDefinitionError {
+  public void testIncDecBytecodes() {
+    incDecBytecodes("+", Bytecodes.INC);
+    incDecBytecodes("-", Bytecodes.DEC);
+  }
+
+  @Test
+  public void testEmptyMethodReturnsSelf() {
     byte[] bytecodes = methodToBytecodes("test = ( )");
 
     assertEquals(1, bytecodes.length);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[0]);
+    check(bytecodes, Bytecodes.RETURN_SELF);
   }
 
   @Test
-  public void testExplicitReturnSelf() throws ProgramDefinitionError {
+  public void testExplicitReturnSelf() {
     byte[] bytecodes = methodToBytecodes("test = ( ^ self )");
 
     assertEquals(1, bytecodes.length);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[0]);
+    check(bytecodes, Bytecodes.RETURN_SELF);
   }
 
+  @Ignore("TODO")
   @Test
-  public void testDupPopArgumentPop() throws ProgramDefinitionError {
+  public void testDupPopArgumentPop() {
     byte[] bytecodes = methodToBytecodes("test: arg = ( arg := 1. ^ self )");
 
     assertEquals(6, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_CONSTANT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_ARGUMENT, bytecodes[2]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[5]);
+    check(bytecodes, Bytecodes.PUSH_CONSTANT, Bytecodes.POP_ARGUMENT, Bytecodes.RETURN_SELF);
+
+    fail(
+        "TODO: first BC should really be a PUSH_1 bytecode, but the optimization is not yet implemented");
   }
 
+  @Ignore("TODO")
   @Test
-  public void testDupPopArgumentPopImplicitReturnSelf() throws ProgramDefinitionError {
+  public void testDupPopArgumentPopImplicitReturnSelf() {
     byte[] bytecodes = methodToBytecodes("test: arg = ( arg := 1 )");
 
     assertEquals(6, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_CONSTANT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_ARGUMENT, bytecodes[2]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[5]);
+    check(bytecodes, Bytecodes.PUSH_CONSTANT, Bytecodes.POP_ARGUMENT, Bytecodes.RETURN_SELF);
+
+    fail(
+        "TODO: first BC should really be a PUSH_1 bytecode, but the optimization is not yet implemented");
   }
 
+  @Ignore("TODO")
   @Test
-  public void testDupPopLocalPop() throws ProgramDefinitionError {
+  public void testDupPopLocalPop() {
     byte[] bytecodes = methodToBytecodes("test = ( | local | local := 1. ^ self )");
 
     assertEquals(6, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_CONSTANT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_LOCAL, bytecodes[2]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[5]);
+    check(bytecodes, Bytecodes.PUSH_CONSTANT, Bytecodes.POP_LOCAL, Bytecodes.RETURN_SELF);
+
+    fail(
+        "TODO: first BC should really be a PUSH_1 bytecode, but the optimization is not yet implemented");
   }
 
+  @Ignore("TODO")
   @Test
-  public void testDupPopField0Pop() throws ProgramDefinitionError {
+  public void testDupPopField0Pop() {
     addField("field");
     byte[] bytecodes = methodToBytecodes("test = ( field := 1. ^ self )");
 
     assertEquals(6, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_CONSTANT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_FIELD, bytecodes[2]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[5]);
+    check(bytecodes, Bytecodes.PUSH_CONSTANT, Bytecodes.POP_FIELD, Bytecodes.RETURN_SELF);
+
+    fail("TODO: should be PUSH_1, POP_FIELD_0");
   }
 
+  @Ignore("TODO")
   @Test
-  public void testDupPopFieldNPop() throws ProgramDefinitionError {
+  public void testDupPopFieldNPop() {
     addField("a");
     addField("b");
     addField("c");
@@ -91,24 +233,23 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
     byte[] bytecodes = methodToBytecodes("test = ( field := 1. ^ self )");
 
     assertEquals(6, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_CONSTANT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_FIELD, bytecodes[2]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[5]);
+    check(bytecodes, Bytecodes.PUSH_CONSTANT, Bytecodes.POP_FIELD, Bytecodes.RETURN_SELF);
+    fail("TODO: should be PUSH_1,...");
   }
 
+  @Ignore("TODO")
   @Test
-  public void testDupPopFieldReturnSelf() throws ProgramDefinitionError {
+  public void testDupPopFieldReturnSelf() {
     addField("field");
     byte[] bytecodes = methodToBytecodes("test: val = ( field := val )");
 
     assertEquals(7, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_ARGUMENT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_FIELD, bytecodes[3]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[6]);
+    check(bytecodes, Bytecodes.PUSH_ARGUMENT, Bytecodes.POP_FIELD, Bytecodes.RETURN_SELF);
+    fail("TODO: should be ...,POP_FIELD_0,...");
   }
 
   @Test
-  public void testDupPopFieldNReturnSelf() throws ProgramDefinitionError {
+  public void testDupPopFieldNReturnSelf() {
     addField("a");
     addField("b");
     addField("c");
@@ -118,53 +259,872 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
     byte[] bytecodes = methodToBytecodes("test: val = ( field := val )");
 
     assertEquals(7, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_ARGUMENT, bytecodes[0]);
-    assertEquals(Bytecodes.POP_FIELD, bytecodes[3]);
-    assertEquals(Bytecodes.RETURN_SELF, bytecodes[6]);
+    check(bytecodes, Bytecodes.PUSH_ARGUMENT, Bytecodes.POP_FIELD, Bytecodes.RETURN_SELF);
   }
 
+  @Ignore("TODO")
   @Test
-  public void testSendDupPopFieldReturnLocal() throws ProgramDefinitionError {
+  public void testSendDupPopFieldReturnLocal() {
     addField("field");
     byte[] bytecodes = methodToBytecodes("test = ( ^ field := self method )");
 
     assertEquals(10, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_ARGUMENT, bytecodes[0]);
-    assertEquals(Bytecodes.SEND, bytecodes[3]);
-    assertEquals(Bytecodes.DUP, bytecodes[5]);
-    assertEquals(Bytecodes.POP_FIELD, bytecodes[6]);
-    assertEquals(Bytecodes.RETURN_LOCAL, bytecodes[9]);
+    check(bytecodes,
+        Bytecodes.PUSH_ARGUMENT,
+        Bytecodes.SEND,
+        Bytecodes.DUP,
+        Bytecodes.POP_FIELD,
+        Bytecodes.RETURN_LOCAL);
+
+    fail("TODO: should be ...,POP_FIELD_0,...");
   }
 
+  @Ignore("TODO")
   @Test
-  public void testSendDupPopFieldReturnLocalPeriod() throws ProgramDefinitionError {
+  public void testSendDupPopFieldReturnLocalPeriod() {
     addField("field");
     byte[] bytecodes = methodToBytecodes("test = ( ^ field := self method. )");
 
     assertEquals(10, bytecodes.length);
-    assertEquals(Bytecodes.PUSH_ARGUMENT, bytecodes[0]);
-    assertEquals(Bytecodes.SEND, bytecodes[3]);
-    assertEquals(Bytecodes.DUP, bytecodes[5]);
-    assertEquals(Bytecodes.POP_FIELD, bytecodes[6]);
-    assertEquals(Bytecodes.RETURN_LOCAL, bytecodes[9]);
+    check(bytecodes,
+        Bytecodes.PUSH_ARGUMENT,
+        Bytecodes.SEND,
+        Bytecodes.DUP,
+        Bytecodes.POP_FIELD,
+        Bytecodes.RETURN_LOCAL);
+
+    fail("TODO: should be ...,POP_FIELD_0,...");
   }
 
+  private void ifTrueWithLiteralReturn(final String literal, final byte bytecode) {
+    initMgenc();
+    byte[] bytecodes = methodToBytecodes("test = (\n"
+        + "  self method ifTrue: [ " + literal + " ].\n"
+        + ")");
+
+    int bcLength = Bytecodes.getBytecodeLength(bytecode);
+
+    assertEquals(10 + bcLength, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_ARGUMENT,
+        Bytecodes.SEND,
+        Bytecodes.JUMP_ON_FALSE_TOP_NIL,
+        bytecode,
+        Bytecodes.POP,
+        Bytecodes.RETURN_SELF);
+
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfTrueWithLiteralReturn() {
+    ifTrueWithLiteralReturn("0", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("1", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("-10", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("3333", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("'str'", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("#sym", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("1.1", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("-2342.234", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("true", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("false", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("nil", Bytecodes.PUSH_CONSTANT);
+    ifTrueWithLiteralReturn("SomeGlobal", Bytecodes.PUSH_GLOBAL);
+    ifTrueWithLiteralReturn("[]", Bytecodes.PUSH_BLOCK_NO_CTX);
+    ifTrueWithLiteralReturn("[ self ]", Bytecodes.PUSH_BLOCK);
+
+    fail("TODO: support for push_0, push_1, ...");
+  }
+
+  private void ifArg(final String selector, final byte jumpBytecode) {
+    initMgenc();
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  #start.\n"
+            + "  self method " + selector + " [ arg ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(18, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_ARGUMENT,
+        Bytecodes.SEND,
+        new BC(jumpBytecode, 6),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.RETURN_SELF);
+
+    fail("TODO: push_constant_0, ...");
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfArg() {
+    ifArg("ifTrue:", Bytecodes.JUMP_ON_FALSE_TOP_NIL);
+    ifArg("ifFalse:", Bytecodes.JUMP_ON_TRUE_TOP_NIL);
+  }
+
+  @Test
+  public void testKeywordIfTrueArg() {
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  #start.\n"
+            + "  (self key: 5) ifTrue: [ arg ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(20, bytecodes.length);
+    check(bytecodes,
+        t(8, Bytecodes.SEND),
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 6),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT);
+
+  }
+
+  @Test
+  public void testIfTrueAndIncField() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  #start.\n"
+            + "  (self key: 5) ifTrue: [ field := field + 1 ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(25, bytecodes.length);
+    dump();
+    check(bytecodes,
+        t(8, Bytecodes.SEND),
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 11), // jump to pop bytecode, which is the dot
+        new BC(Bytecodes.PUSH_FIELD, 0, 0),
+        Bytecodes.INC,
+        Bytecodes.DUP,
+        new BC(Bytecodes.POP_FIELD, 0, 0),
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfTrueAndIncArg() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  #start.\n"
+            + "  (self key: 5) ifTrue: [ arg + 1 ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(25, bytecodes.length);
+    dump();
+    check(bytecodes,
+        t(8, Bytecodes.SEND),
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 7), // jump to pop bytecode, which is the dot
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.INC,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT);
+  }
+
+  private void ifReturnNonLocal(final String ifSelector, final byte jumpBytecode) {
+    initMgenc();
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  #start.\n"
+            + "  (self key: 5) " + ifSelector + " [ ^ arg ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(22, bytecodes.length);
+    dump();
+
+    fail("TODO: change things so that we can eliminate the HALT bytecode, as in PySOM");
+    check(bytecodes,
+        t(8, Bytecodes.SEND),
+        new BC(jumpBytecode, 8), // jump to pop bytecode, which is the dot
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.RETURN_LOCAL,
+        Bytecodes.POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfReturnNonLocal() {
+    ifReturnNonLocal("ifTrue:", Bytecodes.JUMP_ON_FALSE_TOP_NIL);
+    ifReturnNonLocal("ifFalse:", Bytecodes.JUMP_ON_TRUE_TOP_NIL);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testNestedIfs() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  true ifTrue: [\n"
+            + "    false ifFalse: [\n"
+            + "      ^ field - arg\n"
+            + "    ]\n"
+            + "  ]\n"
+            + ")");
+
+    fail("TODO: change things so that we can eliminate the HALT bytecode, as in PySOM");
+    check(bytecodes,
+        Bytecodes.PUSH_GLOBAL,
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 18),
+        t(7, Bytecodes.JUMP_ON_TRUE_TOP_NIL),
+        new BC(Bytecodes.PUSH_FIELD, 0, 0),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.SEND,
+        Bytecodes.RETURN_LOCAL,
+        Bytecodes.RETURN_SELF);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testNestedIfsAndLocals() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  | a b c d |\n"
+            + "  a := b.\n"
+            + "  true ifTrue: [\n"
+            + "    | e f g |\n"
+            + "    e := 2.\n"
+            + "    c := 3.\n"
+            + "    false ifFalse: [\n"
+            + "      | h i j |\n"
+            + "      h := 1.\n"
+            + "      ^ i - j - f - g - d ] ] )");
+
+    assertEquals(55, bytecodes.length);
+    check(bytecodes,
+        new BC(Bytecodes.PUSH_LOCAL, 1, 0),
+        new BC(Bytecodes.POP_LOCAL, 0, 0),
+        t(8, new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 46)),
+        t(13, new BC(Bytecodes.POP_LOCAL, 4, 0)),
+        t(18, new BC(Bytecodes.POP_LOCAL, 2, 0)),
+        t(23, new BC(Bytecodes.JUMP_ON_TRUE_TOP_NIL, 31)),
+        t(27, new BC(Bytecodes.POP_LOCAL, 7, 0)),
+        t(48, new BC(Bytecodes.PUSH_LOCAL, 3, 0)));
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testNestedIfsAndNonInlinedBlocks() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + " | a |\n"
+            + " a := 1.\n"
+            + " true ifTrue: [\n"
+            + "   | e |\n"
+            + "   e := 0.\n"
+            + "   [ a := 1. a ].\n"
+            + "   false ifFalse: [\n"
+            + "     | h |\n"
+            + "     h := 1.\n"
+            + "     [ h + a + e ].\n"
+            + "     ^ h ] ].\n"
+            + " [ a ]\n"
+            + ")");
+
+    assertEquals(36, bytecodes.length);
+    check(bytecodes,
+        t(4, Bytecodes.PUSH_GLOBAL),
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 26),
+        t(10, new BC(Bytecodes.POP_LOCAL, 1, 0, "local e")),
+        t(18, new BC(Bytecodes.JUMP_ON_TRUE_TOP_NIL, 14)),
+        t(22, new BC(Bytecodes.POP_LOCAL, 2, 0, "local h")));
+
+    check(getBytecodesOfBlock(13),
+        t(1, new BC(Bytecodes.POP_LOCAL, 0, 1, "local a")));
+
+    check(getBytecodesOfBlock(25),
+        new BC(Bytecodes.PUSH_LOCAL, 2, 1, "local h"),
+        new BC(Bytecodes.PUSH_LOCAL, 0, 1, "local a"),
+        t(8, new BC(Bytecodes.PUSH_LOCAL, 1, 1, "local e")));
+
+    check(getBytecodesOfBlock(33),
+        new BC(Bytecodes.PUSH_LOCAL, 0, 1, "local a"));
+
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testNestedNonInlinedBlocks() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test: a = ( | b |\n"
+            + " true ifFalse: [ | c |\n"
+            + "   a. b. c.\n"
+            + "   [:d |\n"
+            + "     a. b. c. d.\n"
+            + "     [:e |\n"
+            + "       a. b. c. d. e ] ] ]\n"
+            + ")");
+
+    assertEquals(20, bytecodes.length);
+    check(bytecodes,
+        t(2, new BC(Bytecodes.JUMP_ON_TRUE_TOP_NIL, 17)),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0, "arg a"),
+        t(9, new BC(Bytecodes.PUSH_LOCAL, 0, 0, "local b")),
+        t(13, new BC(Bytecodes.PUSH_LOCAL, 1, 0, "local c")));
+
+    SMethod blockMethod = (SMethod) mgenc.getConstant(17);
+    BytecodeLoopNode blockNode =
+        read(blockMethod.getInvokable(), "expressionOrSequence", BytecodeLoopNode.class);
+    byte[] blockBytecodes = blockNode.getBytecodeArray();
+
+    check(blockBytecodes,
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 1, "arg a"),
+        t(4, new BC(Bytecodes.PUSH_LOCAL, 0, 1, "local b")),
+        t(8, new BC(Bytecodes.PUSH_LOCAL, 1, 1, "local c")),
+        t(12, new BC(Bytecodes.PUSH_ARGUMENT, 1, 0, "arg d")));
+
+    blockMethod = (SMethod) blockNode.getConstant(16);
+
+    check(
+        read(blockMethod.getInvokable(), "expressionOrSequence",
+            BytecodeLoopNode.class).getBytecodeArray(),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 2, "arg a"),
+        t(4, new BC(Bytecodes.PUSH_LOCAL, 0, 2, "local b")),
+        t(8, new BC(Bytecodes.PUSH_LOCAL, 1, 2, "local c")),
+        t(12, new BC(Bytecodes.PUSH_ARGUMENT, 1, 1, "arg d")),
+        t(16, new BC(Bytecodes.PUSH_ARGUMENT, 1, 0, "arg e")));
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockIfTrueArg() {
+    byte[] bytecodes = blockToBytecodes(
+        "[:arg | #start.\n"
+            + " self method ifTrue: [ arg ].\n"
+            + " #end\n"
+            + "]");
+
+    dump();
+    assertEquals(17, bytecodes.length);
+    check(bytecodes,
+        t(5, Bytecodes.SEND),
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 6),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockIfTrueMethodArg() {
+    Source s = SomLanguage.getSyntheticSource("test arg", "arg");
+    mgenc.addArgumentIfAbsent(universe.symbolFor("arg"), s.createSection(1));
+
+    byte[] bytecodes = blockToBytecodes(
+        "[ #start.\n"
+            + " self method ifTrue: [ arg ].\n"
+            + " #end\n"
+            + "]");
+
+    dump();
+    assertEquals(17, bytecodes.length);
+    check(bytecodes,
+        t(7, new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 6)),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 1),
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfTrueIfFalseArg() {
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg1 with: arg2 = (\n"
+            + " #start.\n"
+            + " self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].\n"
+            + " #end\n"
+            + ")");
+
+    assertEquals(23, bytecodes.length);
+    check(bytecodes,
+        t(7, new BC(Bytecodes.JUMP_ON_FALSE_POP, 9)),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        new BC(Bytecodes.JUMP, 6),
+        new BC(Bytecodes.PUSH_ARGUMENT, 2, 0),
+        Bytecodes.POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfTrueIfFalseNlrArg1() {
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg1 with: arg2 = (\n"
+            + "  #start.\n"
+            + "  self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(24, bytecodes.length);
+    check(bytecodes,
+        t(7, new BC(Bytecodes.JUMP_ON_FALSE_POP, 10)),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        Bytecodes.RETURN_LOCAL,
+        new BC(Bytecodes.JUMP, 6),
+        new BC(Bytecodes.PUSH_ARGUMENT, 2, 0),
+        Bytecodes.POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfTrueIfFalseNlrArg2() {
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg1 with: arg2 = (\n"
+            + "  #start.\n"
+            + "  self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(24, bytecodes.length);
+    check(bytecodes,
+        t(7, new BC(Bytecodes.JUMP_ON_FALSE_POP, 9)),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        new BC(Bytecodes.JUMP, 7),
+        new BC(Bytecodes.PUSH_ARGUMENT, 2, 0),
+        Bytecodes.RETURN_LOCAL,
+        Bytecodes.POP);
+  }
+
+  private void ifTrueIfFalseReturn(final String sel1, final String sel2,
+      final byte jumpBytecode) {
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg1 with: arg2 = (\n"
+            + "  #start.\n"
+            + "  ^ self method " + sel1 + " [ ^ arg1 ] " + sel2 + " [ arg2 ]\n"
+            + ")");
+
+    assertEquals(21, bytecodes.length);
+    check(bytecodes,
+        t(7, new BC(jumpBytecode, 10)),
+        t(17, new BC(Bytecodes.JUMP, 6)));
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfTrueIfFalseReturn() {
+    ifTrueIfFalseReturn("ifTrue:", "ifFalse:", Bytecodes.JUMP_ON_FALSE_POP);
+    ifTrueIfFalseReturn("ifFalse:", "ifTrue:", Bytecodes.JUMP_ON_TRUE_POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfPushConsantSame() {
+    byte[] bytecodes = methodToBytecodes(
+        "test = (\n"
+            + "  #a. #b. #c. #d.\n"
+            + "  true ifFalse: [ #a. #b. #c. #d. ]\n"
+            + ")");
+
+    assertEquals(23, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        t(2, Bytecodes.PUSH_CONSTANT),
+        t(4, Bytecodes.PUSH_CONSTANT),
+        t(6, Bytecodes.PUSH_CONSTANT),
+        t(11, new BC(Bytecodes.JUMP_ON_TRUE_TOP_NIL, 11)),
+        t(14, Bytecodes.PUSH_CONSTANT),
+        t(16, Bytecodes.PUSH_CONSTANT),
+        t(18, Bytecodes.PUSH_CONSTANT),
+        t(20, new BC(Bytecodes.PUSH_CONSTANT, 3)));
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfPushConsantDifferent() {
+    byte[] bytecodes = methodToBytecodes(
+        "test = (\n"
+            + "  #a. #b. #c. #d.\n"
+            + "  true ifFalse: [ #e. #f. #g. #h. ]\n"
+            + ")");
+
+    assertEquals(26, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        t(2, Bytecodes.PUSH_CONSTANT),
+        t(4, Bytecodes.PUSH_CONSTANT),
+        t(6, Bytecodes.PUSH_CONSTANT),
+        t(11, new BC(Bytecodes.JUMP_ON_TRUE_TOP_NIL, 14)),
+        t(14, new BC(Bytecodes.PUSH_CONSTANT, 6)),
+        t(17, new BC(Bytecodes.PUSH_CONSTANT, 7)),
+        t(20, new BC(Bytecodes.PUSH_CONSTANT, 8)),
+        t(23, new BC(Bytecodes.PUSH_CONSTANT, 9)));
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testIfInlineAndConstantBcLength() {
+    byte[] bytecodes = methodToBytecodes(
+        " test = (\n"
+            + "  #a. #b. #c.\n"
+            + "  true ifTrue: [\n"
+            + "    true ifFalse: [ #e. #f. #g ] ]\n"
+            + ")");
+
+    assertEquals(Bytecodes.JUMP_ON_TRUE_TOP_NIL, bytecodes[13]);
+    assertEquals("jump offset, should point to correct bytecode"
+        + " and not be affected by changing length of bytecodes in the block",
+        11, bytecodes[14]);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockDupPopArgumentPopReturnArg() {
+    byte[] bytecodes = blockToBytecodes("[:arg | arg := 1. arg ]");
+
+    assertEquals(8, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP_ARGUMENT,
+        t(4, Bytecodes.PUSH_ARGUMENT),
+        Bytecodes.RETURN_LOCAL);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockDupPopArgumentPopImplicitReturn() {
+    byte[] bytecodes = blockToBytecodes("[:arg | arg := 1 ]");
+
+    assertEquals(6, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.DUP,
+        Bytecodes.POP_ARGUMENT,
+        Bytecodes.RETURN_LOCAL);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockDupPopArgumentPopImplicitReturnDot() {
+    byte[] bytecodes = blockToBytecodes("[:arg | arg := 1. ]");
+
+    assertEquals(6, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.DUP,
+        Bytecodes.POP_ARGUMENT,
+        Bytecodes.RETURN_LOCAL);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockDupPopLocalReturnLocal() {
+    byte[] bytecodes = blockToBytecodes("[| local | local := 1 ]");
+
+    assertEquals(6, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.DUP,
+        Bytecodes.POP_LOCAL,
+        Bytecodes.RETURN_LOCAL);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockDupFieldReturnLocal() {
+    addField("field");
+    byte[] bytecodes = blockToBytecodes("[ field := 1 ]");
+
+    assertEquals(6, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.DUP,
+        Bytecodes.POP_FIELD,
+        Bytecodes.RETURN_LOCAL);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockDupFieldReturnLocalDot() {
+    addField("field");
+    byte[] bytecodes = blockToBytecodes("[ field := 1. ]");
+
+    assertEquals(6, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.DUP,
+        Bytecodes.POP_FIELD,
+        Bytecodes.RETURN_LOCAL);
+  }
+
+  private void blockIfReturnNonLocal(final String sel, final byte jumpBytecode) {
+    byte[] bytecodes = blockToBytecodes("[:arg |\n"
+        + " #start.\n"
+        + " self method " + sel + " [ ^ arg ].\n"
+        + " #end\n"
+        + "]");
+
+    assertEquals(19, bytecodes.length);
+    check(bytecodes,
+        t(5, Bytecodes.SEND),
+        new BC(jumpBytecode, 8),
+        new BC(Bytecodes.PUSH_ARGUMENT, 1, 0),
+        new BC(Bytecodes.RETURN_NON_LOCAL, 1),
+        Bytecodes.POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testBlockIfReturnNonLocal() {
+    blockIfReturnNonLocal("ifTrue:", Bytecodes.JUMP_ON_FALSE_TOP_NIL);
+    blockIfReturnNonLocal("ifFalse:", Bytecodes.JUMP_ON_TRUE_TOP_NIL);
+  }
+
+  private void whileInlining(final String sel, final byte jumpBytecode) {
+    byte[] bytecodes = methodToBytecodes(
+        "test: arg = (\n"
+            + "  #start.\n"
+            + "  [ true ] " + sel + " [ arg ].\n"
+            + "  #end\n"
+            + ")");
+
+    assertEquals(19, bytecodes.length);
+    check(bytecodes,
+        t(2, Bytecodes.PUSH_CONSTANT),
+        jumpBytecode,
+        Bytecodes.PUSH_ARGUMENT,
+        Bytecodes.POP,
+        new BC(Bytecodes.JUMP_BACKWARDS, 9),
+        Bytecodes.PUSH_CONSTANT, // TODO: push_nil
+        Bytecodes.POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testWhileInlining() {
+    whileInlining("whileTrue:", Bytecodes.JUMP_ON_FALSE_POP);
+    whileInlining("whileFalse:", Bytecodes.JUMP_ON_TRUE_POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testInliningWhileLoopWithExpandingBranches() {
+    byte[] bytecodes = methodToBytecodes(
+        "test = (\n"
+            + "  #const0. #const1. #const2.\n"
+            + "  0 ifTrue: [\n"
+            + "    [ #const3. #const4. #const5 ]\n"
+            + "       whileTrue: [\n"
+            + "         #const6. #const7. #const8 ]\n"
+            + "    ].\n"
+            + "    ^ #end\n"
+            + ")");
+
+    assertEquals(38, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 27,
+            "jump to the pop BC after the if/right before the push #end"),
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        new BC(Bytecodes.JUMP_ON_FALSE_POP, 15,
+            "jump to push_nil as result of whileTrue"),
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP,
+        new BC(Bytecodes.JUMP_BACKWARDS, 20,
+            "jump to push_nil as result of whileTrue"),
+
+        Bytecodes.PUSH_ARGUMENT,
+        Bytecodes.POP,
+        new BC(Bytecodes.JUMP_BACKWARDS, 9,
+            "jump back to the first push constant in the condition, pushing const3"),
+        Bytecodes.PUSH_CONSTANT, // TODO: push_nil
+        Bytecodes.POP);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testInliningWhileLoopWithContractingBranches() {
+    byte[] bytecodes = methodToBytecodes(
+        "test = (\n"
+            + " 0 ifTrue: [\n"
+            + "   [ ^ 1 ]\n"
+            + "     whileTrue: [\n"
+            + "         ^ 0 ]\n"
+            + " ].\n"
+            + " ^ #end\n"
+            + ")");
+
+    assertEquals(19, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        new BC(Bytecodes.JUMP_ON_FALSE_TOP_NIL, 15,
+            "jump to the pop after the if, before pushing #end"),
+
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.RETURN_LOCAL,
+
+        new BC(Bytecodes.JUMP_ON_FALSE_POP, 9,
+            "jump to push_nil as result of whileTrue"),
+
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.RETURN_LOCAL,
+        Bytecodes.POP,
+
+        new BC(Bytecodes.JUMP_BACKWARDS, 8,
+            "jump to the push_1 of the condition"),
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.POP);
+  }
+
+  private void inliningOfAnd(final String sel) {
+    byte[] bytecodes = methodToBytecodes(
+        "test = ( true " + sel + " [ #val ] )");
+
+    assertEquals(12, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_GLOBAL,
+        new BC(Bytecodes.JUMP_ON_FALSE_POP, 7),
+        // true branch
+        Bytecodes.PUSH_CONSTANT, // push the `#val`
+        new BC(Bytecodes.JUMP, 5),
+        // false branch, jump_on_false target, push false
+        Bytecodes.PUSH_CONSTANT,
+        // target of the jump in the true branch
+        Bytecodes.RETURN_SELF);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testInliningOfAnd() {
+    inliningOfAnd("and:");
+    inliningOfAnd("&&");
+  }
+
+  private void inliningOfOr(final String sel) {
+    byte[] bytecodes = methodToBytecodes(
+        "test = ( true " + sel + " [ #val ] )");
+
+    assertEquals(12, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_GLOBAL,
+        new BC(Bytecodes.JUMP_ON_TRUE_POP, 7),
+        // true branch
+        Bytecodes.PUSH_CONSTANT, // push the `#val`
+        new BC(Bytecodes.JUMP, 5),
+        // false branch, jump_on_false target, push false
+        Bytecodes.PUSH_CONSTANT,
+        // target of the jump in the true branch
+        Bytecodes.RETURN_SELF);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testInliningOfOr() {
+    inliningOfOr("or:");
+    inliningOfOr("||");
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testFieldReadInlining() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test = ( true and: [ field ] )");
+
+    assertEquals(11, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_GLOBAL,
+        new BC(Bytecodes.JUMP_ON_FALSE_POP, 7),
+        // true branch
+        Bytecodes.PUSH_FIELD,
+        new BC(Bytecodes.JUMP, 4),
+        // false branch, jump_on_false target, push false
+        Bytecodes.PUSH_CONSTANT,
+        // target of the jump in the true branch
+        Bytecodes.RETURN_SELF);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testInliningOfToDo() {
+    byte[] bytecodes = methodToBytecodes(
+        "test = ( 1 to: 2 do: [:i | i ] )");
+
+    assertEquals(21, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.PUSH_CONSTANT,
+        -1, // TODO: Bytecodes.DUP_SECOND, // stack: Top[1, 2, 1]
+        -1, // TODO new BC(Bytecodes.jump_if_greater, 17), // consume only on jump
+        Bytecodes.DUP,
+        new BC(Bytecodes.POP_LOCAL, 0, 0), // store the i into the local (arg becomes local
+                                           // after inlining)
+        new BC(Bytecodes.PUSH_LOCAL, 0, 0), // push the local on the stack as part of the
+                                            // block's code
+        Bytecodes.POP, // cleanup after block.
+        Bytecodes.INC, // increment top, the iteration counter
+        -1, // TODO: Bytecodes.nil_local,
+        new BC(Bytecodes.JUMP_BACKWARDS, 14), // jump back to the jump_if_greater bytecode
+        // jump_if_greater target
+        Bytecodes.RETURN_SELF);
+  }
+
+  @Ignore("TODO")
+  @Test
+  public void testToDoBlockBlockInlinedSelf() {
+    addField("field");
+    byte[] bytecodes = methodToBytecodes(
+        "test = (\n"
+            + " | l1 l2 |\n"
+            + " 1 to: 2 do: [:a |\n"
+            + "   l1 do: [:b |\n"
+            + "     b ifTrue: [\n"
+            + "       a.\n"
+            + "       l2 := l2 + 1 ] ] ]\n"
+            + ")");
+
+    assertEquals(25, bytecodes.length);
+    check(bytecodes,
+        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.PUSH_CONSTANT,
+        -1, // TODO: Bytecodes.DUP_SECOND, // stack: Top[1, 2, 1]
+        -1, // TODO new BC(Bytecodes.jump_if_greater, 21), // consume only on jump
+        Bytecodes.DUP,
+        new BC(Bytecodes.POP_LOCAL, 2, 0), // store the i into the local (arg becomes local
+                                           // after inlining)
+        new BC(Bytecodes.PUSH_LOCAL, 0, 0), // push the local on the stack as part of the
+                                            // block's code
+        new BC(Bytecodes.PUSH_BLOCK, 2),
+        Bytecodes.SEND,
+        Bytecodes.POP, // cleanup after block.
+        Bytecodes.INC, // increment top, the iteration counter
+        -1, // TODO: Bytecodes.nil_local,
+        new BC(Bytecodes.JUMP_BACKWARDS, 10), // jump back to the jump_if_greater bytecode
+        // jump_if_greater target
+        Bytecodes.RETURN_SELF);
+
+    // TODO: fix bcIdx to the PUSH_BLOCK bc
+    SMethod blockMethod = (SMethod) mgenc.getConstant(-1);
+
+    check(
+        read(blockMethod.getInvokable(), "expressionOrSequence",
+            BytecodeLoopNode.class).getBytecodeArray(),
+        t(6, new BC(Bytecodes.PUSH_LOCAL, 2, 1, "local b")),
+        Bytecodes.POP);
+  }
 }
-
-/**
- * <pre>
-
-
-
-
-def test_block_dup_pop_field_return_local_dot(cgenc, bgenc):
-    add_field(cgenc, "field")
-    bytecodes = block_to_bytecodes(bgenc, "[ field := 1. ]")
-
-    assert len(bytecodes) == 6
-    assert Bytecodes.push_1 == bytecodes[0]
-    assert Bytecodes.dup == bytecodes[1]
-    assert Bytecodes.pop_field == bytecodes[2]
-    assert Bytecodes.return_local == bytecodes[5]
- * </pre>
- */

--- a/tests/trufflesom/tests/TruffleTestSetup.java
+++ b/tests/trufflesom/tests/TruffleTestSetup.java
@@ -1,0 +1,101 @@
+package trufflesom.tests;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Context.Builder;
+import org.junit.Ignore;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.Source;
+
+import bd.tools.structure.StructuralProbe;
+import trufflesom.compiler.ClassGenerationContext;
+import trufflesom.compiler.Field;
+import trufflesom.compiler.Variable;
+import trufflesom.interpreter.SomLanguage;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.literals.BlockNode;
+import trufflesom.interpreter.objectstorage.StorageAnalyzer;
+import trufflesom.vm.Universe;
+import trufflesom.vmobjects.SClass;
+import trufflesom.vmobjects.SInvokable;
+import trufflesom.vmobjects.SSymbol;
+
+
+@Ignore("provides just setup")
+public class TruffleTestSetup {
+  protected final ClassGenerationContext cgenc;
+
+  protected final Universe universe;
+
+  protected final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe;
+
+  private static Universe getUniverse() {
+    return SomLanguage.getCurrent().getUniverse();
+  }
+
+  protected TruffleTestSetup() {
+    universe = getUniverse();
+    probe = null;
+
+    cgenc = new ClassGenerationContext(universe, null);
+    cgenc.setName(universe.symbolFor("Test"));
+  }
+
+  private static void initTruffle() {
+    StorageAnalyzer.initAccessors();
+
+    Builder builder = Universe.createContextBuilder();
+    builder.logHandler(System.err);
+
+    Context context = builder.build();
+    context.eval(SomLanguage.INIT);
+
+    Universe u = getUniverse();
+    Source s = SomLanguage.getSyntheticSource("self", "self");
+    u.selfSource = s.createSection(1);
+  }
+
+  protected void addField(final String name) {
+    cgenc.addInstanceField(universe.symbolFor(name), null);
+  }
+
+  private java.lang.reflect.Field lookup(final Class<?> cls, final String fieldName) {
+    try {
+      return cls.getDeclaredField(fieldName);
+    } catch (NoSuchFieldException e) {
+      if (cls.getSuperclass() != null) {
+        return lookup(cls.getSuperclass(), fieldName);
+      }
+    } catch (SecurityException e) {
+      throw new RuntimeException(e);
+    }
+    throw new RuntimeException("Didn't find field: " + fieldName);
+  }
+
+  protected Node read(final Object obj, final String fieldName) {
+    return read(obj, fieldName, Node.class);
+  }
+
+  protected ExpressionNode read(final Object obj, final String fieldName, final int idx) {
+    return read(obj, fieldName, ExpressionNode[].class)[idx];
+  }
+
+  protected ExpressionNode[] getBlockExprs(final BlockNode blockNode) {
+    return read(read(blockNode.getMethod().getInvokable(), "expressionOrSequence"),
+        "expressions", ExpressionNode[].class);
+  }
+
+  protected <T> T read(final Object obj, final String fieldName, final Class<T> c) {
+    java.lang.reflect.Field field = lookup(obj.getClass(), fieldName);
+    field.setAccessible(true);
+    try {
+      return c.cast(field.get(obj));
+    } catch (IllegalAccessException | IllegalArgumentException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static {
+    initTruffle();
+  }
+}


### PR DESCRIPTION
This adds PySOM's test, but ignores most of them for the moment, because the two implementations don't yet behave consistently.

There a few more fixes:
 - remove `None` from symbol list
 - fix stack depth of `jump_on_*_pop` bytecodes
 - some cleanups