### PR TITLE
Do not measure startup for Graal on HotSpot

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -207,15 +207,15 @@ experiments:
             #         - macro-startup
             - TruffleSOM-graal:
                 suites:
-                    - micro-startup
+                    # - micro-startup
                     - micro-steady
-                    - macro-startup
+                    # - macro-startup
                     - macro-steady
             - TruffleSOM-graal-bc:
                 suites:
-                    - micro-startup
+                    # - micro-startup
                     - micro-steady
-                    - macro-startup
+                    # - macro-startup
                     - macro-steady
             - TruffleSOM-native-interp-ast:
                 suites:


### PR DESCRIPTION
The results are too noisy, and I am not looking at that data anymore.
The "steady" benchmarks still give an indication, so, major regressions should not be missed.