### PR TITLE
Inline #||, #&&, and #ifFalse:ifTrue: and sync increment node tests with PySOM

### DIFF
--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -17,6 +17,7 @@ import static trufflesom.interpreter.SNodeFactory.createSequence;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.oracle.truffle.api.source.Source;
@@ -245,8 +246,17 @@ public class ParserAst extends Parser<MethodGenerationContext> {
     SSymbol msg = binarySelector();
     ExpressionNode operand = binaryOperand(mgenc);
 
-    ExpressionNode[] args = new ExpressionNode[] {receiver, operand};
     SourceSection source = getSource(coord);
+
+    ExpressionNode inlined =
+        inlinableNodes.inline(msg, Arrays.asList(receiver, operand), mgenc, source);
+    if (inlined != null) {
+      assert !isSuperSend;
+      return inlined;
+    }
+
+    ExpressionNode[] args = new ExpressionNode[] {receiver, operand};
+
     if (isSuperSend) {
       return MessageSendNode.createSuperSend(
           mgenc.getHolder().getSuperClass(), msg, args, source);

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -40,6 +40,7 @@ import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
 import trufflesom.interpreter.nodes.literals.LiteralNode;
 import trufflesom.interpreter.nodes.literals.StringLiteralNode;
 import trufflesom.interpreter.nodes.literals.SymbolLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IntIncrementNodeGen;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SArray;
@@ -260,6 +261,11 @@ public class ParserAst extends Parser<MethodGenerationContext> {
     if (isSuperSend) {
       return MessageSendNode.createSuperSend(
           mgenc.getHolder().getSuperClass(), msg, args, source);
+    } else if (msg.getString().equals("+") && operand instanceof IntegerLiteralNode) {
+      IntegerLiteralNode lit = (IntegerLiteralNode) operand;
+      if (lit.executeLong(null) == 1) {
+        return IntIncrementNodeGen.create(receiver);
+      }
     }
     return MessageSendNode.create(msg, args, source, universe);
   }

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -182,7 +182,7 @@ public abstract class GlobalNode extends ExpressionNode
     }
   }
 
-  private static final class TrueGlobalNode extends GlobalNode {
+  public static final class TrueGlobalNode extends GlobalNode {
     TrueGlobalNode(final SSymbol globalName) {
       super(globalName);
     }
@@ -198,7 +198,7 @@ public abstract class GlobalNode extends ExpressionNode
     }
   }
 
-  private static final class FalseGlobalNode extends GlobalNode {
+  public static final class FalseGlobalNode extends GlobalNode {
     FalseGlobalNode(final SSymbol globalName) {
       super(globalName);
     }
@@ -214,7 +214,7 @@ public abstract class GlobalNode extends ExpressionNode
     }
   }
 
-  private static final class NilGlobalNode extends GlobalNode {
+  public static final class NilGlobalNode extends GlobalNode {
     NilGlobalNode(final SSymbol globalName) {
       super(globalName);
     }

--- a/src/trufflesom/interpreter/nodes/MessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/MessageSendNode.java
@@ -16,9 +16,7 @@ import trufflesom.interpreter.nodes.dispatch.AbstractDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.DispatchChain.Cost;
 import trufflesom.interpreter.nodes.dispatch.GenericDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.UninitializedDispatchNode;
-import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
 import trufflesom.interpreter.nodes.nary.EagerlySpecializableNode;
-import trufflesom.interpreter.nodes.specialized.IntIncrementNodeGen;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vm.Universe;
@@ -31,15 +29,6 @@ public final class MessageSendNode {
 
   public static ExpressionNode create(final SSymbol selector,
       final ExpressionNode[] arguments, final SourceSection source, final Universe universe) {
-    if (selector.getString().charAt(0) == '+') {
-      if (arguments[1] instanceof IntegerLiteralNode) {
-        IntegerLiteralNode lit = (IntegerLiteralNode) arguments[1];
-        if (lit.executeLong(null) == 1) {
-          return IntIncrementNodeGen.create(arguments[0]);
-        }
-      }
-    }
-
     Primitives prims = universe.getPrimitives();
     Specializer<Universe, ExpressionNode, SSymbol> specializer =
         prims.getParserSpecializer(selector, arguments);

--- a/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseInlinedLiteralsNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseInlinedLiteralsNode.java
@@ -19,8 +19,7 @@ import trufflesom.interpreter.nodes.ExpressionNode;
  *
  * @author Stefan Marr
  */
-@Inline(selector = "ifTrue:ifFalse:", inlineableArgIdx = {1, 2})
-public final class IfTrueIfFalseInlinedLiteralsNode extends ExpressionNode {
+public abstract class IfTrueIfFalseInlinedLiteralsNode extends ExpressionNode {
   private final ConditionProfile condProf = ConditionProfile.createCountingProfile();
 
   @Child private ExpressionNode conditionNode;
@@ -58,6 +57,26 @@ public final class IfTrueIfFalseInlinedLiteralsNode extends ExpressionNode {
       return trueNode.executeGeneric(frame);
     } else {
       return falseNode.executeGeneric(frame);
+    }
+  }
+
+  @Inline(selector = "ifTrue:ifFalse:", inlineableArgIdx = {1, 2})
+  public static final class TrueIfElseLiteralNode extends IfTrueIfFalseInlinedLiteralsNode {
+    public TrueIfElseLiteralNode(final ExpressionNode conditionNode,
+        final ExpressionNode originalTrueNode, final ExpressionNode originalFalseNode,
+        final ExpressionNode inlinedTrueNode, final ExpressionNode inlinedFalseNode) {
+      super(conditionNode, originalTrueNode, originalFalseNode, inlinedTrueNode,
+          inlinedFalseNode);
+    }
+  }
+
+  @Inline(selector = "ifFalse:ifTrue:", inlineableArgIdx = {1, 2})
+  public static final class FalseIfElseLiteralNode extends IfTrueIfFalseInlinedLiteralsNode {
+    public FalseIfElseLiteralNode(final ExpressionNode conditionNode,
+        final ExpressionNode originalTrueNode, final ExpressionNode originalFalseNode,
+        final ExpressionNode inlinedTrueNode, final ExpressionNode inlinedFalseNode) {
+      super(conditionNode, originalFalseNode, originalTrueNode, inlinedFalseNode,
+          inlinedTrueNode);
     }
   }
 }

--- a/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/primitives/Primitives.java
@@ -54,7 +54,8 @@ import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.OrInli
 import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfMessageNodeGen.IfFalseMessageNodeFactory;
 import trufflesom.interpreter.nodes.specialized.IfMessageNodeGen.IfTrueMessageNodeFactory;
-import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode;
+import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.FalseIfElseLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.TrueIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseMessageNodeFactory;
 import trufflesom.interpreter.nodes.specialized.IntDownToDoMessageNodeFactory;
 import trufflesom.interpreter.nodes.specialized.IntToByDoMessageNodeFactory;
@@ -309,7 +310,8 @@ public final class Primitives extends PrimitiveLoader<Universe, ExpressionNode, 
     List<Class<? extends Node>> nodes = new ArrayList<>();
 
     nodes.add(IfInlinedLiteralNode.class);
-    nodes.add(IfTrueIfFalseInlinedLiteralsNode.class);
+    nodes.add(TrueIfElseLiteralNode.class);
+    nodes.add(FalseIfElseLiteralNode.class);
     nodes.add(AndInlinedLiteralNode.class);
     nodes.add(OrInlinedLiteralNode.class);
     nodes.add(WhileInlinedLiteralsNode.class);

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -465,7 +465,6 @@ public class AstInliningTests extends TruffleTestSetup {
     return read(seq, "expressions", 0);
   }
 
-  @Ignore("TODO")
   @Test
   public void testInliningOf() {
     assertThat(inliningOf("or:"), instanceOf(OrInlinedLiteralNode.class));

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -38,7 +38,8 @@ import trufflesom.interpreter.nodes.nary.EagerBinaryPrimitiveNode;
 import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.AndInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.OrInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
-import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode;
+import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.FalseIfElseLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.TrueIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IntToDoInlinedLiteralsNode;
 import trufflesom.interpreter.nodes.specialized.whileloops.WhileInlinedLiteralsNode;
 
@@ -340,7 +341,7 @@ public class AstInliningTests extends TruffleTestSetup {
   }
 
   private void ifTrueIfFalseReturn(final String sel1, final String sel2,
-      final boolean expectedBool) {
+      final Class<?> cls) {
     initMgenc();
     SequenceNode seq = (SequenceNode) parseMethod(
         "test: arg1 with: arg2 = (\n"
@@ -348,18 +349,14 @@ public class AstInliningTests extends TruffleTestSetup {
             + "   ^ self method " + sel1 + " [ ^ arg1 ] " + sel2 + " [ arg2 ]\n"
             + "   )");
 
-    fail("TruffleSOM doesn't yet specialize both ifTrue:ifFalse: and ifFalse:ifTrue:");
-
-    IfTrueIfFalseInlinedLiteralsNode ifNode =
-        (IfTrueIfFalseInlinedLiteralsNode) read(seq, "expressions", 1);
-    assertEquals(expectedBool, read(ifNode, "expectedBool", Boolean.class));
+    Node ifNode = read(seq, "expressions", 1);
+    assertThat(ifNode, instanceOf(cls));
   }
 
-  @Ignore("TODO")
   @Test
   public void testIfTrueIfFalseReturn() {
-    ifTrueIfFalseReturn("ifTrue:", "ifFalse:", true);
-    ifTrueIfFalseReturn("ifFalse:", "ifTrue:", false);
+    ifTrueIfFalseReturn("ifTrue:", "ifFalse:", TrueIfElseLiteralNode.class);
+    ifTrueIfFalseReturn("ifFalse:", "ifTrue:", FalseIfElseLiteralNode.class);
   }
 
   private void whileInlining(final String whileSel, final boolean expectedBool) {

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -21,6 +21,9 @@ import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalArgumentReadNode;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldWriteNode;
+import trufflesom.interpreter.nodes.GlobalNode.FalseGlobalNode;
+import trufflesom.interpreter.nodes.GlobalNode.NilGlobalNode;
+import trufflesom.interpreter.nodes.GlobalNode.TrueGlobalNode;
 import trufflesom.interpreter.nodes.GlobalNode.UninitializedGlobalReadNode;
 import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableWriteNode;
 import trufflesom.interpreter.nodes.NonLocalVariableNode.NonLocalVariableReadNode;
@@ -31,7 +34,6 @@ import trufflesom.interpreter.nodes.literals.BlockNode;
 import trufflesom.interpreter.nodes.literals.BlockNode.BlockNodeWithContext;
 import trufflesom.interpreter.nodes.literals.DoubleLiteralNode;
 import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
-import trufflesom.interpreter.nodes.literals.LiteralNode;
 import trufflesom.interpreter.nodes.literals.StringLiteralNode;
 import trufflesom.interpreter.nodes.literals.SymbolLiteralNode;
 import trufflesom.interpreter.nodes.nary.EagerBinaryPrimitiveNode;
@@ -127,7 +129,6 @@ public class AstInliningTests extends TruffleTestSetup {
     assertThat(literal, instanceOf(cls));
   }
 
-  @Ignore("TODO")
   @Test
   public void testIfTrueWithLiteralReturn() {
     literalTest("0", IntegerLiteralNode.class);
@@ -139,10 +140,9 @@ public class AstInliningTests extends TruffleTestSetup {
     literalTest("1.1", DoubleLiteralNode.class);
     literalTest("-2342.234", DoubleLiteralNode.class);
 
-    // TODO: TruffleSOM and PySOM don't yet agree
-    literalTest("true", LiteralNode.class);
-    literalTest("false", LiteralNode.class);
-    literalTest("nil", LiteralNode.class);
+    literalTest("true", TrueGlobalNode.class);
+    literalTest("false", FalseGlobalNode.class);
+    literalTest("nil", NilGlobalNode.class);
 
     literalTest("SomeGlobal", UninitializedGlobalReadNode.class);
     literalTest("[]", BlockNode.class);


### PR DESCRIPTION
This PR fixes missing inlining for `#||` and `#&&` with literal blocks.
It also adds inlining for `#ifFalse:ifTrue:`, and synchronizes the so far ignored AST inlining tests with PySOM, mostly around the increment nodes.