### PR TITLE
Use array instead of list for inliner, which we need in most cases anyway

### DIFF
--- a/src/bd/inlining/InlinableNodes.java
+++ b/src/bd/inlining/InlinableNodes.java
@@ -123,7 +123,7 @@ public final class InlinableNodes<Id> {
    *           triggered by the inlining logic.
    */
   public <N extends Node, S extends ScopeBuilder<S>> N inline(final Id selector,
-      final List<N> argNodes, final S builder, final long coord)
+      final N[] argNodes, final S builder, final long coord)
       throws ProgramDefinitionError {
     Inliner inliner = inlinableNodes.get(selector);
     if (inliner == null || (VmSettings.DYNAMIC_METRICS && inliner.isDisabled())) {

--- a/src/bd/inlining/Inliner.java
+++ b/src/bd/inlining/Inliner.java
@@ -28,21 +28,21 @@ class Inliner {
     return inline.disabled();
   }
 
-  public boolean matches(final List<? extends Node> argNodes) {
+  public <N extends Node> boolean matches(final N[] argNodes) {
     int[] args = inline.inlineableArgIdx();
     assert args != null;
 
     boolean allInlinable = true;
     for (int i : args) {
-      allInlinable &= argNodes.get(i) instanceof Inlinable;
+      allInlinable &= argNodes[i] instanceof Inlinable;
     }
     return allInlinable;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public <N extends Node> N create(final List<N> argNodes, final ScopeBuilder scopeBuilder,
+  public <N extends Node> N create(final N[] argNodes, final ScopeBuilder scopeBuilder,
       final long coord) throws ProgramDefinitionError {
-    Object[] args = new Object[argNodes.size() + inline.inlineableArgIdx().length
+    Object[] args = new Object[argNodes.length + inline.inlineableArgIdx().length
         + inline.additionalArgs().length];
 
     assert args.length == ctor.getParameterCount();
@@ -54,7 +54,7 @@ class Inliner {
     }
 
     for (int a : inline.inlineableArgIdx()) {
-      args[i] = ((Inlinable) argNodes.get(a)).inline(scopeBuilder);
+      args[i] = ((Inlinable) argNodes[a]).inline(scopeBuilder);
       i += 1;
     }
 
@@ -103,9 +103,9 @@ class Inliner {
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public <N extends Node> N create(final List<N> argNodes, final ScopeBuilder scopeBuilder,
+    public <N extends Node> N create(final N[] argNodes, final ScopeBuilder scopeBuilder,
         final long coord) throws ProgramDefinitionError {
-      Object[] args = new Object[argNodes.size() + inline.inlineableArgIdx().length
+      Object[] args = new Object[argNodes.length + inline.inlineableArgIdx().length
           + inline.introduceTemps().length + inline.additionalArgs().length];
 
       assert args.length == factory.getNodeSignatures().get(0).size();
@@ -113,24 +113,24 @@ class Inliner {
       int restArgs = factory.getExecutionSignature().size();
 
       int i = 0;
-      for (int j = 0; j < argNodes.size(); j += 1) {
+      for (int j = 0; j < argNodes.length; j += 1) {
         if (j < restArgs) {
           int endOffset = args.length - restArgs + j;
-          args[endOffset] = argNodes.get(j);
+          args[endOffset] = argNodes[j];
         } else {
-          args[i] = argNodes.get(j);
+          args[i] = argNodes[j];
           i += 1;
         }
       }
 
       for (int a : inline.inlineableArgIdx()) {
-        args[i] = ((Inlinable) argNodes.get(a)).inline(scopeBuilder);
+        args[i] = ((Inlinable) argNodes[a]).inline(scopeBuilder);
         i += 1;
       }
 
       for (int a : inline.introduceTemps()) {
         args[i] = scopeBuilder.introduceTempForInlinedVersion(
-            (Inlinable) argNodes.get(a), coord);
+            (Inlinable) argNodes[a], coord);
       }
 
       for (Class<?> c : inline.additionalArgs()) {

--- a/tests/bd/inlining/InliningTests.java
+++ b/tests/bd/inlining/InliningTests.java
@@ -7,9 +7,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 
 import bd.basic.ProgramDefinitionError;
@@ -31,16 +28,15 @@ public class InliningTests {
 
   @Test
   public void testNonInlinableNode() throws ProgramDefinitionError {
-    List<ExprNode> argNodes = new ArrayList<>();
-    argNodes.add(AddNodeFactory.create(null, null));
+    ExprNode[] argNodes = new ExprNode[] {AddNodeFactory.create(null, null)};
     assertNull(nodes.inline("value", argNodes, null, coord));
   }
 
   @Test
   public void testValueNode() throws ProgramDefinitionError {
-    List<ExprNode> argNodes = new ArrayList<>();
     LambdaNode arg = new LambdaNode();
-    argNodes.add(arg);
+    ExprNode[] argNodes = new ExprNode[] {arg};
+
     ExprNode valueNode = nodes.inline("value", argNodes, null, coord);
     assertNotNull(valueNode);
     assertTrue(valueNode instanceof ValueNode);
@@ -58,9 +54,9 @@ public class InliningTests {
 
   @Test
   public void testValueSpecNode() throws ProgramDefinitionError {
-    List<ExprNode> argNodes = new ArrayList<>();
     LambdaNode arg = new LambdaNode();
-    argNodes.add(arg);
+    ExprNode[] argNodes = new ExprNode[] {arg};
+
     ExprNode valueNode = nodes.inline("valueSpec", argNodes, null, coord);
     assertNotNull(valueNode);
     assertTrue(valueNode instanceof ValueSpecializedNode);


### PR DESCRIPTION
This is mostly a cleanup change.
It also reorders the check for inlining opportunities after the handling of super messages, since we do have the assumption (and assert) that it's not a super send.