### PR TITLE
Simplify #== primitive and split #<> and #~= primitives to simplify them

### DIFF
--- a/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/primitives/Primitives.java
@@ -101,6 +101,7 @@ import trufflesom.primitives.basics.LengthPrimFactory;
 import trufflesom.primitives.basics.NewObjectPrimFactory;
 import trufflesom.primitives.basics.StringPrimsFactory;
 import trufflesom.primitives.basics.SystemPrimsFactory;
+import trufflesom.primitives.basics.UnequalUnequalPrimFactory;
 import trufflesom.primitives.basics.UnequalsPrimFactory;
 import trufflesom.primitives.reflection.ClassPrimsFactory;
 import trufflesom.primitives.reflection.GlobalPrimFactory;
@@ -278,6 +279,7 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
 
     add(allFactories, AsStringPrimFactory.getInstance());
     add(allFactories, EqualsEqualsPrimFactory.getInstance());
+    add(allFactories, UnequalUnequalPrimFactory.getInstance());
     add(allFactories, EqualsPrimFactory.getInstance());
     add(allFactories, HashPrimFactory.getInstance());
     add(allFactories, LengthPrimFactory.getInstance());

--- a/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
@@ -1,36 +1,19 @@
 package trufflesom.primitives.basics;
 
-import java.math.BigInteger;
-
+import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
-import trufflesom.interpreter.nodes.nary.BinaryMsgExprNode;
-import trufflesom.vm.SymbolTable;
-import trufflesom.vmobjects.SArray;
-import trufflesom.vmobjects.SBlock;
-import trufflesom.vmobjects.SInvokable;
-import trufflesom.vmobjects.SObject;
-import trufflesom.vmobjects.SSymbol;
+import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 
 
 @GenerateNodeFactory
 @Primitive(className = "Object", primitive = "==", selector = "==")
-public abstract class EqualsEqualsPrim extends BinaryMsgExprNode {
-  @Override
-  public SSymbol getSelector() {
-    return SymbolTable.symbolFor("==");
-  }
-
+public abstract class EqualsEqualsPrim extends BinaryExpressionNode {
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {
     return left == right;
-  }
-
-  @Specialization
-  public final boolean doBoolean(final boolean left, final SObject right) {
-    return false;
   }
 
   @Specialization
@@ -39,87 +22,12 @@ public abstract class EqualsEqualsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
-    return left == right;
-  }
-
-  @Specialization
-  public final boolean doString(final String left, final String right) {
-    return left == right;
-  }
-
-  @Specialization
   public final boolean doDouble(final double left, final double right) {
     return left == right;
   }
 
-  @Specialization
-  public final boolean doSBlock(final SBlock left, final Object right) {
-    return left == right;
-  }
-
-  @Specialization
-  public final boolean doArray(final SArray left, final Object right) {
-    return left == right;
-  }
-
-  @Specialization
-  public final boolean doSMethod(final SInvokable left, final Object right) {
-    return left == right;
-  }
-
-  @Specialization
-  public final boolean doSSymbol(final SSymbol left, final Object right) {
-    return left == right;
-  }
-
-  @Specialization
-  public final boolean doSObject(final SObject left, final Object right) {
-    return left == right;
-  }
-
-  @Specialization
-  public final boolean doLong(final long left, final double right) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doBigInteger(final BigInteger left, final long right) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doLong(final long left, final BigInteger right) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doDouble(final double left, final long right) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doLong(final long left, final String right) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doLong(final long left, final SObject right) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doString(final String receiver, final long argument) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doString(final String receiver, final SSymbol argument) {
-    return false;
-  }
-
-  @Specialization
-  public final boolean doString(final String receiver, final SObject argument) {
-    return false;
+  @Fallback
+  public final boolean fallback(final Object receiver, final Object argument) {
+    return receiver == argument;
   }
 }

--- a/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
@@ -12,11 +12,6 @@ import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 @Primitive(className = "Object", primitive = "==", selector = "==")
 public abstract class EqualsEqualsPrim extends BinaryExpressionNode {
   @Specialization
-  public final boolean doBoolean(final boolean left, final boolean right) {
-    return left == right;
-  }
-
-  @Specialization
   public final boolean doLong(final long left, final long right) {
     return left == right;
   }

--- a/src/trufflesom/primitives/basics/UnequalUnequalPrim.java
+++ b/src/trufflesom/primitives/basics/UnequalUnequalPrim.java
@@ -9,23 +9,23 @@ import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 
 
 @GenerateNodeFactory
-@Primitive(className = "Integer", primitive = "==")
-@Primitive(className = "Double", primitive = "==")
-@Primitive(className = "Object", primitive = "==")
-@Primitive(selector = "==")
-public abstract class EqualsEqualsPrim extends BinaryExpressionNode {
+@Primitive(className = "Integer", primitive = "~=")
+@Primitive(className = "Double", primitive = "~=")
+@Primitive(className = "Object", primitive = "~=")
+@Primitive(selector = "~=")
+public abstract class UnequalUnequalPrim extends BinaryExpressionNode {
   @Specialization
   public final boolean doLong(final long left, final long right) {
-    return left == right;
+    return left != right;
   }
 
   @Specialization
   public final boolean doDouble(final double left, final double right) {
-    return left == right;
+    return left != right;
   }
 
   @Fallback
   public final boolean fallback(final Object receiver, final Object argument) {
-    return receiver == argument;
+    return receiver != argument;
   }
 }

--- a/src/trufflesom/primitives/basics/UnequalsPrim.java
+++ b/src/trufflesom/primitives/basics/UnequalsPrim.java
@@ -14,18 +14,12 @@ import trufflesom.vmobjects.SSymbol;
 
 
 @Primitive(className = "Integer", primitive = "<>")
-@Primitive(className = "Integer", primitive = "~=")
 @Primitive(className = "Double", primitive = "<>")
-@Primitive(className = "Double", primitive = "~=")
 @Primitive(selector = "<>")
-@Primitive(selector = "~=")
 @GenerateNodeFactory
 public abstract class UnequalsPrim extends BinaryMsgExprNode {
   @Override
   public SSymbol getSelector() {
-    if (getSourceChar(0) == '~') {
-      return SymbolTable.symbolFor("~=");
-    }
     return SymbolTable.symbolFor("<>");
   }
 


### PR DESCRIPTION
The `#==` primitive can be simplified by using the generic pointer comparison to avoid the overhead of the different cases in the interpreter.