### PR TITLE
Update core-lib and other minor improvements

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -19,7 +19,7 @@ runs:
 benchmark_suites:
     macro-startup:
         gauge_adapter: RebenchLog
-        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
         iterations: 1
         invocations: 5
         benchmarks:
@@ -44,7 +44,7 @@ benchmark_suites:
 
     micro-startup:
         gauge_adapter: RebenchLog
-        command: &MICRO_CMD "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        command: &MICRO_CMD "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
         iterations: 1
         invocations: 5
         benchmarks:
@@ -98,7 +98,7 @@ benchmark_suites:
 
     micro-somsom:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
         iterations: 1
         benchmarks:
             - Loop:         {extra_args: 1, machines: [yuria3]}

--- a/rebench.conf
+++ b/rebench.conf
@@ -19,7 +19,7 @@ runs:
 benchmark_suites:
     macro-startup:
         gauge_adapter: RebenchLog
-        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 1
         invocations: 5
         benchmarks:
@@ -44,7 +44,7 @@ benchmark_suites:
 
     micro-startup:
         gauge_adapter: RebenchLog
-        command: &MICRO_CMD "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        command: &MICRO_CMD "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 1
         invocations: 5
         benchmarks:
@@ -98,7 +98,7 @@ benchmark_suites:
 
     micro-somsom:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 1
         benchmarks:
             - Loop:         {extra_args: 1, machines: [yuria3]}

--- a/src/trufflesom/compiler/Lexer.java
+++ b/src/trufflesom/compiler/Lexer.java
@@ -32,16 +32,6 @@ public final class Lexer {
   private static final String SEPARATOR = "----";
   private static final String PRIMITIVE = "primitive";
 
-  public static final class Peek {
-    public final Symbol nextSym;
-    public final String nextText;
-
-    private Peek(final Symbol sym, final String text) {
-      nextSym = sym;
-      nextText = text;
-    }
-  }
-
   private static class LexerState {
     LexerState() {
       startCoord = SourceCoordinate.createEmpty();
@@ -376,18 +366,18 @@ public final class Lexer {
     return peekDone;
   }
 
-  protected Peek peek() {
+  protected Symbol peek() {
     LexerState old = new LexerState(state);
     if (peekDone) {
       throw new IllegalStateException("SOM lexer: cannot peek twice!");
     }
     getSym();
-    Peek peek = new Peek(state.sym, state.text.toString());
+    Symbol nextSym = state.sym;
     stateAfterPeek = state;
     state = old;
 
     peekDone = true;
-    return peek;
+    return nextSym;
   }
 
   protected String getText() {

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -72,7 +72,6 @@ import com.oracle.truffle.api.source.SourceSection;
 import bd.basic.ProgramDefinitionError;
 import bd.source.SourceCoordinate;
 import bd.tools.structure.StructuralProbe;
-import trufflesom.compiler.Lexer.Peek;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
 import trufflesom.interpreter.nodes.GlobalNode;
@@ -682,8 +681,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
   }
 
   protected void peekForNextSymbolFromLexer() {
-    Peek peek = lexer.peek();
-    nextSym = peek.nextSym;
+    nextSym = lexer.peek();
   }
 
   protected static boolean isIdentifier(final Symbol sym) {

--- a/src/trufflesom/interpreter/objectstorage/ObjectLayout.java
+++ b/src/trufflesom/interpreter/objectstorage/ObjectLayout.java
@@ -43,17 +43,17 @@ public final class ObjectLayout {
 
       StorageLocation storage;
       if (type == Long.class) {
-        storage = StorageLocation.createForLong(this, i, nextFreePrimIdx);
+        storage = StorageLocation.createForLong(i, nextFreePrimIdx);
         nextFreePrimIdx++;
       } else if (type == Double.class) {
-        storage = StorageLocation.createForDouble(this, i, nextFreePrimIdx);
+        storage = StorageLocation.createForDouble(i, nextFreePrimIdx);
         nextFreePrimIdx++;
       } else if (type == Object.class) {
-        storage = StorageLocation.createForObject(this, nextFreeObjIdx);
+        storage = StorageLocation.createForObject(nextFreeObjIdx);
         nextFreeObjIdx++;
       } else {
         assert type == null;
-        storage = new UnwrittenStorageLocation(this, i);
+        storage = new UnwrittenStorageLocation(i);
       }
 
       storageLocations[i] = storage;

--- a/src/trufflesom/interpreter/objectstorage/StorageLocation.java
+++ b/src/trufflesom/interpreter/objectstorage/StorageLocation.java
@@ -42,42 +42,38 @@ public abstract class StorageLocation {
     void writeDouble(SObject obj, double value);
   }
 
-  public static StorageLocation createForLong(final ObjectLayout layout,
-      final long fieldIndex, final int primFieldIndex) {
+  public static StorageLocation createForLong(final long fieldIndex,
+      final int primFieldIndex) {
     CompilerAsserts.neverPartOfCompilation("StorageLocation");
     if (primFieldIndex < SObject.NUM_PRIMITIVE_FIELDS) {
-      return new LongDirectStoreLocation(layout, fieldIndex, primFieldIndex);
+      return new LongDirectStoreLocation(fieldIndex, primFieldIndex);
     } else {
-      return new LongArrayStoreLocation(layout, fieldIndex, primFieldIndex);
+      return new LongArrayStoreLocation(fieldIndex, primFieldIndex);
     }
   }
 
-  public static StorageLocation createForDouble(final ObjectLayout layout,
-      final long fieldIndex, final int primFieldIndex) {
+  public static StorageLocation createForDouble(final long fieldIndex,
+      final int primFieldIndex) {
     CompilerAsserts.neverPartOfCompilation("StorageLocation");
     if (primFieldIndex < SObject.NUM_PRIMITIVE_FIELDS) {
-      return new DoubleDirectStoreLocation(layout, fieldIndex, primFieldIndex);
+      return new DoubleDirectStoreLocation(fieldIndex, primFieldIndex);
     } else {
-      return new DoubleArrayStoreLocation(layout, fieldIndex, primFieldIndex);
+      return new DoubleArrayStoreLocation(fieldIndex, primFieldIndex);
     }
   }
 
-  public static StorageLocation createForObject(final ObjectLayout layout,
-      final int objFieldIndex) {
+  public static StorageLocation createForObject(final int objFieldIndex) {
     CompilerAsserts.neverPartOfCompilation("StorageLocation");
     if (objFieldIndex < SObject.NUM_PRIMITIVE_FIELDS) {
-      return new ObjectDirectStorageLocation(layout, objFieldIndex);
+      return new ObjectDirectStorageLocation(objFieldIndex);
     } else {
-      return new ObjectArrayStorageLocation(layout, objFieldIndex);
+      return new ObjectArrayStorageLocation(objFieldIndex);
     }
   }
-
-  @SuppressWarnings("unused") private final ObjectLayout layout; // for debugging only
 
   protected final long fieldIndex;
 
-  protected StorageLocation(final ObjectLayout layout, final long fieldIndex) {
-    this.layout = layout;
+  protected StorageLocation(final long fieldIndex) {
     this.fieldIndex = fieldIndex;
   }
 
@@ -95,8 +91,8 @@ public abstract class StorageLocation {
 
   protected static final class UnwrittenStorageLocation extends StorageLocation {
 
-    public UnwrittenStorageLocation(final ObjectLayout layout, final long index) {
-      super(layout, index);
+    public UnwrittenStorageLocation(final long index) {
+      super(index);
     }
 
     @Override
@@ -139,8 +135,8 @@ public abstract class StorageLocation {
 
   public abstract static class AbstractObjectStorageLocation extends StorageLocation {
 
-    public AbstractObjectStorageLocation(final ObjectLayout layout, final int fieldIndex) {
-      super(layout, fieldIndex);
+    public AbstractObjectStorageLocation(final int fieldIndex) {
+      super(fieldIndex);
     }
 
     @Override
@@ -165,8 +161,8 @@ public abstract class StorageLocation {
       extends AbstractObjectStorageLocation {
     private final long fieldOffset;
 
-    protected ObjectDirectStorageLocation(final ObjectLayout layout, final int fieldIndex) {
-      super(layout, fieldIndex);
+    protected ObjectDirectStorageLocation(final int fieldIndex) {
+      super(fieldIndex);
       fieldOffset = StorageAnalyzer.getObjectFieldOffset(fieldIndex);
     }
 
@@ -198,8 +194,8 @@ public abstract class StorageLocation {
       extends AbstractObjectStorageLocation {
     private final int extensionIndex;
 
-    public ObjectArrayStorageLocation(final ObjectLayout layout, final int fieldIndex) {
-      super(layout, fieldIndex);
+    public ObjectArrayStorageLocation(final int fieldIndex) {
+      super(fieldIndex);
       extensionIndex = fieldIndex - SObject.NUM_OBJECT_FIELDS;
     }
 
@@ -232,9 +228,8 @@ public abstract class StorageLocation {
   protected abstract static class PrimitiveStorageLocation extends StorageLocation {
     protected final int mask;
 
-    protected PrimitiveStorageLocation(final ObjectLayout layout,
-        final long fieldIndex, final int primField) {
-      super(layout, fieldIndex);
+    protected PrimitiveStorageLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex);
       mask = SObject.getPrimitiveFieldMask(primField);
     }
 
@@ -252,18 +247,16 @@ public abstract class StorageLocation {
       extends PrimitiveStorageLocation {
     protected final long fieldMemoryOffset;
 
-    protected PrimitiveDirectStoreLocation(final ObjectLayout layout, final long fieldIndex,
-        final int primField) {
-      super(layout, fieldIndex, primField);
+    protected PrimitiveDirectStoreLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex, primField);
       this.fieldMemoryOffset = StorageAnalyzer.getPrimitiveFieldOffset(primField);
     }
   }
 
   public static final class DoubleDirectStoreLocation extends PrimitiveDirectStoreLocation
       implements DoubleStorageLocation {
-    public DoubleDirectStoreLocation(final ObjectLayout layout,
-        final long fieldIndex, final int primField) {
-      super(layout, fieldIndex, primField);
+    public DoubleDirectStoreLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex, primField);
     }
 
     @Override
@@ -327,9 +320,8 @@ public abstract class StorageLocation {
   protected static final class LongDirectStoreLocation extends PrimitiveDirectStoreLocation
       implements LongStorageLocation {
 
-    public LongDirectStoreLocation(final ObjectLayout layout, final long fieldIndex,
-        final int primField) {
-      super(layout, fieldIndex, primField);
+    public LongDirectStoreLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex, primField);
     }
 
     @Override
@@ -400,9 +392,8 @@ public abstract class StorageLocation {
   public abstract static class PrimitiveArrayStoreLocation extends PrimitiveStorageLocation {
     protected final int extensionIndex;
 
-    public PrimitiveArrayStoreLocation(final ObjectLayout layout,
-        final long fieldIndex, final int primField) {
-      super(layout, fieldIndex, primField);
+    public PrimitiveArrayStoreLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex, primField);
       extensionIndex = primField - SObject.NUM_PRIMITIVE_FIELDS;
       assert extensionIndex >= 0;
     }
@@ -410,9 +401,8 @@ public abstract class StorageLocation {
 
   public static final class LongArrayStoreLocation extends PrimitiveArrayStoreLocation
       implements LongStorageLocation {
-    public LongArrayStoreLocation(final ObjectLayout layout,
-        final long fieldIndex, final int primField) {
-      super(layout, fieldIndex, primField);
+    public LongArrayStoreLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex, primField);
     }
 
     @Override
@@ -484,9 +474,8 @@ public abstract class StorageLocation {
 
   public static final class DoubleArrayStoreLocation extends PrimitiveArrayStoreLocation
       implements DoubleStorageLocation {
-    public DoubleArrayStoreLocation(final ObjectLayout layout,
-        final long fieldIndex, final int primField) {
-      super(layout, fieldIndex, primField);
+    public DoubleArrayStoreLocation(final long fieldIndex, final int primField) {
+      super(fieldIndex, primField);
     }
 
     @Override

--- a/src/trufflesom/interpreter/objectstorage/StorageLocation.java
+++ b/src/trufflesom/interpreter/objectstorage/StorageLocation.java
@@ -22,21 +22,7 @@ import trufflesom.vmobjects.SObject;
 
 
 public abstract class StorageLocation {
-  private static Unsafe loadUnsafe() {
-    try {
-      return Unsafe.getUnsafe();
-    } catch (SecurityException e) {}
-    try {
-      Field theUnsafeInstance = Unsafe.class.getDeclaredField("theUnsafe");
-      theUnsafeInstance.setAccessible(true);
-      return (Unsafe) theUnsafeInstance.get(Unsafe.class);
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "exception while trying to get Unsafe.theUnsafe via reflection:", e);
-    }
-  }
-
-  private static final Unsafe unsafe = loadUnsafe();
+  private static final Unsafe unsafe = UnsafeUtil.load();
 
   public static long getFieldOffset(final Field field) {
     return unsafe.objectFieldOffset(field);

--- a/tests/trufflesom/intepreter/objectstorage/BasicStorageTester.java
+++ b/tests/trufflesom/intepreter/objectstorage/BasicStorageTester.java
@@ -92,7 +92,7 @@ public class BasicStorageTester {
   }
 
   private static void testDirectDouble(final SObject obj) {
-    StorageLocation sl = StorageLocation.createForDouble(null, 0, 0);
+    StorageLocation sl = StorageLocation.createForDouble(0, 0);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, 5.5);
@@ -104,7 +104,7 @@ public class BasicStorageTester {
   }
 
   private static void testDirectLong(final SObject obj) {
-    StorageLocation sl = StorageLocation.createForLong(null, 1, 1);
+    StorageLocation sl = StorageLocation.createForLong(1, 1);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, 32L);
@@ -116,7 +116,7 @@ public class BasicStorageTester {
   }
 
   private static void testDirectObject(final SObject obj) {
-    StorageLocation sl = StorageLocation.createForObject(null, 2);
+    StorageLocation sl = StorageLocation.createForObject(2);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, obj);
@@ -128,7 +128,7 @@ public class BasicStorageTester {
   }
 
   private static void testExtDouble(final SObject obj) {
-    StorageLocation sl = StorageLocation.createForDouble(null, 0, 10);
+    StorageLocation sl = StorageLocation.createForDouble(0, 10);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, 5.5);
@@ -139,7 +139,7 @@ public class BasicStorageTester {
   }
 
   private static void testExtLong(final SObject obj) {
-    StorageLocation sl = StorageLocation.createForLong(null, 1, 11);
+    StorageLocation sl = StorageLocation.createForLong(1, 11);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, 32L);
@@ -150,7 +150,7 @@ public class BasicStorageTester {
   }
 
   private static void testExtObject(final SObject obj) {
-    StorageLocation sl = StorageLocation.createForObject(null, 12);
+    StorageLocation sl = StorageLocation.createForObject(12);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, obj);
@@ -162,7 +162,7 @@ public class BasicStorageTester {
 
   private static StorageLocation testDouble(final SObject obj, final int idx,
       final double value) {
-    StorageLocation sl = StorageLocation.createForDouble(null, idx, idx);
+    StorageLocation sl = StorageLocation.createForDouble(idx, idx);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, value);
@@ -174,7 +174,7 @@ public class BasicStorageTester {
   }
 
   private static StorageLocation testLong(final SObject obj, final int idx, final long value) {
-    StorageLocation sl = StorageLocation.createForLong(null, idx, idx);
+    StorageLocation sl = StorageLocation.createForLong(idx, idx);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, value);
@@ -187,7 +187,7 @@ public class BasicStorageTester {
 
   private static StorageLocation testObject(final SObject obj, final int idx,
       final Object value) {
-    StorageLocation sl = StorageLocation.createForObject(null, idx);
+    StorageLocation sl = StorageLocation.createForObject(idx);
     assertIsInitiallyNil(obj, sl);
 
     sl.write(obj, value);


### PR DESCRIPTION
- with the updated core-lib, it's now explicit that we do GC between benchmark iterations
- avoid unnecessary object for peek operation in lexer
- remove redundant code to load `Unsafe`
- remove `layout` from `StorageLocation` to make it independent. We can't really cache them though, because we still have the `fieldIndex` as well as the other "raw access index". The `fieldIndex` is needed for fallbacks, so, there might be some special cases where it could be avoided, but not generally.