### PR TITLE
Add benchmark to measure AST vs BC GC overhead

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -70,6 +70,7 @@ benchmark_suites:
             - Mandelbrot:   {extra_args:  50, machines: [yuria2]}
 
             - Test:     {invocations: 10, machines: [yuria ]}
+            - TestGC:   {invocations: 10, extra_args: 10, machines: [yuria ]}
 
     micro-steady:
         gauge_adapter: RebenchLog


### PR DESCRIPTION
- remove `system fullGC` call from `Hash?Test` classes, don't need it, just slows things down