### PR TITLE
Enable Truffle Guest Safepoints

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,6 @@ build:native-interp-ast:
   stage: build-and-test
   tags: [yuria2]
   script:
-    - (cd libs/truffle; git checkout compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java)
-    - sed -i'' '45,56d' libs/truffle/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java
     - ${ANT} compile native-ast -Dno.jit=true
     - ./som-native-interp-ast -cp Smalltalk TestSuite/TestHarness.som
     
@@ -42,8 +40,6 @@ build:native-interp-bc:
   stage: build-and-test
   tags: [yuria3]
   script:
-    - (cd libs/truffle; git checkout compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java)
-    - sed -i'' '45,56d' libs/truffle/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java
     - ${ANT} compile native-bc  -Dno.jit=true
     - ./som-native-interp-bc -cp Smalltalk TestSuite/TestHarness.som
     
@@ -60,8 +56,6 @@ benchmark-y1:
   needs: ["build:native-interp-ast", "build:native-interp-bc"]
   tags: [yuria]
   script:
-    - (cd libs/truffle; git checkout compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java)
-    - sed -i'' '45,56d' libs/truffle/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java
     - ${ANT} compile
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
@@ -79,8 +73,6 @@ benchmark-y2:
   needs: ["build:native-interp-ast", "build:native-interp-bc"]
   tags: [yuria2]
   script:
-    - (cd libs/truffle; git checkout compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java)
-    - sed -i'' '45,56d' libs/truffle/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java
     - ${ANT} compile
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
@@ -98,8 +90,6 @@ benchmark-y3:
   needs: ["build:native-interp-ast", "build:native-interp-bc"]
   tags: [yuria3]
   script:
-    - (cd libs/truffle; git checkout compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java)
-    - sed -i'' '45,56d' libs/truffle/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/TruffleCompilerPhases.java
     - ${ANT} compile
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4

--- a/build.xml
+++ b/build.xml
@@ -6,15 +6,6 @@
     <property name="jvmci.version" value="jvmci-21.3-b05" />
     <property name="jdk8.version"  value="302+06" />
 
-    <macrodef name="travis">
-        <attribute name="target" />
-        <attribute name="start" default="" />
-        <sequential>
-            <echo message="travis_fold:start:@{target}${line.separator}@{start}${line.separator}" unless:blank="@{start}" if:true="${env.TRAVIS}" />
-            <echo message="travis_fold:end:@{target}${line.separator}"             if:blank="@{start}" if:true="${env.TRAVIS}" />
-        </sequential>
-    </macrodef>
-
     <condition property="is.atLeastJava9" value="true" else="false">
       <or>
         <matches string="${java.version}" pattern="^9"/>
@@ -28,15 +19,12 @@
         <os family="mac"/>
     </condition>
 
-    <travis target="env" start="Environment" />
     <echo>
         ant.java.version: ${ant.java.version}
         java.version:     ${java.version}
         is.atLeastJava9:  ${is.atLeastJava9}
         kernel:           ${kernel}
-        env.TRAVIS:       ${env.TRAVIS}
     </echo>
-    <travis target="env" />
 
     <property name="src.dir"     location="src"/>
     <property name="src_gen.dir" location="src_gen"/>
@@ -98,30 +86,20 @@
     </condition>
 
     <target name="clean" description="Remove build directories and generated code">
-        <travis target="clean" start="clean" />
-
         <delete dir="${build.dir}"/>
         <delete dir="${src_gen.dir}"/>
-
-        <travis target="clean" />
     </target>
 
     <target name="clean-truffle" if="truffle.and.jvmci.present">
-        <travis target="clean-truffle" start="clean-truffle" />
-
         <exec executable="${mx.cmd}" dir="${svm.dir}">
           <arg value="--dynamicimports"/>
           <arg value="../truffle,../tools,../compiler,../sdk"/>
           <arg value="clean"/>
           <env key="JAVA_HOME" value="${jvmci.home}" />
         </exec>
-
-        <travis target="clean-truffle" />
     </target>
 
     <target name="clobber" description="Do clean, and also clean truffle build" depends="clean,clean-truffle">
-        <travis target="clobber" start="clobber" />
-
         <exec executable="${mx.cmd}" dir="${truffle.dir}">
           <arg value="--dynamicimports"/>
           <arg value="../sdk"/>
@@ -136,8 +114,6 @@
         </exec>
 
         <ant dir="${bd.dir}" useNativeBasedir="true" target="clean" inheritAll="false" />
-
-        <travis target="clobber" />
     </target>
 
     <target name="check-core-lib-available">
@@ -153,17 +129,14 @@
     </target>
 
     <target name="truffle-libs" depends="jvmci-libs,core-lib">
-        <travis target="truffle-libs" start="Build Truffle" />
         <exec executable="${mx.cmd}" dir="${compiler.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>
             <env key="JAVA_HOME" value="${jvmci.home}" />
         </exec>
-        <travis target="truffle-libs" />
     </target>
     
     <target name="libgraal-jdk" depends="jvmci-libs,core-lib">
-        <travis target="libgraal-jdk" start="Build LibGraal-enabled JDK" />
         <exec executable="${mx.cmd}" dir="${vm.dir}" failonerror="true">
             <env key="JAVA_HOME" value="${jvmci.home}" />
             <!-- REM: This needs to match ./som -->
@@ -173,12 +146,9 @@
             <env key="EXCLUDE_COMPONENTS" value="svmag,nju,nic,ni,nil" />
             <arg line="build"/>
         </exec>
-        <travis target="libgraal-jdk" />
     </target>
 
     <target name="bd-libs"> <!-- implicit dependency on truffle-libs/libgraal-jdk -->
-        <travis target="bd-libs" start="Build Black Diamonds" />
-
         <ant dir="${bd.dir}" useNativeBasedir="true" target="libs-junit" inheritAll="false">
             <property name="force.java8"   value="${is.atLeastJava9}" />
         </ant>
@@ -188,8 +158,6 @@
             <property name="truffle.build" value="${truffle.build}" />
             <property name="force.java8"   value="${is.atLeastJava9}" />
         </ant>
-
-        <travis target="bd-libs" />
     </target>
 
     <target name="ideinit" depends="core-lib">
@@ -233,7 +201,6 @@
     </target>
 
     <target name="eclipseformat">
-      <travis target="eclipseformat" start="Format code with Eclipse" />
       <pathconvert pathsep=" " property="javafiles">
         <fileset dir="${src.dir}">
           <include name="**/*.java"/>
@@ -255,11 +222,9 @@
           <arg value="${basedir}/.settings/org.eclipse.jdt.core.prefs"/>
           <arg line="${javafiles}"/>
       </exec>
-      <travis target="eclipseformat" />
   </target>
 
   <target name="eclipseformat-check" depends="eclipseformat">
-      <travis target="eclipseformat-check" start="Check Eclipse Format" />
       <exec executable="git" dir="${basedir}">
           <arg value="status" />
           <arg value="*.java" />
@@ -271,32 +236,25 @@
           <arg value="--ignore-submodules" />
           <arg value="HEAD" />
       </exec>
-      <travis target="eclipseformat-check" />
     </target>
 
     <target name="checkstyle-jar">
-        <travis target="checkstyle-jar" start="Get Checkstyle Jar" />
         <mkdir dir="${lib.dir}" />
         <get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
             usetimestamp="true"
             dest="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
-        <travis target="checkstyle-jar" />
     </target>
 
     <target name="checkstyle" depends="checkstyle-jar" description="Check Code with Checkstyle">
-        <travis target="checkstyle" start="Run Checkstyle" />
         <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties" classpath="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
         <checkstyle config=".checkstyle_checks.xml">
           <fileset dir="${src.dir}" includes="**/*.java"/>
           <fileset dir="${unit.dir}" includes="**/*.java"/>
           <formatter type="plain"/>
         </checkstyle>
-        <travis target="checkstyle" />
     </target>
 
     <target name="compile-som" description="Compile TruffleSOM, without dependencies">
-        <travis target="compile" start="compile" />
-
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${classes.dir}" />
         <mkdir dir="${src_gen.dir}" />
@@ -314,8 +272,6 @@
         <javac includeantruntime="false" srcdir="${unit.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="som.cp" />
         </javac>
-
-        <travis target="compile" />
     </target>
 
     <target name="compile-for-jar" depends="truffle-libs,libs,compile-som" description="Compile TruffleSOM without LibGraal">
@@ -329,8 +285,6 @@
     </target>
 
     <target name="test" depends="compile-for-jar" description="Execute tests">
-        <travis target="test" start="test" />
-
         <junit haltonerror="false" haltonfailure="false" failureproperty="test.failed.ast"
             outputtoformatters="true">
             <jvmarg value="-ea" />
@@ -370,13 +324,9 @@
         </java>
         <fail message="Basic tests failed for AST interpreter." if="test.failed.ast" />
         <fail message="Basic tests failed for BC interpreter." if="test.failed.bc" />
-
-        <travis target="test" />
     </target>
 
     <target name="som-test" depends="compile-for-jar" description="Test som script">
-        <travis target="som-test" start="SOM Test" />
-
         <exec executable="./som" failonerror="true">
             <arg value="-G" />
             <arg value="--no-libgraal" />
@@ -394,20 +344,14 @@
             <arg value="Smalltalk" />
             <arg value="TestSuite/TestHarness.com" />
         </exec>
-
-        <travis target="som-test" />
     </target>
 
     <target name="native-tests" depends="native-ast">
-      <travis target="native-tests" start="Run TruffleSOM native image Tests" />
-
       <exec executable="${src.dir}/../som-native-ast" failonerror="true">
           <arg value="-cp" />
           <arg value="Smalltalk" />
           <arg value="TestSuite/TestHarness.com" />
       </exec>
-
-      <travis target="native-tests" />
     </target>
     
     <target name="tests" depends="test,som-test" />
@@ -422,8 +366,6 @@
     </target>
 
     <target name="compile-native-ast">
-      <travis target="native" start="Build Native Image" />
-
       <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
         <env key="JAVA_HOME" value="${jvmci.home}" />
         <arg line="native-image" />
@@ -446,15 +388,11 @@
 
       <move file="${svm.dir}/som-native-ast" todir="${src.dir}/../" />
       <move file="${src.dir}/../som-native-ast" tofile="${src.dir}/../som-native-interp-ast" if:true="${no.jit}" />
-      
-      <travis target="native" />
     </target>
 
     <target name="native-bc" depends="truffle-libs,libs,jvmci-libs,compile-svm,compile-som,compile-native-bc"></target>
 
     <target name="compile-native-bc">
-      <travis target="native" start="Build Native Image" />
-
       <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
         <env key="JAVA_HOME" value="${jvmci.home}" />
         <arg line="native-image" />
@@ -476,17 +414,12 @@
 
       <move file="${svm.dir}/som-native-bc" todir="${src.dir}/../" />
       <move file="${src.dir}/../som-native-bc" tofile="${src.dir}/../som-native-interp-bc" if:true="${no.jit}" />
-          
-
-      <travis target="native" />
     </target>
 
     
     <target name="native-obj-storage-test" depends="truffle-libs,libs,jvmci-libs,compile-svm,compile-som,compile-native-obj-storage-test"></target>
 
     <target name="compile-native-obj-storage-test">
-      <travis target="native" start="Build Native Image" />
-
       <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
         <env key="JAVA_HOME" value="${jvmci.home}" />
         <arg line="native-image" />
@@ -499,7 +432,5 @@
       <move file="${svm.dir}/som-obj-storage-tester" todir="${src.dir}/../" />
             
       <exec executable="${src.dir}/../som-obj-storage-tester" failonerror="true" />
-
-      <travis target="native" />
     </target>
 </project>

--- a/src/trufflesom/interpreter/SomLanguage.java
+++ b/src/trufflesom/interpreter/SomLanguage.java
@@ -13,14 +13,12 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.Option;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 
 import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vm.Universe;
 import trufflesom.vm.Universe.SomExit;
-import trufflesom.vmobjects.SAbstractObject;
 
 
 @TruffleLanguage.Registration(id = "som", name = "som", version = "0.1.0",
@@ -74,8 +72,7 @@ public class SomLanguage extends TruffleLanguage<Universe> {
     current = null;
   }
 
-  /** This is used by the Language Server to get to an initialized instance easily. */
-  private static SomLanguage current;
+  @CompilationFinal private static SomLanguage current;
 
   /** This is used by the Language Server to get to an initialized instance easily. */
   public static SomLanguage getCurrent() {
@@ -188,20 +185,8 @@ public class SomLanguage extends TruffleLanguage<Universe> {
     }
   }
 
-  @Override
-  protected boolean isObjectOfLanguage(final Object object) {
-    if (object instanceof SAbstractObject) {
-      return true;
-    }
-    throw new NotYetImplementedException();
-  }
-
   public static Universe getCurrentContext() {
-    return getCurrentContext(SomLanguage.class);
-  }
-
-  public static Universe getCurrentContext(final Node node) {
-    return node.getRootNode().getLanguage(SomLanguage.class).getUniverse();
+    return current.getUniverse();
   }
 
   @Override


### PR DESCRIPTION
Truffle Guest Safepoints have a performance impact on most microbenchmarks, and thus, I initially disabled them.

Though, it's part of the Truffle feature set, so, it should be enabled. It's also used by TruffleRuby to implement its features. Thus, having enabled is good for comparability.

However, I should remember it, especially when comparing to PySOM.