### PR TITLE
Add continuous profiling to benchmark setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,8 +62,10 @@ benchmark-y1:
     - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
     - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
 
+    # Profile
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria
     # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria
 
 benchmark-y2:
   stage: benchmark
@@ -76,8 +78,10 @@ benchmark-y2:
     - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
     - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
 
+    # Profile
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria2
     # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria2
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria2
 
 benchmark-y3:
   stage: benchmark
@@ -90,8 +94,10 @@ benchmark-y3:
     - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
     - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
 
+    # Profile
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria3
     # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria3
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria3
 
 report-completion:
   stage: benchmark-completion

--- a/.graal-git-rev
+++ b/.graal-git-rev
@@ -1,9 +1,0 @@
-#!/bin/sh
-# This version is used with the following version of the Graal repo:
-#  https://github.com/smarr/GraalBasic.git
-
-SCRIPT=`head -n 6 .graal-git-rev; echo ''; echo '# current revision'; echo ' '`
-echo "${SCRIPT}GIT-REV="`git --git-dir ../graal/graal-core/.git rev-parse HEAD` > .graal-git-rev; exit 0
-
-# current revision
- GIT-REV=11ec1deb54c9b2aa2c3ded338e4115ca7b15e120

--- a/build.xml
+++ b/build.xml
@@ -418,6 +418,7 @@
         <env key="JAVA_HOME" value="${jvmci.home}" />
         <arg line="native-image" />
         <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
+        <arg line="-H:-DeleteLocalSymbols" />
         <arg line="-Dsom.interp=AST" />
         <arg line="-Dsom.jitCompiler=false" if:true="${no.jit}" />
         <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->
@@ -448,6 +449,7 @@
         <env key="JAVA_HOME" value="${jvmci.home}" />
         <arg line="native-image" />
         <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
+        <arg line="-H:-DeleteLocalSymbols" />
         <arg line="-Dsom.interp=BC" />
         <arg line="-Dsom.jitCompiler=false" if:true="${no.jit}" />
         <!-- <arg line="-Dbd.settings=som.vm.VmSettings" /> -->

--- a/rebench.conf
+++ b/rebench.conf
@@ -1,6 +1,6 @@
 # -*- mode: yaml -*-
 # Config file for ReBench
-default_experiment: all
+default_experiment: benchmarks
 default_data_file: 'rebench.data'
 
 reporting:
@@ -134,25 +134,33 @@ executors:
     TruffleSOM-native-interp-ast:
         path: .
         executable: som-native-interp-ast
+        profiler:
+          perf: {}
+          
     TruffleSOM-native-interp-bc:
         path: .
         executable: som-native-interp-bc
+        profiler:
+          perf: {}
     
     SomSom-native-interp-ast:
         path: .
         executable: som-native-interp-ast
         args: "-cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+        profiler:
+          perf: {}
 
     SomSom-native-interp-bc:
         path: .
         executable: som-native-interp-bc
         args: "-Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
-
+        profiler:
+          perf: {}
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:
-    TruffleSOM:
-        description: All benchmarks on TruffleSOM (Java, AST Interpreter)
+    benchmarks:
+        description: All benchmarks
         executions:
             # - TruffleSOM-interp:
             #     suites:
@@ -182,10 +190,37 @@ experiments:
                 suites:
                     - micro-startup
                     - macro-startup
-    SomSom:
-      description: Just startup benchmarks on SomSom
+            - SomSom-native-interp-ast:
+                suites:
+                  - micro-somsom
+            - SomSom-native-interp-bc:
+                suites:
+                  - micro-somsom
+    
+    profiling:
+      description: Profile Native Image Interpreters
+      action: profile
       suites:
-        - micro-somsom
       executions:
-        - SomSom-native-interp-ast
-        - SomSom-native-interp-bc
+        - TruffleSOM-native-interp-ast:
+            iterations: 10!
+            invocations: 1!
+            suites:
+              - micro-startup
+              - macro-startup
+        - TruffleSOM-native-interp-bc:
+            iterations: 10!
+            invocations: 1!
+            suites:
+              - micro-startup
+              - macro-startup
+        - SomSom-native-interp-ast:
+            iterations: 1!
+            invocations: 1!
+            suites:
+              - micro-somsom
+        - SomSom-native-interp-bc:
+            iterations: 1!
+            invocations: 1!
+            suites:
+              - micro-somsom


### PR DESCRIPTION
This adds profiling of the native image interpreters.
This will allow us to track interpreter performance in more detail.


Also remove an old script not used/needed.