### PR TITLE
Implement inlining for #and:/#&&/#or:#||

### DIFF
--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -266,6 +266,10 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     if (isSuperSend) {
       emitSUPERSEND(mgenc, msg, this);
     } else {
+      if ((msg.getString().equals("||") && mgenc.inlineAndOr(this, true))
+          || (msg.getString().equals("&&") && mgenc.inlineAndOr(this, false))) {
+        return;
+      }
       emitSEND(mgenc, msg, this);
     }
   }
@@ -289,7 +293,9 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
           ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this, true)) ||
           ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this, false)) ||
           ("whileTrue:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, true)) ||
-          ("whileFalse:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, false))) {
+          ("whileFalse:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, false)) ||
+          ("or:".equals(kwStr) && mgenc.inlineAndOr(this, true)) ||
+          ("and:".equals(kwStr) && mgenc.inlineAndOr(this, false))) {
         // all done
         return;
       }

--- a/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/compiler/ParserBc.java
@@ -234,12 +234,10 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     superSend = false;
 
     SSymbol msg = unarySelector();
-    mgenc.addLiteralIfAbsent(msg, this);
-
     if (isSuperSend) {
-      emitSUPERSEND(mgenc, msg);
+      emitSUPERSEND(mgenc, msg, this);
     } else {
-      emitSEND(mgenc, msg);
+      emitSEND(mgenc, msg, this);
     }
   }
 
@@ -249,7 +247,6 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     superSend = false;
 
     SSymbol msg = binarySelector();
-    mgenc.addLiteralIfAbsent(msg, this);
 
     boolean isPossibleIncOrDec = msg == symPlus || msg == symMinus;
     if (isPossibleIncOrDec) {
@@ -267,9 +264,9 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     binaryOperand(mgenc);
 
     if (isSuperSend) {
-      emitSUPERSEND(mgenc, msg);
+      emitSUPERSEND(mgenc, msg, this);
     } else {
-      emitSEND(mgenc, msg);
+      emitSEND(mgenc, msg, this);
     }
   }
 
@@ -300,12 +297,10 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
 
     SSymbol msg = symbolFor(kwStr);
 
-    mgenc.addLiteralIfAbsent(msg, this);
-
     if (isSuperSend) {
-      emitSUPERSEND(mgenc, msg);
+      emitSUPERSEND(mgenc, msg, this);
     } else {
-      emitSEND(mgenc, msg);
+      emitSEND(mgenc, msg, this);
     }
   }
 
@@ -365,14 +360,12 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     expect(Pound);
     expect(NewTerm);
 
-    mgenc.addLiteralIfAbsent(symNewMsg, this);
-    mgenc.addLiteralIfAbsent(symAtPutMsg, this);
     final byte arraySizeLiteralIndex = mgenc.addLiteral(symArraySizePlaceholder, this);
 
     // create empty array
     emitPUSHGLOBAL(mgenc, symArray, this);
     emitPUSHCONSTANT(mgenc, arraySizeLiteralIndex);
-    emitSEND(mgenc, symNewMsg);
+    emitSEND(mgenc, symNewMsg, this);
 
     long i = 1;
 
@@ -381,7 +374,7 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
 
       emitPUSHCONSTANT(mgenc, i, this);
       literal(mgenc);
-      emitSEND(mgenc, symAtPutMsg);
+      emitSEND(mgenc, symAtPutMsg, this);
       emitPOP(mgenc);
       i += 1;
     }

--- a/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -290,14 +290,20 @@ public final class BytecodeGenerator {
     emit3(mgenc, POP_FIELD, fieldIdx, ctx, -1);
   }
 
-  public static void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {
+  public static void emitSUPERSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg,
+      final ParserBc parser) throws ParseError {
     int stackEffect = -msg.getNumberOfSignatureArguments() + 1; // +1 for the return value
-    emit2(mgenc, SUPER_SEND, mgenc.findLiteralIndex(msg), stackEffect);
+
+    byte idx = mgenc.addLiteralIfAbsent(msg, parser);
+    emit2(mgenc, SUPER_SEND, idx, stackEffect);
   }
 
-  public static void emitSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg) {
+  public static void emitSEND(final BytecodeMethodGenContext mgenc, final SSymbol msg,
+      final ParserBc parser) throws ParseError {
     int stackEffect = -msg.getNumberOfSignatureArguments() + 1; // +1 for the return value
-    emit2(mgenc, SEND, mgenc.findLiteralIndex(msg), stackEffect);
+
+    byte idx = mgenc.addLiteralIfAbsent(msg, parser);
+    emit2(mgenc, SEND, idx, stackEffect);
   }
 
   public static void emitPUSHCONSTANT(final BytecodeMethodGenContext mgenc, final Object lit,

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1410,16 +1410,14 @@ public class BytecodeLoopNode extends ExpressionNode implements ScopeReference {
         case SEND: {
           byte literalIdx = bytecodes[i + 1];
           SSymbol signature = (SSymbol) literalsAndConstants[literalIdx];
-          mgenc.addLiteralIfAbsent(signature, null);
-          emitSEND(mgenc, signature);
+          emitSEND(mgenc, signature, null);
           break;
         }
 
         case SUPER_SEND: {
           byte literalIdx = bytecodes[i + 1];
           SSymbol signature = (SSymbol) literalsAndConstants[literalIdx];
-          mgenc.addLiteralIfAbsent(signature, null);
-          emitSUPERSEND(mgenc, signature);
+          emitSUPERSEND(mgenc, signature, null);
           break;
         }
 

--- a/tests/trufflesom/tests/BytecodeMethodTests.java
+++ b/tests/trufflesom/tests/BytecodeMethodTests.java
@@ -817,15 +817,16 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
   }
 
   private void inliningOfAnd(final String sel) {
+    initMgenc();
     byte[] bytecodes = methodToBytecodes(
         "test = ( true " + sel + " [ #val ] )");
 
-    assertEquals(12, bytecodes.length);
+    assertEquals(11, bytecodes.length);
     check(bytecodes,
-        Bytecodes.PUSH_GLOBAL,
+        Bytecodes.PUSH_CONSTANT_0,
         new BC(Bytecodes.JUMP_ON_FALSE_POP, 7),
         // true branch
-        Bytecodes.PUSH_CONSTANT, // push the `#val`
+        Bytecodes.PUSH_CONSTANT_2, // push the `#val`
         new BC(Bytecodes.JUMP, 5),
         // false branch, jump_on_false target, push false
         Bytecodes.PUSH_CONSTANT,
@@ -833,7 +834,6 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
         Bytecodes.RETURN_SELF);
   }
 
-  @Ignore("Not yet implemendeted bytecode and:/or:")
   @Test
   public void testInliningOfAnd() {
     inliningOfAnd("and:");
@@ -841,46 +841,45 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
   }
 
   private void inliningOfOr(final String sel) {
+    initMgenc();
     byte[] bytecodes = methodToBytecodes(
         "test = ( true " + sel + " [ #val ] )");
 
-    assertEquals(12, bytecodes.length);
+    dump();
+    assertEquals(10, bytecodes.length);
     check(bytecodes,
-        Bytecodes.PUSH_GLOBAL,
+        Bytecodes.PUSH_CONSTANT_0,
         new BC(Bytecodes.JUMP_ON_TRUE_POP, 7),
         // true branch
-        Bytecodes.PUSH_CONSTANT, // push the `#val`
-        new BC(Bytecodes.JUMP, 5),
+        Bytecodes.PUSH_CONSTANT_2, // push the `#val`
+        new BC(Bytecodes.JUMP, 4),
         // false branch, jump_on_false target, push false
-        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.PUSH_CONSTANT_0,
         // target of the jump in the true branch
         Bytecodes.RETURN_SELF);
   }
 
-  @Ignore("Not yet implemendeted bytecode and:/or:")
   @Test
   public void testInliningOfOr() {
     inliningOfOr("or:");
     inliningOfOr("||");
   }
 
-  @Ignore("Not yet implemendeted bytecode and:/or:")
   @Test
   public void testFieldReadInlining() {
     addField("field");
     byte[] bytecodes = methodToBytecodes(
         "test = ( true and: [ field ] )");
 
-    dump();
-    assertEquals(6, bytecodes.length);
+    assertEquals(10, bytecodes.length);
     check(bytecodes,
         Bytecodes.PUSH_CONSTANT_0,
         new BC(Bytecodes.JUMP_ON_FALSE_POP, 7),
         // true branch
-        Bytecodes.PUSH_FIELD,
+        Bytecodes.PUSH_FIELD_0,
         new BC(Bytecodes.JUMP, 4),
         // false branch, jump_on_false target, push false
-        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.PUSH_CONSTANT_2,
         // target of the jump in the true branch
         Bytecodes.RETURN_SELF);
   }

--- a/tests/trufflesom/tests/BytecodeMethodTests.java
+++ b/tests/trufflesom/tests/BytecodeMethodTests.java
@@ -1071,7 +1071,7 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
     check(bytecodes,
         Bytecodes.PUSH_1, Bytecodes.POP,
         new BC(Bytecodes.INC_FIELD, field, 0),
-        Bytecodes.PUSH_CONSTANT_1,
+        Bytecodes.PUSH_CONSTANT_0,
         Bytecodes.RETURN_SELF);
   }
 


### PR DESCRIPTION
This PR inlines literal blocks for and/or messages.

It also moves the `addLiteralIfAbsent()` calls into the emit*Send methods to avoid adding unnecessary literals to methods.

This change is only for the bytecode interpreter.
Overall performance seems to suffer on the startup metric.

Though, the interpreter-only benchmarks seem to benefit a little.
Steady state performance seems largely unaffected. NBody (-14%), Richards (-7%), and Towers (-10%) seem to see reductions in run time for the interpreter only execution.

https://rebench.stefan-marr.de/compare/TruffleSOM/c3388f263550dc18ca5a703bfbda2a029546b3a3/c2dffba0800176fb267fcbf46b3b70858370c93f#micro-somsom-SomSom-native-interp-bc