### PR TITLE
Enable G1 on Linux EE Builds and Fix macOS Builds 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -357,7 +357,7 @@
         <sequential>
             <exec executable="@{exe}" dir="@{dir}" failonerror="true">
               <env key="JAVA_HOME" value="@{java-home}" />
-              <arg line="native-image" if:true="@{is-ce}" if:blank="${home.ext}" /> <!--  -->
+              <arg line="native-image" if:true="@{is-ce}" />
               <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
               <!-- <arg line="- -gc=G1" unless:true="@{is-ce}" /> -->
               <arg line="-H:-DeleteLocalSymbols" />

--- a/build.xml
+++ b/build.xml
@@ -359,7 +359,7 @@
               <env key="JAVA_HOME" value="@{java-home}" />
               <arg line="native-image" if:true="@{is-ce}" />
               <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
-              <!-- <arg line="- -gc=G1" unless:true="@{is-ce}" /> -->
+              <arg line="--gc=G1" unless:true="@{is-ce}" if:blank="${home.ext}" />
               <arg line="-H:-DeleteLocalSymbols" />
               <arg line="-Dsom.interp=@{type}" />
               <arg line="-Dsom.jitCompiler=false" if:true="${no.jit}" />

--- a/build.xml
+++ b/build.xml
@@ -58,8 +58,6 @@
     
     <path id="common.cp">
         <pathelement location="${classes.dir}" />
-
-        <pathelement location="${svm.build}/svm-core.jar" />
     </path>
     
     <path id="som.cp">


### PR DESCRIPTION
Previously, the G1 garbage collector was not enabled for the EE builds, it seems to have some impact on interpreter speed, but is a better GC for the AST-heavy benchmarks.

For absolute peak performance, one may need to reconsider.