### PR TITLE
Use exact class check in dispatch guard

### DIFF
--- a/src/trufflesom/interpreter/nodes/dispatch/DispatchGuard.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/DispatchGuard.java
@@ -19,11 +19,11 @@ public abstract class DispatchGuard {
       return new CheckFalse();
     }
 
-    if (obj instanceof SClass) {
+    if (obj.getClass() == SClass.class) {
       return new CheckSClass(((SClass) obj).getObjectLayout());
     }
 
-    if (obj instanceof SObject) {
+    if (obj.getClass() == SObject.class) {
       return new CheckSObject(((SObject) obj).getObjectLayout());
     }
 
@@ -69,7 +69,7 @@ public abstract class DispatchGuard {
     @Override
     public boolean entryMatches(final Object obj) throws InvalidAssumptionException {
       expected.checkIsLatest();
-      return obj instanceof SClass &&
+      return obj.getClass() == SClass.class &&
           ((SClass) obj).getObjectLayout() == expected;
     }
   }
@@ -85,7 +85,7 @@ public abstract class DispatchGuard {
     @Override
     public boolean entryMatches(final Object obj) throws InvalidAssumptionException {
       expected.checkIsLatest();
-      return obj instanceof SObject &&
+      return obj.getClass() == SObject.class &&
           ((SObject) obj).getObjectLayout() == expected;
     }
   }

--- a/src/trufflesom/interpreter/nodes/dispatch/DispatchGuard.java
+++ b/src/trufflesom/interpreter/nodes/dispatch/DispatchGuard.java
@@ -19,15 +19,17 @@ public abstract class DispatchGuard {
       return new CheckFalse();
     }
 
-    if (obj.getClass() == SClass.class) {
+    Class<?> clazz = obj.getClass();
+
+    if (clazz == SClass.class) {
       return new CheckSClass(((SClass) obj).getObjectLayout());
     }
 
-    if (obj.getClass() == SObject.class) {
+    if (clazz == SObject.class) {
       return new CheckSObject(((SObject) obj).getObjectLayout());
     }
 
-    return new CheckClass(obj.getClass());
+    return new CheckClass(clazz);
   }
 
   private static final class CheckClass extends DispatchGuard {


### PR DESCRIPTION
Instead of an `instanceof` check, which has complex semantics, just read the class and check that. Tiny optimization/simplification.