### PR TITLE
Fix executable names for EE SomSom benchmarks

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -179,14 +179,14 @@ executors:
 
     SomSom-native-interp-ast-ee:
         path: .
-        executable: som-native-interp-ast
+        executable: som-native-interp-ast-ee
         args: "-cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
         profiler:
           perf: {}
 
     SomSom-native-interp-bc-ee:
         path: .
-        executable: som-native-interp-bc
+        executable: som-native-interp-bc-ee
         args: "-Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
         profiler:
           perf: {}


### PR DESCRIPTION
They where not yet benchmarked. This fixes it.