### PR TITLE
Add Tool to Collect Statistics about AST Nodes

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,11 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="tests"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src_gen">
 		<attributes>
 			<attribute name="optional" value="true"/>
@@ -20,5 +24,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/com.oracle.truffle.api.profiles"/>
 	<classpathentry kind="src" path="/BlackDiamonds"/>
 	<classpathentry kind="src" path="/org.graalvm.polyglot"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/com.oracle.truffle.api.instrumentation"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/som
+++ b/som
@@ -59,6 +59,9 @@ explore.add_argument('-v', '--visual-vm', help='connect to VisualVM for profilin
 explore.add_argument('-fr', '--flight-recorder', help='profile with Java Flight Recorder',
                     dest='flight_recorder', action='store_true', default=False)
 
+tools = parser.add_argument_group('Tools', 'Tools for various purposes')
+explore.add_argument('-n', '--node-stats', help='collect details about AST nodes',
+                    dest='nodestats', action='store_true', default=False)
 
 parser.add_argument('-o', '--only', help='only compile give methods, comma separated list',
                     dest='only_compile', default=None)
@@ -294,6 +297,8 @@ if args.flight_recorder:
     flags += ['-XX:+UnlockCommercialFeatures', '-XX:+FlightRecorder',
               '-XX:StartFlightRecording=delay=10s,duration=10d,name=fr-recording2,filename=fr-recording2.jfr,settings=profile']
 
+if args.nodestats:
+    flags += ['-Dsom.nodestats=true']
 
 if args.assert_:
     flags += ['-esa', '-ea']

--- a/src/tools/nodestats/AstNode.java
+++ b/src/tools/nodestats/AstNode.java
@@ -1,0 +1,176 @@
+package tools.nodestats;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class AstNode {
+  private final Class<?> nodeClass;
+  private List<AstNode>  children;
+
+  private int height;
+
+  private int hashcode;
+
+  public AstNode(final Class<?> nodeClass) {
+    this.nodeClass = nodeClass;
+    height = -1;
+    hashcode = -1;
+  }
+
+  private AstNode(final Class<?> nodeClass, final List<AstNode> children, final int height) {
+    this.nodeClass = nodeClass;
+    this.children = children;
+    this.height = height;
+    hashcode = -1;
+  }
+
+  public void addChild(final AstNode child) {
+    hashcode = -1;
+    if (children == null) {
+      children = new ArrayList<>(3);
+    }
+
+    children.add(child);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AstNode a = (AstNode) o;
+    if (nodeClass != a.nodeClass) {
+      return false;
+    }
+
+    if (children == a.children) {
+      return true;
+    }
+
+    if (children == null || a.children == null) {
+      return false;
+    }
+
+    if (children.size() != a.children.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < children.size(); i += 1) {
+      if (!children.get(i).equals(a.children.get(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashcode != -1) {
+      return hashcode;
+    }
+
+    if (children == null) {
+      hashcode = nodeClass.hashCode();
+      return hashcode;
+    }
+
+    Object[] hashingObjects = new Object[1 + children.size()];
+    hashingObjects[0] = nodeClass;
+
+    for (int i = 0; i < children.size(); i += 1) {
+      hashingObjects[i + 1] = children.get(i);
+    }
+
+    hashcode = Arrays.hashCode(hashingObjects);
+    return hashcode;
+  }
+
+  public int collectTreesAndDetermineHeight(final int maxCandidateTreeHeight,
+      final NodeStatisticsCollector collector) {
+    if (children == null) {
+      height = 0;
+      return 0;
+    }
+
+    int maxChildDepth = 0;
+    for (AstNode c : children) {
+      maxChildDepth = Math.max(maxChildDepth,
+          c.collectTreesAndDetermineHeight(maxCandidateTreeHeight, collector));
+    }
+
+    height = maxChildDepth + 1;
+
+    if (height >= 1 && collector != null) {
+      for (int h = 1; h <= maxCandidateTreeHeight && h <= height; h += 1) {
+        collector.addCandidate(cloneWithMaxHeight(h));
+      }
+    }
+
+    return height;
+  }
+
+  public AstNode cloneWithMaxHeight(final int maxTreeHeight) {
+    assert height >= 0;
+    if (maxTreeHeight >= height || height == 0) {
+      return this;
+    }
+
+    assert height > 0 && children != null && children.size() > 0;
+
+    ArrayList<AstNode> clonedChildren;
+    if (maxTreeHeight == 0) {
+      clonedChildren = null;
+    } else {
+      clonedChildren = new ArrayList<>(children.size());
+      for (AstNode c : children) {
+        clonedChildren.add(c.cloneWithMaxHeight(maxTreeHeight - 1));
+      }
+    }
+
+    AstNode clone = new AstNode(nodeClass, clonedChildren, maxTreeHeight);
+    return clone;
+  }
+
+  public List<AstNode> getChildren() {
+    return children;
+  }
+
+  public Class<?> getNodeClass() {
+    return nodeClass;
+  }
+
+  public int getHeight() {
+    return height;
+  }
+
+  public void prettyPrint(final StringBuilder builder, final int level) {
+    // add indentation
+    for (int i = 0; i < level; i++) {
+      builder.append("  ");
+    }
+
+    builder.append(nodeClass.getSimpleName());
+    builder.append('\n');
+
+    if (children == null) {
+      return;
+    }
+
+    for (AstNode c : children) {
+      c.prettyPrint(builder, level + 1);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "Node(" + nodeClass.getSimpleName() + ", " + height + ")";
+  }
+}

--- a/src/tools/nodestats/AstNode.java
+++ b/src/tools/nodestats/AstNode.java
@@ -151,21 +151,26 @@ public class AstNode {
     return height;
   }
 
-  public void prettyPrint(final StringBuilder builder, final int level) {
-    // add indentation
-    for (int i = 0; i < level; i++) {
-      builder.append("  ");
-    }
-
+  public void yamlPrint(final StringBuilder builder, final String indent, final int level) {
     builder.append(nodeClass.getSimpleName());
-    builder.append('\n');
 
     if (children == null) {
+      builder.append('\n');
       return;
     }
 
+    builder.append(':');
+    builder.append('\n');
+
     for (AstNode c : children) {
-      c.prettyPrint(builder, level + 1);
+      for (int i = 0; i < level; i += 1) {
+        builder.append(indent);
+      }
+
+      builder.append('-');
+      builder.append(' ');
+
+      c.yamlPrint(builder, indent, level + 1);
     }
   }
 

--- a/src/tools/nodestats/NodeStatisticsCollector.java
+++ b/src/tools/nodestats/NodeStatisticsCollector.java
@@ -20,6 +20,9 @@ public class NodeStatisticsCollector {
 
   private final int maxCandidateTreeHeight;
 
+  private int numberOfNodes;
+  private int numberOfNodeClasses;
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   public NodeStatisticsCollector(final int maxCandidateTreeHeight) {
     fullTrees = new HashSet<>();
@@ -33,6 +36,24 @@ public class NodeStatisticsCollector {
     for (RootNode root : roots) {
       add(root);
     }
+  }
+
+  public Map<Class<?>, Integer> getNodeNumbers() {
+    return nodeNumbers;
+  }
+
+  public int getNumberOfNodes() {
+    if (numberOfNodes == 0) {
+      numberOfNodes = nodeNumbers.values().stream().reduce(0, Integer::sum);
+    }
+    return numberOfNodes;
+  }
+
+  public int getNumberOfNodeTypes() {
+    if (numberOfNodeClasses == 0) {
+      numberOfNodeClasses = nodeNumbers.size();
+    }
+    return numberOfNodeClasses;
   }
 
   public void add(final RootNode root) {
@@ -52,7 +73,7 @@ public class NodeStatisticsCollector {
     return ast;
   }
 
-  public void collectCandidates() {
+  public void collectStats() {
     for (AstNode tree : fullTrees) {
       tree.collectTreesAndDetermineHeight(maxCandidateTreeHeight, this);
     }

--- a/src/tools/nodestats/NodeStatisticsCollector.java
+++ b/src/tools/nodestats/NodeStatisticsCollector.java
@@ -1,0 +1,88 @@
+package tools.nodestats;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
+
+
+public class NodeStatisticsCollector {
+
+  private final Set<AstNode>            fullTrees;
+  private final Map<AstNode, Integer>[] partialTrees;
+
+  private final Map<Class<?>, Integer> nodeNumbers;
+
+  private final int maxCandidateTreeHeight;
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public NodeStatisticsCollector(final int maxCandidateTreeHeight) {
+    fullTrees = new HashSet<>();
+    nodeNumbers = new HashMap<>();
+
+    partialTrees = new Map[maxCandidateTreeHeight];
+    this.maxCandidateTreeHeight = maxCandidateTreeHeight;
+  }
+
+  public void addAll(final Collection<RootNode> roots) {
+    for (RootNode root : roots) {
+      add(root);
+    }
+  }
+
+  public void add(final RootNode root) {
+    fullTrees.add(collect(root));
+  }
+
+  private AstNode collect(final Node node) {
+    nodeNumbers.merge(node.getClass(), 1, Integer::sum);
+
+    AstNode ast = new AstNode(node.getClass());
+
+    for (Node c : node.getChildren()) {
+      AstNode child = collect(c);
+      ast.addChild(child);
+    }
+
+    return ast;
+  }
+
+  public void collectCandidates() {
+    for (AstNode tree : fullTrees) {
+      tree.collectTreesAndDetermineHeight(maxCandidateTreeHeight, this);
+    }
+  }
+
+  public void addCandidate(final AstNode candidate) {
+    int h = candidate.getHeight();
+    assert h >= 1;
+    if (partialTrees[h - 1] == null) {
+      partialTrees[h - 1] = new HashMap<>();
+    }
+
+    partialTrees[h - 1].merge(candidate, 1, Integer::sum);
+  }
+
+  public Set<SubTree> getSubTrees() {
+    Set<SubTree> result = new HashSet<>();
+
+    for (Map<AstNode, Integer> candidatesForHeight : partialTrees) {
+      if (candidatesForHeight == null) {
+        continue;
+      }
+
+      for (Entry<AstNode, Integer> c : candidatesForHeight.entrySet()) {
+        assert c.getKey().getHeight() >= 1;
+        SubTree candidate = new SubTree(c.getKey(), c.getValue());
+        result.add(candidate);
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/tools/nodestats/NodeStatsTool.java
+++ b/src/tools/nodestats/NodeStatsTool.java
@@ -1,0 +1,109 @@
+package tools.nodestats;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Instrument;
+
+import com.oracle.truffle.api.instrumentation.Instrumenter;
+import com.oracle.truffle.api.instrumentation.SourceSectionFilter;
+import com.oracle.truffle.api.instrumentation.StandardTags.RootTag;
+import com.oracle.truffle.api.instrumentation.TruffleInstrument;
+import com.oracle.truffle.api.instrumentation.TruffleInstrument.Registration;
+import com.oracle.truffle.api.nodes.RootNode;
+
+import tools.nodestats.SubTree.ScoredAlphabeticRootOrder;
+
+
+/**
+ * The {@link NodeStatsTool} is a Truffle instrumentation tool that collects
+ * statistics about all {@link RootNode}s at the end of an execution.
+ */
+@Registration(name = "AST Node Statistics", id = NodeStatsTool.ID, version = "0.1",
+    services = {NodeStatsTool.class})
+public class NodeStatsTool extends TruffleInstrument {
+
+  public static final String ID = "nodestats";
+
+  private final Set<RootNode> rootNodes;
+
+  public NodeStatsTool() {
+    rootNodes = new HashSet<>();
+  }
+
+  public static void enable(final Engine engine) {
+    Instrument instrument = engine.getInstruments().get(ID);
+    if (instrument == null) {
+      throw new IllegalStateException(
+          "NodeStatsTool not properly installed into polyglot.Engine");
+    }
+    instrument.lookup(NodeStatsTool.class);
+  }
+
+  @Override
+  protected void onCreate(final Env env) {
+    Instrumenter instrumenter = env.getInstrumenter();
+
+    SourceSectionFilter rootFilter =
+        SourceSectionFilter.newBuilder().tagIs(RootTag.class).build();
+
+    instrumenter.attachLoadSourceSectionListener(
+        rootFilter, e -> rootNodes.add(e.getNode().getRootNode()),
+        true);
+
+    env.registerService(this);
+  }
+
+  @Override
+  protected void onDispose(final Env env) {
+    String outputFile = System.getProperty("ns.output", "node-stats.yml");
+    collectStatistics(outputFile);
+  }
+
+  private void collectStatistics(final String outputFile) {
+    println("[ns] AST Node Statistics");
+    println("[ns] -------------------");
+    println("[ns] Number of Methods: " + rootNodes.size());
+
+    NodeStatisticsCollector collector = new NodeStatisticsCollector(3);
+    collector.addAll(rootNodes);
+    collector.collectCandidates();
+
+    Set<SubTree> cs = collector.getSubTrees();
+    cs.stream();
+
+    final List<SubTree> sorted = cs.stream()
+                                   .sorted(new ScoredAlphabeticRootOrder())
+                                   .collect(Collectors.toList());
+
+    // Universe.println("[ns] Number of Nodes: " + collector.getNumberOfAstNodes());
+
+    StringBuilder builder = new StringBuilder();
+    builder.append("# Static Node Frequency\n\n");
+
+    for (SubTree c : sorted) {
+      c.prettyPrint(builder);
+      builder.append('\n');
+    }
+
+    Path reportPath = Paths.get(outputFile);
+    try {
+      Files.write(reportPath, builder.toString().getBytes());
+    } catch (IOException e) {
+      throw new RuntimeException("Could not write AST Node Statistics: " + e);
+    }
+  }
+
+  public static void println(final String msg) {
+    // Checkstyle: stop
+    System.out.println(msg);
+    // Checkstyle: resume
+  }
+}

--- a/src/tools/nodestats/SubTree.java
+++ b/src/tools/nodestats/SubTree.java
@@ -1,11 +1,9 @@
 package tools.nodestats;
 
-import java.util.Comparator;
-
-
 final class SubTree {
   private final AstNode rootNode;
-  private final int     score;
+
+  final int score;
 
   SubTree(final AstNode rootNode, final int score) {
     this.rootNode = rootNode;
@@ -22,14 +20,29 @@ final class SubTree {
 
   public String prettyPrint() {
     StringBuilder builder = new StringBuilder();
-    rootNode.prettyPrint(builder, 0);
+    rootNode.yamlPrint(builder, "  ", 0);
     return builder.toString();
   }
 
-  public void prettyPrint(final StringBuilder builder) {
+  public void yamlPrint(final StringBuilder builder, final String indent, final int level) {
+
+    for (int i = 0; i < level; i += 1) {
+      builder.append(indent);
+    }
+    builder.append('-');
+    builder.append(' ');
+
     builder.append("score: ");
-    builder.append(score + " ");
-    rootNode.prettyPrint(builder, 0);
+    builder.append(score);
+    builder.append('\n');
+
+    int nextLevel = level + 1;
+
+    for (int i = 0; i < nextLevel; i += 1) {
+      builder.append(indent);
+    }
+
+    rootNode.yamlPrint(builder, indent, nextLevel);
   }
 
   @Override
@@ -55,17 +68,5 @@ final class SubTree {
   public String toString() {
     return "Candidate(" + score + ": " + rootNode.getNodeClass().getSimpleName() + ", "
         + rootNode.getHeight() + ")";
-  }
-
-  public static final class ScoredAlphabeticRootOrder implements Comparator<SubTree> {
-    @Override
-    public int compare(final SubTree o1, final SubTree o2) {
-      int score = o2.score - o1.score;
-      if (score != 0) {
-        return score;
-      }
-
-      return o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName());
-    }
   }
 }

--- a/src/tools/nodestats/SubTree.java
+++ b/src/tools/nodestats/SubTree.java
@@ -1,0 +1,71 @@
+package tools.nodestats;
+
+import java.util.Comparator;
+
+
+final class SubTree {
+  private final AstNode rootNode;
+  private final int     score;
+
+  SubTree(final AstNode rootNode, final int score) {
+    this.rootNode = rootNode;
+    this.score = score;
+  }
+
+  public AstNode getRoot() {
+    return rootNode;
+  }
+
+  public int getScore() {
+    return score;
+  }
+
+  public String prettyPrint() {
+    StringBuilder builder = new StringBuilder();
+    rootNode.prettyPrint(builder, 0);
+    return builder.toString();
+  }
+
+  public void prettyPrint(final StringBuilder builder) {
+    builder.append("score: ");
+    builder.append(score + " ");
+    rootNode.prettyPrint(builder, 0);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SubTree candidate = (SubTree) o;
+    return rootNode.equals(candidate.rootNode);
+  }
+
+  @Override
+  public int hashCode() {
+    return rootNode.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "Candidate(" + score + ": " + rootNode.getNodeClass().getSimpleName() + ", "
+        + rootNode.getHeight() + ")";
+  }
+
+  public static final class ScoredAlphabeticRootOrder implements Comparator<SubTree> {
+    @Override
+    public int compare(final SubTree o1, final SubTree o2) {
+      int score = o2.score - o1.score;
+      if (score != 0) {
+        return score;
+      }
+
+      return o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName());
+    }
+  }
+}

--- a/src/tools/nodestats/YamlReport.java
+++ b/src/tools/nodestats/YamlReport.java
@@ -1,0 +1,107 @@
+package tools.nodestats;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+public class YamlReport {
+  private static final class ScoredAlphaOrder implements Comparator<Entry<Class<?>, Integer>> {
+    @Override
+    public int compare(final Entry<Class<?>, Integer> e1, final Entry<Class<?>, Integer> e2) {
+      int score = e2.getValue() - e1.getValue();
+      if (score != 0) {
+        return score;
+      }
+
+      return e1.getClass().getName().compareTo(e2.getClass().getName());
+    }
+  }
+
+  public static final class ScoredAlphabeticRootOrder implements Comparator<SubTree> {
+    @Override
+    public int compare(final SubTree o1, final SubTree o2) {
+      int score = o2.score - o1.score;
+      if (score != 0) {
+        return score;
+      }
+
+      return o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName());
+    }
+  }
+
+  private static void reportNodeNumbers(final NodeStatisticsCollector collector,
+      final StringBuilder builder, final String indent) {
+    Map<Class<?>, Integer> allNodes = collector.getNodeNumbers();
+
+    int maxNameLength = allNodes.keySet().stream()
+                                .map(c -> c.getName())
+                                .mapToInt(String::length)
+                                .max()
+                                .orElse(0);
+
+    List<Entry<Class<?>, Integer>> nodes = allNodes.entrySet().stream()
+                                                   .sorted(new ScoredAlphaOrder())
+                                                   .collect(Collectors.toList());
+
+    builder.append(indent);
+    builder.append("node-numbers:\n");
+
+    for (Entry<Class<?>, Integer> e : nodes) {
+      builder.append(indent);
+      builder.append(indent);
+      builder.append('-');
+      builder.append(' ');
+
+      String name = e.getKey().getName();
+      int length = name.length();
+
+      builder.append(name);
+      builder.append(':');
+
+      for (int i = 0; i < maxNameLength - length; i += 1) {
+        builder.append(' ');
+      }
+
+      builder.append("  { score: ");
+      builder.append(e.getValue());
+      builder.append(" }\n");
+    }
+  }
+
+  private static void reportSubTrees(final NodeStatisticsCollector collector,
+      final StringBuilder builder, final String indent) {
+    builder.append(indent);
+    builder.append("subtree-frequency:\n");
+
+    Set<SubTree> cs = collector.getSubTrees();
+    final List<SubTree> sorted = cs.stream()
+                                   .sorted(new ScoredAlphabeticRootOrder())
+                                   .collect(Collectors.toList());
+
+    for (SubTree c : sorted) {
+      c.yamlPrint(builder, indent, 2);
+      builder.append('\n');
+    }
+
+  }
+
+  public static String createReport(final NodeStatisticsCollector collector) {
+    StringBuilder builder = new StringBuilder();
+
+    builder.append("# Node Statistics Report\n");
+    builder.append("report:\n");
+
+    reportNodeNumbers(collector, builder, "  ");
+
+    builder.append('\n');
+    builder.append('\n');
+
+    reportSubTrees(collector, builder, "  ");
+
+    return builder.toString();
+  }
+}

--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -67,6 +67,7 @@ import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
 
+@SuppressWarnings("unchecked")
 public class MethodGenerationContext
     implements ScopeBuilder<MethodGenerationContext>, Scope<LexicalScope, Method> {
 

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -88,6 +88,7 @@ import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SSymbol;
 
 
+@SuppressWarnings("unchecked")
 public class BytecodeMethodGenContext extends MethodGenerationContext {
 
   private final List<Object>                  literals;

--- a/src/trufflesom/interpreter/LexicalScope.java
+++ b/src/trufflesom/interpreter/LexicalScope.java
@@ -10,6 +10,7 @@ import bd.inlining.Scope;
 import trufflesom.compiler.Variable;
 
 
+@SuppressWarnings("unchecked")
 public final class LexicalScope implements Scope<LexicalScope, Method> {
   private final FrameDescriptor frameDescriptor;
   private final LexicalScope    outerScope;

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -21,6 +21,8 @@
  */
 package trufflesom.interpreter;
 
+import java.util.Objects;
+
 import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
@@ -67,6 +69,11 @@ public final class Method extends Invokable {
     }
 
     return m.sourceSection.equals(sourceSection);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, sourceSection);
   }
 
   @Override

--- a/src/trufflesom/interpreter/SomLanguage.java
+++ b/src/trufflesom/interpreter/SomLanguage.java
@@ -14,6 +14,8 @@ import com.oracle.truffle.api.Option;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.ProvidedTags;
+import com.oracle.truffle.api.instrumentation.StandardTags.RootTag;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 
@@ -25,6 +27,7 @@ import trufflesom.vm.Universe.SomExit;
 @TruffleLanguage.Registration(id = "som", name = "som", version = "0.1.0",
     defaultMimeType = SomLanguage.MIME_TYPE,
     characterMimeTypes = SomLanguage.MIME_TYPE)
+@ProvidedTags({RootTag.class})
 public class SomLanguage extends TruffleLanguage<Universe> {
 
   public static final String MIME_TYPE = "application/x-som-smalltalk";

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -49,6 +49,7 @@ import com.oracle.truffle.api.utilities.CyclicAssumption;
 import bd.basic.IdProvider;
 import bd.basic.ProgramDefinitionError;
 import bd.tools.structure.StructuralProbe;
+import tools.nodestats.NodeStatsTool;
 import trufflesom.compiler.Disassembler;
 import trufflesom.compiler.Field;
 import trufflesom.compiler.SourcecodeCompiler;
@@ -143,8 +144,16 @@ public final class Universe implements IdProvider<SSymbol> {
 
     Context context = builder.build();
 
+    setupInstruments(context);
+
     Value returnCode = context.eval(SomLanguage.START);
     return returnCode;
+  }
+
+  private static void setupInstruments(final Context context) {
+    if (VmSettings.UseNodeStatsTool) {
+      NodeStatsTool.enable(context.getEngine());
+    }
   }
 
   public Object interpret(String[] arguments) {
@@ -608,7 +617,7 @@ public final class Universe implements IdProvider<SSymbol> {
       try {
         // Load the class from a file and return the loaded class
         SClass result =
-            compiler.compileClass(cpEntry, name.getString(), systemClass, systemClassProbe);
+            compiler.compileClass(cpEntry, name.getString(), systemClass, structuralProbe);
         if (printIR > 0) {
           Disassembler.dump(result.getSOMClass(this));
           Disassembler.dump(result);
@@ -702,9 +711,9 @@ public final class Universe implements IdProvider<SSymbol> {
     return primitives;
   }
 
-  public void setSystemClassProbe(
+  public void setStructuralProbe(
       final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe) {
-    systemClassProbe = probe;
+    structuralProbe = probe;
   }
 
   public final SClass objectClass;
@@ -733,10 +742,7 @@ public final class Universe implements IdProvider<SSymbol> {
   private String[]              classPath;
   @CompilationFinal private int printIR;
 
-  /**
-   * A {@link StructuralProbe} that is used when loading the system classes.
-   */
-  private StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> systemClassProbe;
+  private static StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe;
 
   private final SomLanguage language;
 

--- a/src/trufflesom/vm/VmSettings.java
+++ b/src/trufflesom/vm/VmSettings.java
@@ -10,6 +10,8 @@ public class VmSettings implements Settings {
   public static final boolean UseJitCompiler;
   public static final boolean PrintStackTraceOnDNU;
 
+  public static final boolean UseNodeStatsTool;
+
   static {
     String val = System.getProperty("som.interp", "AST").toUpperCase();
     UseAstInterp = "AST".equals(val);
@@ -22,6 +24,9 @@ public class VmSettings implements Settings {
 
     val = System.getProperty("som.jitCompiler", "true");
     UseJitCompiler = "true".equals(val);
+
+    val = System.getProperty("som.nodestats", "false");
+    UseNodeStatsTool = "true".equals(val);
 
     val = System.getProperty("som.printStackTraceOnDNU", "false");
     PrintStackTraceOnDNU = "true".equals(val);

--- a/tests/tools/nodestats/AstNodeTests.java
+++ b/tests/tools/nodestats/AstNodeTests.java
@@ -1,0 +1,84 @@
+package tools.nodestats;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.List;
+
+import org.junit.Test;
+
+
+public class AstNodeTests {
+
+  @Test
+  public void testCloneHeight0() {
+    AstNode tree = new AstNode(getClass());
+    tree.collectTreesAndDetermineHeight(100, null);
+
+    AstNode clone = tree.cloneWithMaxHeight(0);
+    assertSame(tree, clone);
+
+    tree.addChild(new AstNode(getClass()));
+
+    tree.collectTreesAndDetermineHeight(100, null);
+
+    clone = tree.cloneWithMaxHeight(0);
+    assertNotSame(tree, clone);
+
+    assertFalse(tree.equals(clone));
+    assertNotEquals(tree.hashCode(), clone.hashCode());
+  }
+
+  @Test
+  public void testCloneHeight1() {
+    AstNode tree = new AstNode(getClass());
+    tree.collectTreesAndDetermineHeight(100, null);
+
+    AstNode clone = tree.cloneWithMaxHeight(1);
+    assertSame(tree, clone);
+
+    tree.addChild(new AstNode(getClass()));
+
+    tree.collectTreesAndDetermineHeight(100, null);
+
+    clone = tree.cloneWithMaxHeight(1);
+    assertSame(tree, clone);
+  }
+
+  @Test
+  public void testCloneHeight2() {
+    AstNode tree = new AstNode(getClass());
+
+    AstNode child1 = new AstNode(getClass());
+    child1.addChild(new AstNode(getClass()));
+    child1.addChild(new AstNode(getClass()));
+
+    AstNode child2 = new AstNode(getClass());
+    AstNode child21 = new AstNode(getClass());
+    child2.addChild(child21);
+    child2.addChild(new AstNode(getClass()));
+
+    child21.addChild(new AstNode(getClass()));
+
+    tree.addChild(child1);
+    tree.addChild(child2);
+
+    tree.collectTreesAndDetermineHeight(100, null);
+
+    AstNode clone = tree.cloneWithMaxHeight(1);
+    assertNotSame(tree, clone);
+    List<AstNode> children = clone.getChildren();
+
+    assertEquals(2, children.size());
+
+    AstNode c1 = children.get(0);
+    AstNode c2 = children.get(1);
+
+    assertNull(c1.getChildren());
+    assertNull(c2.getChildren());
+  }
+}

--- a/tests/tools/nodestats/StaticNodeStructureTests.java
+++ b/tests/tools/nodestats/StaticNodeStructureTests.java
@@ -1,0 +1,104 @@
+package tools.nodestats;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.junit.Test;
+
+import trufflesom.interpreter.LexicalScope;
+import trufflesom.interpreter.Method;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.literals.LiteralNode;
+import trufflesom.primitives.arithmetic.AdditionPrim;
+import trufflesom.primitives.arithmetic.AdditionPrimFactory;
+import trufflesom.primitives.arithmetic.SubtractionPrimFactory;
+import trufflesom.primitives.basics.AsStringPrimFactory;
+import trufflesom.primitives.basics.IntegerPrimsFactory.AbsPrimFactory;
+import trufflesom.primitives.basics.IntegerPrimsFactory.AsDoubleValueFactory;
+
+
+public class StaticNodeStructureTests {
+
+  @Test
+  public void testSimpleAdd() {
+    ExpressionNode body =
+        AdditionPrimFactory.create(LiteralNode.create(1L), LiteralNode.create(2L));
+    Method m = constructMethod(body);
+
+    NodeStatisticsCollector s = new NodeStatisticsCollector(5);
+    s.add(m);
+
+    s.collectCandidates();
+
+    Set<SubTree> cs = s.getSubTrees();
+
+    assertEquals(3, cs.size());
+    Iterator<SubTree> i = cs.iterator();
+    SubTree c1 = i.next();
+    SubTree c2 = i.next();
+    SubTree c3 = i.next();
+
+    assertTrue(c1.getRoot().getNodeClass() == Method.class
+        || (Class<?>) c2.getRoot().getNodeClass() == Method.class
+        || (Class<?>) c3.getRoot().getNodeClass() == Method.class);
+
+    assertTrue(AdditionPrim.class.isAssignableFrom(c1.getRoot().getNodeClass()) ||
+        AdditionPrim.class.isAssignableFrom(c2.getRoot().getNodeClass()) ||
+        AdditionPrim.class.isAssignableFrom(c3.getRoot().getNodeClass()));
+  }
+
+  @Test
+  public void testFindAllExpectedUniquieSubTreesNoDuplicates() {
+    ExpressionNode body = AdditionPrimFactory.create(
+        AbsPrimFactory.create(
+            LiteralNode.create(1L)),
+        SubtractionPrimFactory.create(
+            AsDoubleValueFactory.create(
+                LiteralNode.create(44L)),
+            AsStringPrimFactory.create(
+                LiteralNode.create(4445.55d))));
+    Method m = constructMethod(body);
+
+    NodeStatisticsCollector s = new NodeStatisticsCollector(5);
+    s.add(m);
+
+    s.collectCandidates();
+
+    Set<SubTree> cs = s.getSubTrees();
+
+    assertEquals(12, cs.size());
+  }
+
+  @Test
+  public void testFindAllExpectedUniquieSubTreesWithDuplicates() {
+    ExpressionNode body = AdditionPrimFactory.create(
+        AbsPrimFactory.create(
+            LiteralNode.create(1L)),
+        AdditionPrimFactory.create(
+            AbsPrimFactory.create(
+                LiteralNode.create(44L)),
+            AdditionPrimFactory.create(
+                AbsPrimFactory.create(
+                    LiteralNode.create(44L)),
+                AbsPrimFactory.create(
+                    LiteralNode.create(4445.55d)))));
+    Method m = constructMethod(body);
+
+    NodeStatisticsCollector s = new NodeStatisticsCollector(5);
+    s.add(m);
+
+    s.collectCandidates();
+
+    Set<SubTree> cs = s.getSubTrees();
+
+    assertEquals(15, cs.size());
+  }
+
+  private Method constructMethod(final ExpressionNode body) {
+    LexicalScope scope = new LexicalScope(null, null);
+    return new Method("test", null, body, scope, body, null);
+  }
+}

--- a/tests/tools/nodestats/StaticNodeStructureTests.java
+++ b/tests/tools/nodestats/StaticNodeStructureTests.java
@@ -31,7 +31,7 @@ public class StaticNodeStructureTests {
     NodeStatisticsCollector s = new NodeStatisticsCollector(5);
     s.add(m);
 
-    s.collectCandidates();
+    s.collectStats();
 
     Set<SubTree> cs = s.getSubTrees();
 
@@ -65,7 +65,7 @@ public class StaticNodeStructureTests {
     NodeStatisticsCollector s = new NodeStatisticsCollector(5);
     s.add(m);
 
-    s.collectCandidates();
+    s.collectStats();
 
     Set<SubTree> cs = s.getSubTrees();
 
@@ -90,7 +90,7 @@ public class StaticNodeStructureTests {
     NodeStatisticsCollector s = new NodeStatisticsCollector(5);
     s.add(m);
 
-    s.collectCandidates();
+    s.collectStats();
 
     Set<SubTree> cs = s.getSubTrees();
 


### PR DESCRIPTION
This adds a tool that collects some basic statistics about nodes after running a SOM application/benchmark.

It gets all `RootNode`s and traverses the ASTs to collect the details.

The output written to a YAML file, and looks roughly like this:

```
# Node Statistics Report
report:
  node-numbers:
    - com.oracle.truffle.api.impl.DefaultDirectCallNode:                  { score: 8615 }
    - trufflesom.interpreter.nodes.GenericMessageSendNode:                { score: 8583 }
    - trufflesom.interpreter.nodes.dispatch.UninitializedDispatchNode:    { score: 8556 }
    - trufflesom.interpreter.nodes.dispatch.CachedDispatchNode:           { score: 8329 }
    - trufflesom.interpreter.nodes.ArgumentReadNode$LocalArgumentReadNode:{ score: 6823 }
    - trufflesom.interpreter.nodes.literals.IntegerLiteralNode:           { score: 5431 }
    
  subtree-frequency:
    - score: 1878
      CachedDispatchNode:
      - DefaultDirectCallNode
      - UninitializedDispatchNode

    - score: 911
      ReadObjectFieldNode:
      - ReadObjectFieldNode

    - score: 902
      ReadObjectFieldNode:
      - ReadObjectFieldNode:
        - ReadObjectFieldNode
```

/cc @OctaveLarose might be relevant to you. Note that this is different and more basic than what the SuperInstruction Candidate tool does in SOMns.