### PR TITLE
Added SomParse benchmark, and make SomSom not measure parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download Eclipse
         run: |
           export ECLIPSE_TAR=eclipse.tar.gz
-          export ECLIPSE_URL=https://ftp.snt.utwente.nl/pub/software/eclipse/eclipse/downloads/drops4/R-4.19-202103031800/eclipse-SDK-4.19-linux-gtk-x86_64.tar.gz
+          export ECLIPSE_URL=https://ftp.snt.utwente.nl/pub/software/eclipse/eclipse/downloads/drops4/R-4.22-202111241800/eclipse-SDK-4.22-linux-gtk-x86_64.tar.gz
           curl ${ECLIPSE_URL} -o ${ECLIPSE_TAR}
           tar -C ${GITHUB_WORKSPACE}/.. -xzf ${ECLIPSE_TAR}
 

--- a/rebench.conf
+++ b/rebench.conf
@@ -108,6 +108,14 @@ benchmark_suites:
             - Recurse:      {extra_args: 1, machines: [yuria3]}
             - Mandelbrot:   {extra_args: 3, machines: [yuria ]}
 
+    som-parse:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples:Examples/Benchmarks/NBody:TestSuite:core-lib/SomSom/tests:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/primitives:core-lib/SomSom/src/compiler  Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1!
+        invocations: 10
+        benchmarks:
+            - SomParse: {extra_args: 1, machines: [yuria2]}
+
 executors:
     TruffleSOM-interp:
         path: .
@@ -167,28 +175,28 @@ executors:
     SomSom-native-interp-ast:
         path: .
         executable: som-native-interp-ast
-        args: "-cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+        args: "-cp core-lib/Smalltalk:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/MainLoadAll.som"
         profiler:
           perf: {}
 
     SomSom-native-interp-bc:
         path: .
         executable: som-native-interp-bc
-        args: "-Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+        args: "-Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/MainLoadAll.som"
         profiler:
           perf: {}
 
     SomSom-native-interp-ast-ee:
         path: .
         executable: som-native-interp-ast-ee
-        args: "-cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+        args: "-cp core-lib/Smalltalk:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/MainLoadAll.som"
         profiler:
           perf: {}
 
     SomSom-native-interp-bc-ee:
         path: .
         executable: som-native-interp-bc-ee
-        args: "-Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+        args: "-Dsom.interp=BC -cp core-lib/Smalltalk:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/MainLoadAll.som"
         profiler:
           perf: {}
 
@@ -221,10 +229,12 @@ experiments:
                 suites:
                     - micro-startup
                     - macro-startup
+                    - som-parse
             - TruffleSOM-native-interp-bc:
                 suites:
                     - micro-startup
                     - macro-startup
+                    - som-parse
             - SomSom-native-interp-ast:
                 suites:
                   - micro-somsom
@@ -236,10 +246,12 @@ experiments:
                 suites:
                   - micro-startup
                   - macro-startup
+                  - som-parse
             - TruffleSOM-native-interp-bc-ee:
                 suites:
                   - micro-startup
                   - macro-startup
+                  - som-parse
             - SomSom-native-interp-ast-ee:
                 suites:
                   - micro-somsom
@@ -257,12 +269,14 @@ experiments:
             suites:
               - micro-startup
               - macro-startup
+              - som-parse
         - TruffleSOM-native-interp-bc:
             iterations: 10!
             invocations: 1!
             suites:
               - micro-startup
               - macro-startup
+              - som-parse
         - SomSom-native-interp-ast:
             iterations: 1!
             invocations: 1!


### PR DESCRIPTION
SomParse loads a bunch of SOM files, and benchmarks that.
It's useful to get an impression of what impact the parser changes have.

The changes to the SomSom benchmark seems to have minimal impact, if at all.