### PR TITLE
Remove second bytecode pass for stack hight and use symbols for checks

### DIFF
--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -275,7 +275,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     }
 
     // Load the super class, if it is not nil (break the dependency cycle)
-    if (!superName.getString().equals("nil")) {
+    if (superName != universe.symNil) {
       SClass superClass = universe.loadClass(superName);
       if (superClass == null) {
         throw new ParseError("Super class " + superName.getString() +

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -175,6 +175,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     if (jumpOffset <= 0xff) {
       bytecode.set(idxOfOffset, (byte) jumpOffset);
+      bytecode.set(idxOfOffset + 1, (byte) 0);
     } else {
       int offsetOfBytecode = idxOfOffset - 1;
       // we need two bytes for the jump offset

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -260,7 +260,7 @@ public class Disassembler {
           int offset1 = Byte.toUnsignedInt(bytecodes.get(b + 1));
           int offset2 = Byte.toUnsignedInt(bytecodes.get(b + 2));
 
-          int offset = offset2 << 8 + offset1;
+          int offset = (offset2 << 8) + offset1;
 
           Universe.errorPrintln(
               "(jump offset: " + offset + " -> jump target: " + (b - offset) + ")");

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -128,7 +128,7 @@ public class Disassembler {
   }
 
   public static void dumpMethod(final BytecodeMethodGenContext mgenc) {
-    dumpMethod(mgenc.getBytecodes(), "", mgenc.getNumberOfLocals(), mgenc.computeStackDepth(),
+    dumpMethod(mgenc.getBytecodes(), "", mgenc.getNumberOfLocals(), mgenc.getStackDepth(),
         null, null);
   }
 

--- a/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/compiler/bc/Disassembler.java
@@ -120,8 +120,11 @@ public class Disassembler {
   }
 
   private static SClass getClass(final BytecodeLoopNode m) {
-    Invokable i = (Invokable) m.getRootNode();
-    return i.getHolder();
+    if (m.getRootNode() instanceof Invokable) {
+      Invokable i = (Invokable) m.getRootNode();
+      return i.getHolder();
+    }
+    return null;
   }
 
   public static void dumpMethod(final BytecodeMethodGenContext mgenc) {

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -109,6 +109,10 @@ public class Bytecodes {
   // Static array holding lengths of each bytecode
   @CompilationFinal(dimensions = 1) private static final int[] BYTECODE_LENGTH;
 
+  @CompilationFinal(dimensions = 1) public static final int[] BYTECODE_STACK_EFFECT;
+
+  public static final int STACK_EFFECT_DEPENDS_ON_MESSAGE = -1000;
+
   static {
     NUM_BYTECODES = Q_SEND_3 + 1;
 
@@ -201,6 +205,54 @@ public class Bytecodes {
         2, // Q_SEND_3
     };
 
+    BYTECODE_STACK_EFFECT = new int[] {
+        0, // HALT
+        1, // DUP
+        1, // PUSH_LOCAL
+        1, // PUSH_ARGUMENT
+        1, // PUSH_FIELD
+        1, // PUSH_BLOCK
+        1, // PUSH_BLOCK_NO_CTX
+        1, // PUSH_CONSTANT
+        1, // PUSH_GLOBAL
+        -1, // POP
+        -1, // POP_LOCAL
+        -1, // POP_ARGUMENT
+        -1, // POP_FIELD
+        STACK_EFFECT_DEPENDS_ON_MESSAGE, // SEND
+        STACK_EFFECT_DEPENDS_ON_MESSAGE, // SUPER_SEND
+        0, // RETURN_LOCAL
+        0, // RETURN_NON_LOCAL
+        0, // RETURN_SELF
+
+        0, // INC
+        0, // DEC
+
+        0, // INC_FIELD
+        0, // INC_FIELD_PUSH
+
+        0, // JUMP
+        0, // JUMP_ON_TRUE_TOP_NIL
+        0, // JUMP_ON_FALSE_TOP_NIL
+        -1, // JUMP_ON_TRUE_POP
+        -1, // JUMP_ON_FALSE_POP
+        0, // JUMP_BACKWARDS
+
+        0, // JUMP2
+        0, // JUMP2_ON_TRUE_TOP_NIL
+        0, // JUMP2_ON_FALSE_TOP_NIL
+        -1, // JUMP2_ON_TRUE_POP
+        -1, // JUMP2_ON_FALSE_POP
+        0, // JUMP2_BACKWARDS
+
+        1, // Q_PUSH_GLOBAL
+        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND
+        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND_1
+        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND_2
+        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND_3
+    };
+
     assert BYTECODE_LENGTH.length == NUM_BYTECODES : "The BYTECODE_LENGTH array is not having the same size as number of bytecodes";
+    assert BYTECODE_STACK_EFFECT.length == NUM_BYTECODES : "The BYTECODE_STACK_EFFECT array is not having the same size as number of bytecodes";
   }
 }

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -109,10 +109,6 @@ public class Bytecodes {
   // Static array holding lengths of each bytecode
   @CompilationFinal(dimensions = 1) private static final int[] BYTECODE_LENGTH;
 
-  @CompilationFinal(dimensions = 1) public static final int[] BYTECODE_STACK_EFFECT;
-
-  public static final int STACK_EFFECT_DEPENDS_ON_MESSAGE = -1000;
-
   static {
     NUM_BYTECODES = Q_SEND_3 + 1;
 
@@ -205,54 +201,6 @@ public class Bytecodes {
         2, // Q_SEND_3
     };
 
-    BYTECODE_STACK_EFFECT = new int[] {
-        0, // HALT
-        1, // DUP
-        1, // PUSH_LOCAL
-        1, // PUSH_ARGUMENT
-        1, // PUSH_FIELD
-        1, // PUSH_BLOCK
-        1, // PUSH_BLOCK_NO_CTX
-        1, // PUSH_CONSTANT
-        1, // PUSH_GLOBAL
-        -1, // POP
-        -1, // POP_LOCAL
-        -1, // POP_ARGUMENT
-        -1, // POP_FIELD
-        STACK_EFFECT_DEPENDS_ON_MESSAGE, // SEND
-        STACK_EFFECT_DEPENDS_ON_MESSAGE, // SUPER_SEND
-        0, // RETURN_LOCAL
-        0, // RETURN_NON_LOCAL
-        0, // RETURN_SELF
-
-        0, // INC
-        0, // DEC
-
-        0, // INC_FIELD
-        0, // INC_FIELD_PUSH
-
-        0, // JUMP
-        0, // JUMP_ON_TRUE_TOP_NIL
-        0, // JUMP_ON_FALSE_TOP_NIL
-        -1, // JUMP_ON_TRUE_POP
-        -1, // JUMP_ON_FALSE_POP
-        0, // JUMP_BACKWARDS
-
-        0, // JUMP2
-        0, // JUMP2_ON_TRUE_TOP_NIL
-        0, // JUMP2_ON_FALSE_TOP_NIL
-        -1, // JUMP2_ON_TRUE_POP
-        -1, // JUMP2_ON_FALSE_POP
-        0, // JUMP2_BACKWARDS
-
-        1, // Q_PUSH_GLOBAL
-        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND
-        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND_1
-        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND_2
-        STACK_EFFECT_DEPENDS_ON_MESSAGE, // Q_SEND_3
-    };
-
     assert BYTECODE_LENGTH.length == NUM_BYTECODES : "The BYTECODE_LENGTH array is not having the same size as number of bytecodes";
-    assert BYTECODE_STACK_EFFECT.length == NUM_BYTECODES : "The BYTECODE_STACK_EFFECT array is not having the same size as number of bytecodes";
   }
 }

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -44,17 +44,17 @@ public abstract class GlobalNode extends ExpressionNode
     implements Invocation<SSymbol>, PreevaluatedExpression {
 
   public static boolean isPotentiallyUnknown(final SSymbol global, final Universe universe) {
-    return global != universe.symNil && !global.getString().equals("true")
-        && !global.getString().equals("false") && !universe.hasGlobal(global);
+    return global != universe.symNil && global != universe.symTrue
+        && global != universe.symFalse && !universe.hasGlobal(global);
   }
 
   public static GlobalNode create(final SSymbol globalName, final Universe universe,
       final MethodGenerationContext mgenc) {
     if (globalName == universe.symNil) {
       return new NilGlobalNode(globalName);
-    } else if (globalName.getString().equals("true")) {
+    } else if (globalName == universe.symTrue) {
       return new TrueGlobalNode(globalName);
-    } else if (globalName.getString().equals("false")) {
+    } else if (globalName == universe.symFalse) {
       return new FalseGlobalNode(globalName);
     }
 

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1013,7 +1013,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
       switch (bytecode) {
         case HALT:
         case DUP: {
-          emit1(mgenc, bytecode);
+          emit1(mgenc, bytecode, bytecode == HALT ? 0 : 1);
           break;
         }
 
@@ -1029,7 +1029,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case PUSH_FIELD: {
           byte argIdx = bytecodes[i + 1];
           byte contextIdx = bytecodes[i + 2];
-          emit3(mgenc, bytecode, argIdx, (byte) (contextIdx - 1));
+          emit3(mgenc, bytecode, argIdx, (byte) (contextIdx - 1), 1);
           break;
         }
 
@@ -1083,7 +1083,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case POP_FIELD: {
           byte argIdx = bytecodes[i + 1];
           byte contextIdx = bytecodes[i + 2];
-          emit3(mgenc, bytecode, argIdx, (byte) (contextIdx - 1));
+          emit3(mgenc, bytecode, argIdx, (byte) (contextIdx - 1), -1);
           break;
         }
 
@@ -1130,7 +1130,7 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
 
         case INC:
         case DEC: {
-          emit1(mgenc, bytecode);
+          emit1(mgenc, bytecode, 0);
           break;
         }
 
@@ -1138,25 +1138,32 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case INC_FIELD_PUSH: {
           byte fieldIdx = bytecodes[i + 1];
           byte contextIdx = bytecodes[i + 2];
-          emit3(mgenc, bytecode, fieldIdx, (byte) (contextIdx - 1));
+          emit3(mgenc, bytecode, fieldIdx, (byte) (contextIdx - 1),
+              bytecode == INC_FIELD ? 0 : 1);
           break;
         }
 
         case JUMP:
         case JUMP_ON_TRUE_TOP_NIL:
         case JUMP_ON_FALSE_TOP_NIL:
-        case JUMP_ON_TRUE_POP:
-        case JUMP_ON_FALSE_POP:
         case JUMP_BACKWARDS:
         case JUMP2:
         case JUMP2_ON_TRUE_TOP_NIL:
         case JUMP2_ON_FALSE_TOP_NIL:
-        case JUMP2_ON_TRUE_POP:
-        case JUMP2_ON_FALSE_POP:
         case JUMP2_BACKWARDS: {
           byte offset1 = bytecodes[i + 1];
           byte offset2 = bytecodes[i + 2];
-          emit3(mgenc, bytecode, offset1, offset2);
+          emit3(mgenc, bytecode, offset1, offset2, 0);
+          break;
+        }
+
+        case JUMP_ON_TRUE_POP:
+        case JUMP_ON_FALSE_POP:
+        case JUMP2_ON_TRUE_POP:
+        case JUMP2_ON_FALSE_POP: {
+          byte offset1 = bytecodes[i + 1];
+          byte offset2 = bytecodes[i + 2];
+          emit3(mgenc, bytecode, offset1, offset2, -1);
           break;
         }
 

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -182,6 +182,8 @@ public final class Universe implements IdProvider<SSymbol> {
     this.primitives = new Primitives(this);
 
     symNil = symbolFor("nil");
+    symTrue = symbolFor("true");
+    symFalse = symbolFor("false");
     symSelf = symbolFor("self");
     symBlockSelf = symbolFor("$blockSelf");
     symSuper = symbolFor("super");
@@ -753,6 +755,8 @@ public final class Universe implements IdProvider<SSymbol> {
   @CompilationFinal private SClass systemClass;
 
   public final SSymbol symNil;
+  public final SSymbol symTrue;
+  public final SSymbol symFalse;
   public final SSymbol symSelf;
   public final SSymbol symBlockSelf;
   public final SSymbol symFrameOnStack;


### PR DESCRIPTION
This PR removes the second pass over the bytecode to compute the stack hight.
This doesn't seem to have any measurable performance impact, but avoids a bit of code duplication.
I also tried using a lookup array as in PySOM, but no significant performance difference.

However, this PR also uses symbols to check for specialization opportunities, instead of using string comparison.
For some reason, this turns out to be a bit slower.
Don't really understand why, but it might lead to issue in the symbol table? Haven't investigated it further.

Though, I'll leave it in, since it seems a semantically useful change.