### PR TITLE
Make symbol table global, to avoid indirection to universe

### DIFF
--- a/src/trufflesom/compiler/ClassGenerationContext.java
+++ b/src/trufflesom/compiler/ClassGenerationContext.java
@@ -24,6 +24,8 @@
  */
 package trufflesom.compiler;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -186,7 +188,7 @@ public final class ClassGenerationContext {
     // Initialize the class of the resulting class
     resultClass.setInstanceFields(classFields);
     resultClass.setInstanceInvokables(classMethods, classHasPrimitives);
-    resultClass.setName(universe.symbolFor(ccname));
+    resultClass.setName(symbolFor(ccname));
 
     SClass superMClass = superClass == null ? null : superClass.getSOMClass(universe);
     resultClass.setSuperClass(superMClass);

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -56,6 +56,11 @@ import static trufflesom.compiler.Symbol.Primitive;
 import static trufflesom.compiler.Symbol.STString;
 import static trufflesom.compiler.Symbol.Separator;
 import static trufflesom.compiler.Symbol.Star;
+import static trufflesom.vm.SymbolTable.symBlockSelf;
+import static trufflesom.vm.SymbolTable.symNil;
+import static trufflesom.vm.SymbolTable.symObject;
+import static trufflesom.vm.SymbolTable.symSelf;
+import static trufflesom.vm.SymbolTable.symbolFor;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -224,7 +229,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
       StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe);
 
   public void classdef(final ClassGenerationContext cgenc) throws ProgramDefinitionError {
-    cgenc.setName(universe.symbolFor(text));
+    cgenc.setName(symbolFor(text));
     SourceCoordinate coord = getCoordinate();
     if ("Object".equals(text)) {
       universe.selfSource = getSource(coord);
@@ -268,14 +273,14 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
   private void superclass(final ClassGenerationContext cgenc) throws ParseError {
     SSymbol superName;
     if (sym == Identifier) {
-      superName = universe.symbolFor(text);
+      superName = symbolFor(text);
       accept(Identifier);
     } else {
-      superName = universe.symbolFor("Object");
+      superName = symObject;
     }
 
     // Load the super class, if it is not nil (break the dependency cycle)
-    if (superName != universe.symNil) {
+    if (superName != symNil) {
       SClass superClass = universe.loadClass(superName);
       if (superClass == null) {
         throw new ParseError("Super class " + superName.getString() +
@@ -392,7 +397,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     expect(NewBlock);
     SourceCoordinate coord = getCoordinate();
 
-    mgenc.addArgumentIfAbsent(universe.symBlockSelf, getEmptySource());
+    mgenc.addArgumentIfAbsent(symBlockSelf, getEmptySource());
 
     if (sym == Colon) {
       blockPattern(mgenc);
@@ -411,7 +416,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
 
   private void pattern(final MGenC mgenc) throws ProgramDefinitionError {
     assert universe.selfSource != null;
-    mgenc.addArgumentIfAbsent(universe.symSelf, universe.selfSource);
+    mgenc.addArgumentIfAbsent(symSelf, universe.selfSource);
     switch (sym) {
       case Identifier:
       case Primitive:
@@ -444,7 +449,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
       mgenc.addArgumentIfAbsent(argument(), getSource(coord));
     } while (sym == Keyword);
 
-    mgenc.setSignature(universe.symbolFor(kw.toString()));
+    mgenc.setSignature(symbolFor(kw.toString()));
   }
 
   protected SSymbol unarySelector() throws ParseError {
@@ -464,7 +469,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     } else { expect(NONE); }
     // Checkstyle: resume @formatter:on
 
-    return universe.symbolFor(s);
+    return symbolFor(s);
   }
 
   private SSymbol identifier() throws ParseError {
@@ -473,7 +478,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     if (!isPrimitive) {
       expect(Identifier);
     }
-    return universe.symbolFor(s);
+    return symbolFor(s);
   }
 
   protected String keyword() throws ParseError {
@@ -597,7 +602,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
     expect(Pound);
     if (sym == STString) {
       String s = string();
-      symb = universe.symbolFor(s);
+      symb = symbolFor(s);
     } else {
       symb = selector();
     }
@@ -621,7 +626,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
   private SSymbol keywordSelector() throws ParseError {
     String s = new String(text);
     expectOneOf(keywordSelectorSyms);
-    SSymbol symb = universe.symbolFor(s);
+    SSymbol symb = symbolFor(s);
     return symb;
   }
 

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -14,6 +14,10 @@ import static trufflesom.compiler.Symbol.OperatorSequence;
 import static trufflesom.compiler.Symbol.Period;
 import static trufflesom.compiler.Symbol.Pound;
 import static trufflesom.interpreter.SNodeFactory.createSequence;
+import static trufflesom.vm.SymbolTable.symNil;
+import static trufflesom.vm.SymbolTable.symSelf;
+import static trufflesom.vm.SymbolTable.symSuper;
+import static trufflesom.vm.SymbolTable.symbolFor;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -87,7 +91,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
       } else if (sym == EndTerm) {
         // the end of the method has been found (EndTerm) - make it implicitly return "self"
         ExpressionNode self =
-            variableRead(mgenc, universe.symSelf, getSource(getCoordinate()));
+            variableRead(mgenc, symSelf, getSource(getCoordinate()));
         expressions.add(self);
         return createSequenceNode(coord, expressions);
       }
@@ -104,7 +108,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
   private ExpressionNode createSequenceNode(final SourceCoordinate coord,
       final List<ExpressionNode> expressions) {
     if (expressions.size() == 0) {
-      return GlobalNode.create(universe.symNil, universe, null).initialize(getSource(coord));
+      return GlobalNode.create(symNil, universe, null).initialize(getSource(coord));
     } else if (expressions.size() == 1) {
       return expressions.get(0);
     }
@@ -285,7 +289,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
       arguments.add(formula(mgenc));
     } while (sym == Keyword);
 
-    SSymbol msg = universe.symbolFor(kw.toString());
+    SSymbol msg = symbolFor(kw.toString());
 
     SourceSection source = getSource(coord);
 
@@ -385,7 +389,7 @@ public class ParserAst extends Parser<MethodGenerationContext> {
         return literalDouble(isNegativeNumber());
       case Identifier:
         expect(Identifier);
-        return universe.getGlobal(universe.symbolFor(text));
+        return universe.getGlobal(symbolFor(text));
       default:
         throw new ParseError("Could not parse literal array value", NONE, this);
     }
@@ -399,11 +403,11 @@ public class ParserAst extends Parser<MethodGenerationContext> {
         SourceCoordinate coord = getCoordinate();
         SSymbol v = variable();
 
-        if (v == universe.symSuper) {
+        if (v == symSuper) {
           assert !superSend : "Since super is consumed directly, it should never be true here";
           superSend = true;
           // sends to super push self as the receiver
-          v = universe.symSelf;
+          v = symSelf;
         }
 
         return variableRead(mgenc, v, getSource(coord));

--- a/src/trufflesom/compiler/Variable.java
+++ b/src/trufflesom/compiler/Variable.java
@@ -7,6 +7,9 @@ import static trufflesom.compiler.bc.BytecodeGenerator.emitPUSHLOCAL;
 import static trufflesom.interpreter.SNodeFactory.createArgumentRead;
 import static trufflesom.interpreter.SNodeFactory.createArgumentWrite;
 import static trufflesom.interpreter.TruffleCompiler.transferToInterpreterAndInvalidate;
+import static trufflesom.vm.SymbolTable.symBlockSelf;
+import static trufflesom.vm.SymbolTable.symSelf;
+import static trufflesom.vm.SymbolTable.symbolFor;
 
 import java.util.Objects;
 
@@ -42,8 +45,8 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
   }
 
   /** Gets the name including lexical location. */
-  public final SSymbol getQualifiedName(final Universe u) {
-    return u.symbolFor(name.getString() + Universe.getLocationQualifier(source));
+  public final SSymbol getQualifiedName() {
+    return symbolFor(name.getString() + Universe.getLocationQualifier(source));
   }
 
   @Override
@@ -96,7 +99,7 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     }
 
     public boolean isSelf(final Universe universe) {
-      return universe.symSelf == name || universe.symBlockSelf == name;
+      return symSelf == name || symBlockSelf == name;
     }
 
     @Override

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -29,6 +29,7 @@ import static trufflesom.interpreter.bc.Bytecodes.PUSH_GLOBAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_LOCAL;
 import static trufflesom.interpreter.bc.Bytecodes.RETURN_SELF;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeLength;
+import static trufflesom.vm.SymbolTable.symSelf;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -556,7 +557,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
 
     byte idx = getIndex(1);
     // because we don't handle block methods, we don't need to worry about ctx > 0
-    return new FieldReadNode(new LocalArgumentReadNode(arguments.get(universe.symSelf)), idx);
+    return new FieldReadNode(new LocalArgumentReadNode(arguments.get(symSelf)), idx);
   }
 
   private static int expectedSetterMethodLength =

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -21,6 +21,10 @@
  */
 package trufflesom.interpreter.nodes;
 
+import static trufflesom.vm.SymbolTable.symFalse;
+import static trufflesom.vm.SymbolTable.symNil;
+import static trufflesom.vm.SymbolTable.symTrue;
+
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
@@ -44,17 +48,17 @@ public abstract class GlobalNode extends ExpressionNode
     implements Invocation<SSymbol>, PreevaluatedExpression {
 
   public static boolean isPotentiallyUnknown(final SSymbol global, final Universe universe) {
-    return global != universe.symNil && global != universe.symTrue
-        && global != universe.symFalse && !universe.hasGlobal(global);
+    return global != symNil && global != symTrue
+        && global != symFalse && !universe.hasGlobal(global);
   }
 
   public static GlobalNode create(final SSymbol globalName, final Universe universe,
       final MethodGenerationContext mgenc) {
-    if (globalName == universe.symNil) {
+    if (globalName == symNil) {
       return new NilGlobalNode(globalName);
-    } else if (globalName == universe.symTrue) {
+    } else if (globalName == symTrue) {
       return new TrueGlobalNode(globalName);
-    } else if (globalName == universe.symFalse) {
+    } else if (globalName == symFalse) {
       return new FalseGlobalNode(globalName);
     }
 

--- a/src/trufflesom/interpreter/nodes/dispatch/CachedDnuNode.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/CachedDnuNode.java
@@ -1,5 +1,7 @@
 package trufflesom.interpreter.nodes.dispatch;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -45,7 +47,7 @@ public final class CachedDnuNode extends AbstractCachedDispatchNode {
 
   public static CallTarget getDnuCallTarget(final SClass rcvrClass, final Universe universe) {
     return rcvrClass.lookupInvokable(
-        universe.symbolFor("doesNotUnderstand:arguments:")).getCallTarget();
+        symbolFor("doesNotUnderstand:arguments:")).getCallTarget();
   }
 
   protected Object performDnu(final Object[] arguments, final Object rcvr) {

--- a/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/primitives/Primitives.java
@@ -25,6 +25,8 @@
 
 package trufflesom.primitives;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -148,7 +150,7 @@ public final class Primitives extends PrimitiveLoader<Universe, ExpressionNode, 
 
     if (probe != null) {
       String id = prim.getIdentifier();
-      probe.recordNewMethod(lang.getUniverse().symbolFor(id), prim);
+      probe.recordNewMethod(symbolFor(id), prim);
     }
     return prim;
   }

--- a/src/trufflesom/primitives/basics/StringPrims.java
+++ b/src/trufflesom/primitives/basics/StringPrims.java
@@ -1,5 +1,7 @@
 package trufflesom.primitives.basics;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -47,7 +49,7 @@ public class StringPrims {
   public abstract static class AsSymbolPrim extends UnarySystemOperation {
     @Specialization
     public final SAbstractObject doString(final String receiver) {
-      return universe.symbolFor(receiver);
+      return symbolFor(receiver);
     }
 
     @Specialization

--- a/src/trufflesom/vm/Shell.java
+++ b/src/trufflesom/vm/Shell.java
@@ -25,6 +25,8 @@
 
 package trufflesom.vm;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
@@ -82,7 +84,7 @@ public class Shell {
           myObject = new SObject(myClass);
 
           // Lookup the run: method
-          SInvokable shellMethod = myClass.lookupInvokable(universe.symbolFor("run:"));
+          SInvokable shellMethod = myClass.lookupInvokable(symbolFor("run:"));
 
           // Invoke the run method
           it = shellMethod.invoke(new Object[] {myObject, it});

--- a/src/trufflesom/vm/SymbolTable.java
+++ b/src/trufflesom/vm/SymbolTable.java
@@ -1,0 +1,69 @@
+package trufflesom.vm;
+
+import java.util.HashMap;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
+import trufflesom.primitives.Primitives;
+import trufflesom.vmobjects.SSymbol;
+
+
+public class SymbolTable {
+  private static final HashMap<String, SSymbol> symbolTable;
+
+  public static final SSymbol symNil;
+  public static final SSymbol symTrue;
+  public static final SSymbol symFalse;
+  public static final SSymbol symSelf;
+  public static final SSymbol symBlockSelf;
+  public static final SSymbol symFrameOnStack;
+  public static final SSymbol symSuper;
+
+  public static final SSymbol symObject;
+  public static final SSymbol symArray;
+  public static final SSymbol symNewMsg;
+  public static final SSymbol symAtPutMsg;
+  public static final SSymbol symArraySizePlaceholder;
+
+  public static final SSymbol symPlus;
+  public static final SSymbol symMinus;
+
+  @TruffleBoundary
+  public static SSymbol symbolFor(final String string) {
+    String interned = string.intern();
+    // Lookup the symbol in the symbol table
+    SSymbol result = symbolTable.get(interned);
+    if (result != null) {
+      return result;
+    }
+
+    result = new SSymbol(interned);
+    symbolTable.put(interned, result);
+    return result;
+  }
+
+  static {
+    symbolTable = new HashMap<>();
+    Primitives.initializeStaticSymbols(symbolTable);
+
+    symNil = symbolFor("nil");
+    symTrue = symbolFor("true");
+    symFalse = symbolFor("false");
+    symSelf = symbolFor("self");
+    symBlockSelf = symbolFor("$blockSelf");
+    symSuper = symbolFor("super");
+
+    symObject = symbolFor("Object");
+    symArray = symbolFor("Array");
+    symNewMsg = symbolFor("new:");
+    symAtPutMsg = symbolFor("at:put:");
+    symArraySizePlaceholder = symbolFor("ArraySizeLiteralPlaceholder");
+
+    symPlus = symbolFor("+");
+    symMinus = symbolFor("-");
+
+    // Name for the frameOnStack slot,
+    // starting with ! to make it a name that's not possible in Smalltalk
+    symFrameOnStack = symbolFor("!frameOnStack");
+  }
+}

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -25,6 +25,9 @@
 
 package trufflesom.vm;
 
+import static trufflesom.vm.SymbolTable.symNil;
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -156,8 +159,7 @@ public final class Universe implements IdProvider<SSymbol> {
     this.language = language;
     this.compiler = new SourcecodeCompiler(language);
     this.globals = new HashMap<SSymbol, Association>();
-    this.symbolTable = new HashMap<>();
-    Primitives.initializeStaticSymbols(this.symbolTable);
+
     this.alreadyInitialized = false;
 
     this.blockClasses = new SClass[4];
@@ -180,20 +182,6 @@ public final class Universe implements IdProvider<SSymbol> {
     booleanClass = newSystemClass();
 
     this.primitives = new Primitives(this);
-
-    symNil = symbolFor("nil");
-    symTrue = symbolFor("true");
-    symFalse = symbolFor("false");
-    symSelf = symbolFor("self");
-    symBlockSelf = symbolFor("$blockSelf");
-    symSuper = symbolFor("super");
-
-    symPlus = symbolFor("+");
-    symMinus = symbolFor("-");
-
-    // Name for the frameOnStack slot,
-    // starting with ! to make it a name that's not possible in Smalltalk
-    symFrameOnStack = symbolFor("!frameOnStack");
   }
 
   public static final class SomExit extends ThreadDeath {
@@ -449,20 +437,6 @@ public final class Universe implements IdProvider<SSymbol> {
       errorExit("Initialization went wrong for class Blocks");
     }
     objectSystemInitialized = true;
-  }
-
-  @TruffleBoundary
-  public SSymbol symbolFor(final String string) {
-    String interned = string.intern();
-    // Lookup the symbol in the symbol table
-    SSymbol result = symbolTable.get(interned);
-    if (result != null) {
-      return result;
-    }
-
-    result = new SSymbol(interned);
-    symbolTable.put(interned, result);
-    return result;
   }
 
   @Override
@@ -754,17 +728,6 @@ public final class Universe implements IdProvider<SSymbol> {
   @CompilationFinal private SClass falseClass;
   @CompilationFinal private SClass systemClass;
 
-  public final SSymbol symNil;
-  public final SSymbol symTrue;
-  public final SSymbol symFalse;
-  public final SSymbol symSelf;
-  public final SSymbol symBlockSelf;
-  public final SSymbol symFrameOnStack;
-  public final SSymbol symSuper;
-
-  public final SSymbol symPlus;
-  public final SSymbol symMinus;
-
   private final HashMap<SSymbol, Association> globals;
 
   private String[]              classPath;
@@ -778,8 +741,6 @@ public final class Universe implements IdProvider<SSymbol> {
   private final SomLanguage language;
 
   private final SourcecodeCompiler compiler;
-
-  private final HashMap<String, SSymbol> symbolTable;
 
   // Optimizations
   @CompilationFinal(dimensions = 1) private final SClass[] blockClasses;

--- a/src/trufflesom/vmobjects/SAbstractObject.java
+++ b/src/trufflesom/vmobjects/SAbstractObject.java
@@ -1,5 +1,7 @@
 package trufflesom.vmobjects;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -31,7 +33,7 @@ public abstract class SAbstractObject implements TruffleObject {
       final String selectorString,
       final Object[] arguments, final Universe universe) {
     CompilerAsserts.neverPartOfCompilation("SAbstractObject.send()");
-    SSymbol selector = universe.symbolFor(selectorString);
+    SSymbol selector = symbolFor(selectorString);
 
     // Lookup the invokable
     SInvokable invokable = Types.getClassOf(arguments[0], universe).lookupInvokable(selector);

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static trufflesom.vm.SymbolTable.symSelf;
 
 import org.junit.Test;
 
@@ -56,7 +57,7 @@ public class AstInliningTests extends TruffleTestSetup {
 
   private void initMgenc() {
     mgenc = new MethodGenerationContext(cgenc, probe);
-    mgenc.addArgumentIfAbsent(universe.symSelf, null);
+    mgenc.addArgumentIfAbsent(symSelf, null);
   }
 
   protected ExpressionNode parseMethod(final String source) {

--- a/tests/trufflesom/tests/BytecodeBlockTests.java
+++ b/tests/trufflesom/tests/BytecodeBlockTests.java
@@ -2,6 +2,8 @@ package trufflesom.tests;
 
 import static org.junit.Assert.assertEquals;
 import static trufflesom.compiler.bc.Disassembler.dumpMethod;
+import static trufflesom.vm.SymbolTable.symBlockSelf;
+import static trufflesom.vm.SymbolTable.symbolFor;
 
 import org.junit.Test;
 
@@ -19,10 +21,10 @@ public class BytecodeBlockTests extends BytecodeTestSetup {
   protected final BytecodeMethodGenContext bgenc;
 
   public BytecodeBlockTests() {
-    mgenc.setSignature(universe.symbolFor("outer"));
+    mgenc.setSignature(symbolFor("outer"));
 
     bgenc = new BytecodeMethodGenContext(cgenc, mgenc);
-    bgenc.addArgumentIfAbsent(universe.symBlockSelf, null);
+    bgenc.addArgumentIfAbsent(symBlockSelf, null);
   }
 
   @Override

--- a/tests/trufflesom/tests/BytecodeMethodTests.java
+++ b/tests/trufflesom/tests/BytecodeMethodTests.java
@@ -3,6 +3,7 @@ package trufflesom.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static trufflesom.vm.SymbolTable.symbolFor;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -621,7 +622,7 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
   @Test
   public void testBlockIfTrueMethodArg() {
     Source s = SomLanguage.getSyntheticSource("test arg", "arg");
-    mgenc.addArgumentIfAbsent(universe.symbolFor("arg"), s.createSection(1));
+    mgenc.addArgumentIfAbsent(symbolFor("arg"), s.createSection(1));
 
     byte[] bytecodes = blockToBytecodes(
         "[ #start.\n"

--- a/tests/trufflesom/tests/BytecodeTestSetup.java
+++ b/tests/trufflesom/tests/BytecodeTestSetup.java
@@ -1,6 +1,8 @@
 package trufflesom.tests;
 
 import static trufflesom.compiler.bc.Disassembler.dumpMethod;
+import static trufflesom.vm.SymbolTable.symSelf;
+import static trufflesom.vm.SymbolTable.symbolFor;
 
 import org.junit.Ignore;
 
@@ -23,11 +25,11 @@ public class BytecodeTestSetup extends TruffleTestSetup {
 
   public void initMgenc() {
     mgenc = new BytecodeMethodGenContext(cgenc, probe);
-    mgenc.addArgumentIfAbsent(universe.symSelf, null);
+    mgenc.addArgumentIfAbsent(symSelf, null);
   }
 
   public void initBgenc() {
-    mgenc.setSignature(universe.symbolFor("test"));
+    mgenc.setSignature(symbolFor("test"));
     mgenc.setVarsOnMethodScope();
     bgenc = new BytecodeMethodGenContext(cgenc, mgenc);
   }

--- a/tests/trufflesom/tests/TruffleTestSetup.java
+++ b/tests/trufflesom/tests/TruffleTestSetup.java
@@ -1,5 +1,7 @@
 package trufflesom.tests;
 
+import static trufflesom.vm.SymbolTable.symbolFor;
+
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Context.Builder;
 import org.junit.Ignore;
@@ -38,7 +40,7 @@ public class TruffleTestSetup {
     probe = null;
 
     cgenc = new ClassGenerationContext(universe, null);
-    cgenc.setName(universe.symbolFor("Test"));
+    cgenc.setName(symbolFor("Test"));
   }
 
   private static void initTruffle() {
@@ -56,7 +58,7 @@ public class TruffleTestSetup {
   }
 
   protected void addField(final String name) {
-    cgenc.addInstanceField(universe.symbolFor(name), null);
+    cgenc.addInstanceField(symbolFor(name), null);
   }
 
   private java.lang.reflect.Field lookup(final Class<?> cls, final String fieldName) {


### PR DESCRIPTION
This extracts the symbol table from the universe.
The main reason to keep the change is to reduce a little the various responsibilities of the universe.
There doesn't seem to be any positive performance impact from this change though.