### PR TITLE
Parallelize benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - build-and-test
   - benchmark
+  - benchmark-completion
 
 variables:
   PYTHONUNBUFFERED: "true"
@@ -13,19 +14,87 @@ before_script:
   - (cd core-lib && git remote add smarr https://github.com/smarr/SOM.git || true; git fetch --all)
   - git submodule update --init
 
-build_and_test_job:
+test:
   stage: build-and-test
-  tags: [benchmarks, infinity]
+  tags: [yuria]
   script:
     - ${ANT} tests native-obj-storage-test native-tests
     - ./som -G -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/tests/SomSomTests.som
 
-benchmark_job:
-  stage: benchmark
-  tags: [benchmarks, infinity]
-  allow_failure: true
+build-native-interp-ast:
+  stage: build-and-test
+  tags: [yuria2]
   script:
     - ${ANT} compile native-ast -Dno.jit=true
+    - ./som-native-interp-ast -cp Smalltalk TestSuite/TestHarness.som
+    
+    # Package and Upload
+    - lz4 som-native-interp-ast som-native-interp-ast.lz4
+    - |
+      sftp tmp-artifacts << EOF
+        -mkdir incoming/${CI_PIPELINE_ID}/
+        put som-native-interp-ast.lz4 incoming/${CI_PIPELINE_ID}/
+      EOF
+
+build-native-interp-bc:
+  stage: build-and-test
+  tags: [yuria3]
+  script:
     - ${ANT} compile native-bc  -Dno.jit=true
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf
+    - ./som-native-interp-bc -cp Smalltalk TestSuite/TestHarness.som
+    
+    - lz4 som-native-interp-bc som-native-interp-bc.lz4
+    - |
+      sftp tmp-artifacts << EOF
+        -mkdir incoming/${CI_PIPELINE_ID}/
+        put som-native-interp-bc.lz4 incoming/${CI_PIPELINE_ID}/
+      EOF
+
+
+benchmark-y1:
+  stage: benchmark
+  tags: [yuria]
+  script:
+    - ${ANT} compile
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
+    
+    - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
+    - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
+
+    # Run Benchmarks
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria
+
+benchmark-y2:
+  stage: benchmark
+  tags: [yuria2]
+  script:
+    - ${ANT} compile
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
+    
+    - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
+    - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
+
+    # Run Benchmarks
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria2
+
+benchmark-y3:
+  stage: benchmark
+  tags: [yuria3]
+  script:
+    - ${ANT} compile
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
+    
+    - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
+    - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
+
+    # Run Benchmarks
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria3
+
+report-completion:
+  stage: benchmark-completion
+  tags: [yuria]
+  script:
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/rebench.conf
+++ b/rebench.conf
@@ -22,23 +22,23 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - Richards:     {extra_args: 1}
-            - DeltaBlue:    {extra_args: 100}
-            - NBody:        {extra_args: 1000}
-            - Json:         {extra_args: 1}
-            - GraphSearch:  {extra_args: 7}
-            - PageRank:     {extra_args: 75}
+            - Richards:     {extra_args:    1, machines: [yuria ]}
+            - DeltaBlue:    {extra_args:  100, machines: [yuria2]}
+            - NBody:        {extra_args: 1000, machines: [yuria3]}
+            - Json:         {extra_args:    1, machines: [yuria ]}
+            - GraphSearch:  {extra_args:    7, machines: [yuria2]}
+            - PageRank:     {extra_args:   75, machines: [yuria3]}
 
     macro-steady:
         gauge_adapter: RebenchLog
         command: *MACRO_CMD
         benchmarks:
-            - Richards:     {extra_args: 40,     warmup:  30,   iterations: 130}
-            - DeltaBlue:    {extra_args: 10000,  warmup:  20,   iterations: 120}
-            - NBody:        {extra_args: 200000, warmup:  20,   iterations: 120}
-            - Json:         {extra_args: 80,     warmup:  20,   iterations: 120}
-            - GraphSearch:  {extra_args: 25,     warmup: 100,   iterations: 250}
-            - PageRank:     {extra_args: 1000,   warmup:  20,   iterations: 120}
+            - Richards:     {extra_args: 40,     warmup:  30,   iterations: 130, machines: [yuria ]}
+            - DeltaBlue:    {extra_args: 10000,  warmup:  20,   iterations: 120, machines: [yuria2]}
+            - NBody:        {extra_args: 200000, warmup:  20,   iterations: 120, machines: [yuria3]}
+            - Json:         {extra_args: 80,     warmup:  20,   iterations: 120, machines: [yuria ]}
+            - GraphSearch:  {extra_args: 25,     warmup: 100,   iterations: 250, machines: [yuria2]}
+            - PageRank:     {extra_args: 1000,   warmup:  20,   iterations: 120, machines: [yuria3]}
 
 
     micro-startup:
@@ -47,62 +47,62 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - Fannkuch:     {extra_args: 7}
-            - Fibonacci:    {extra_args: 10}
-            - Dispatch:     {extra_args: 10}
-            - Bounce:       {extra_args: 10}
-            - Loop:         {extra_args: 100}
-            - Permute:      {extra_args: 10}
-            - Queens:       {extra_args: 10}
-            - List:         {extra_args: 2}
-            - Recurse:      {extra_args: 12}
-            - Storage:      {extra_args: 8}
-            - Sieve:        {extra_args: 20}
-            - BubbleSort:   {extra_args: 15}
-            - QuickSort:    {extra_args: 15}
-            - Sum:          {extra_args: 40}
-            - Towers:       {extra_args: 2}
-            - TreeSort:     {extra_args: 7}
-            - IntegerLoop:  {extra_args: 7}
-            - FieldLoop:    {extra_args: 1}
-            - WhileLoop:    {extra_args: 30}
-            - Mandelbrot:   {extra_args: 50}
+            - Fannkuch:     {extra_args:   7, machines: [yuria ]}
+            - Fibonacci:    {extra_args:  10, machines: [yuria2]}
+            - Dispatch:     {extra_args:  10, machines: [yuria3]}
+            - Bounce:       {extra_args:  10, machines: [yuria ]}
+            - Loop:         {extra_args: 100, machines: [yuria2]}
+            - Permute:      {extra_args:  10, machines: [yuria3]}
+            - Queens:       {extra_args:  10, machines: [yuria ]}
+            - List:         {extra_args:   2, machines: [yuria2]}
+            - Recurse:      {extra_args:  12, machines: [yuria3]}
+            - Storage:      {extra_args:   8, machines: [yuria ]}
+            - Sieve:        {extra_args:  20, machines: [yuria2]}
+            - BubbleSort:   {extra_args:  15, machines: [yuria3]}
+            - QuickSort:    {extra_args:  15, machines: [yuria ]}
+            - Sum:          {extra_args:  40, machines: [yuria2]}
+            - Towers:       {extra_args:   2, machines: [yuria3]}
+            - TreeSort:     {extra_args:   7, machines: [yuria ]}
+            - IntegerLoop:  {extra_args:   7, machines: [yuria2]}
+            - FieldLoop:    {extra_args:   1, machines: [yuria3]}
+            - WhileLoop:    {extra_args:  30, machines: [yuria ]}
+            - Mandelbrot:   {extra_args:  50, machines: [yuria2]}
 
     micro-steady:
         gauge_adapter: RebenchLog
         command: *MICRO_CMD
         benchmarks:
-            - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55}
-            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60}
-            - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55}
-            - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60}
-            - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55}
-            - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55}
-            - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55}
-            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65}
-            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65}
-            - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60}
-            - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60}
-            - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55}
-            - QuickSort:    {extra_args: 2000,   warmup:   5,   iterations:  55}
-            - Sum:          {extra_args: 10000,  warmup:   5,   iterations:  55}
-            - Towers:       {extra_args: 1000,   warmup:   5,   iterations:  55}
-            - TreeSort:     {extra_args: 1000,   warmup:  10,   iterations:  60}
-            - IntegerLoop:  {extra_args: 8000,   warmup:   5,   iterations:  55}
-            - FieldLoop:    {extra_args: 900,    warmup:   5,   iterations:  55}
-            - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55}
-            - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110}
+            - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55, machines: [yuria ]}
+            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria3]}
+            - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
+            - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55, machines: [yuria3]}
+            - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria ]}
+            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, machines: [yuria ]}
+            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, machines: [yuria ]}
+            - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60, machines: [yuria2]}
+            - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55, machines: [yuria3]}
+            - QuickSort:    {extra_args: 2000,   warmup:   5,   iterations:  55, machines: [yuria ]}
+            - Sum:          {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
+            - Towers:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria3]}
+            - TreeSort:     {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - IntegerLoop:  {extra_args: 8000,   warmup:   5,   iterations:  55, machines: [yuria2]}
+            - FieldLoop:    {extra_args: 900,    warmup:   5,   iterations:  55, machines: [yuria3]}
+            - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55, machines: [yuria2]}
+            - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110, machines: [yuria3]}
 
     micro-somsom:
         gauge_adapter: RebenchLog
         command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
         iterations: 1
         benchmarks:
-            - Loop:         {extra_args: 1}
-            - Queens:       {extra_args: 1}
-            - List:         {extra_args: 1}
-            - Recurse:      {extra_args: 1}
-            - Mandelbrot:   {extra_args: 3}
+            - Loop:         {extra_args: 1, machines: [yuria3]}
+            - Queens:       {extra_args: 1, machines: [yuria ]}
+            - List:         {extra_args: 1, machines: [yuria2]}
+            - Recurse:      {extra_args: 1, machines: [yuria3]}
+            - Mandelbrot:   {extra_args: 3, machines: [yuria ]}
 
 executors:
     TruffleSOM-interp:


### PR DESCRIPTION
Run benchmarks on all three benchmarking machines.

Currently only building the native images is done in parallel, because we don't have support for packaging and distributing TruffleSOM.
This means, each machine builds is own local version of libgraal and co. Though, it's relatively quick. So, will leave it like this.