### PR TITLE
Handle more situations where we read and then set a variable/field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,13 @@ user-dict.txt
 /rebench.data
 /payload.json
 /tests/tools/coverage/expected-results
+/tests/tools/coverage/old-results
 /tests/tools/coverage/results
 /tests/tools/nodestats/expected-results
 /tests/tools/nodestats/old-results
 /tests/tools/nodestats/results
+*.yml
+*.jfr
+*.txt
+*.zip
+

--- a/src/bd/inlining/Inliner.java
+++ b/src/bd/inlining/Inliner.java
@@ -2,7 +2,6 @@ package bd.inlining;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.nodes.Node;

--- a/src/trufflesom/compiler/Variable.java
+++ b/src/trufflesom/compiler/Variable.java
@@ -22,16 +22,21 @@ import com.oracle.truffle.api.source.Source;
 import bd.source.SourceCoordinate;
 import trufflesom.compiler.bc.BytecodeMethodGenContext;
 import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableReadNode;
 import trufflesom.interpreter.nodes.LocalVariableNodeFactory.LocalVariableReadNodeGen;
 import trufflesom.interpreter.nodes.LocalVariableNodeFactory.LocalVariableWriteNodeGen;
+import trufflesom.interpreter.nodes.NonLocalVariableNode.NonLocalVariableReadNode;
 import trufflesom.interpreter.nodes.NonLocalVariableNodeFactory.NonLocalVariableReadNodeGen;
 import trufflesom.interpreter.nodes.NonLocalVariableNodeFactory.NonLocalVariableWriteNodeGen;
-import trufflesom.interpreter.supernodes.LocalVariableIncNodeGen;
+import trufflesom.interpreter.supernodes.IncLocalVariableNodeGen;
+import trufflesom.interpreter.supernodes.IncNonLocalVariableNodeGen;
+import trufflesom.interpreter.supernodes.IntIncLocalVariableNodeGen;
+import trufflesom.interpreter.supernodes.IntIncNonLocalVariableNodeGen;
 import trufflesom.interpreter.supernodes.LocalVariableReadSquareWriteNodeGen;
 import trufflesom.interpreter.supernodes.LocalVariableSquareNodeGen;
-import trufflesom.interpreter.supernodes.NonLocalVariableIncNodeGen;
 import trufflesom.interpreter.supernodes.NonLocalVariableReadSquareWriteNodeGen;
 import trufflesom.interpreter.supernodes.NonLocalVariableSquareNodeGen;
+import trufflesom.primitives.arithmetic.AdditionPrim;
 import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vmobjects.SSymbol;
 
@@ -190,10 +195,10 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
         final long coord) {
       transferToInterpreterAndInvalidate("Variable.getReadNode");
       if (contextLevel > 0) {
-        return NonLocalVariableIncNodeGen.create(contextLevel, this, incValue)
-                                         .initialize(coord);
+        return IntIncNonLocalVariableNodeGen.create(contextLevel, this, incValue)
+                                            .initialize(coord);
       }
-      return LocalVariableIncNodeGen.create(this, incValue).initialize(coord);
+      return IntIncLocalVariableNodeGen.create(this, incValue).initialize(coord);
     }
 
     @Override
@@ -235,10 +240,48 @@ public abstract class Variable implements bd.inlining.Variable<ExpressionNode> {
     public ExpressionNode getWriteNode(final int contextLevel,
         final ExpressionNode valueExpr, final long coord) {
       transferToInterpreterAndInvalidate("Variable.getWriteNode");
+
       if (contextLevel > 0) {
+        if (valueExpr instanceof AdditionPrim) {
+          AdditionPrim add = (AdditionPrim) valueExpr;
+          ExpressionNode rcvr = add.getReceiver();
+          ExpressionNode arg = add.getArgument();
+
+          if (rcvr instanceof NonLocalVariableReadNode
+              && ((NonLocalVariableReadNode) rcvr).getLocal() == this) {
+            return IncNonLocalVariableNodeGen.create(contextLevel, this, arg)
+                                             .initialize(coord);
+          }
+
+          if (arg instanceof NonLocalVariableReadNode
+              && ((NonLocalVariableReadNode) arg).getLocal() == this) {
+            return IncNonLocalVariableNodeGen.create(contextLevel, this, rcvr)
+                                             .initialize(coord);
+          }
+        }
+
         return NonLocalVariableWriteNodeGen.create(contextLevel, this, valueExpr)
                                            .initialize(coord);
       }
+
+      if (valueExpr instanceof AdditionPrim) {
+        AdditionPrim add = (AdditionPrim) valueExpr;
+        ExpressionNode rcvr = add.getReceiver();
+        ExpressionNode arg = add.getArgument();
+
+        if (rcvr instanceof LocalVariableReadNode
+            && ((LocalVariableReadNode) rcvr).getLocal() == this) {
+          return IncLocalVariableNodeGen.create(this, arg)
+                                        .initialize(coord);
+        }
+
+        if (arg instanceof LocalVariableReadNode
+            && ((LocalVariableReadNode) arg).getLocal() == this) {
+          return IncLocalVariableNodeGen.create(this, rcvr)
+                                        .initialize(coord);
+        }
+      }
+
       return LocalVariableWriteNodeGen.create(this, valueExpr).initialize(coord);
     }
 

--- a/src/trufflesom/interpreter/SNodeFactory.java
+++ b/src/trufflesom/interpreter/SNodeFactory.java
@@ -51,11 +51,11 @@ public final class SNodeFactory {
 
       if (rcvr instanceof FieldReadNode
           && fieldIndex == ((FieldReadNode) rcvr).getFieldIndex()) {
-        return new UninitIncFieldNode(self, arg, fieldIndex, coord);
+        return new UninitIncFieldNode(self, arg, true, fieldIndex, coord);
       }
       if (arg instanceof FieldReadNode
           && fieldIndex == ((FieldReadNode) arg).getFieldIndex()) {
-        return new UninitIncFieldNode(self, rcvr, fieldIndex, coord);
+        return new UninitIncFieldNode(self, rcvr, false, fieldIndex, coord);
       }
     }
 

--- a/src/trufflesom/interpreter/SNodeFactory.java
+++ b/src/trufflesom/interpreter/SNodeFactory.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import trufflesom.compiler.Variable.Argument;
 import trufflesom.compiler.Variable.Internal;
-import trufflesom.compiler.Variable.Local;
 import trufflesom.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
 import trufflesom.interpreter.nodes.ArgumentReadNode.LocalArgumentWriteNode;
 import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalArgumentReadNode;
@@ -13,8 +12,6 @@ import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.interpreter.nodes.FieldNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
 import trufflesom.interpreter.nodes.FieldNodeFactory.FieldWriteNodeGen;
-import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableWriteNode;
-import trufflesom.interpreter.nodes.LocalVariableNodeFactory.LocalVariableWriteNodeGen;
 import trufflesom.interpreter.nodes.ReturnNonLocalNode;
 import trufflesom.interpreter.nodes.ReturnNonLocalNode.CatchNonLocalReturnNode;
 import trufflesom.interpreter.nodes.SequenceNode;
@@ -69,11 +66,6 @@ public final class SNodeFactory {
     } else {
       return new NonLocalArgumentReadNode(variable, contextLevel).initialize(coord);
     }
-  }
-
-  public static LocalVariableWriteNode createLocalVariableWrite(
-      final Local var, final ExpressionNode exp, final long coord) {
-    return LocalVariableWriteNodeGen.create(var, exp).initialize(coord);
   }
 
   public static ExpressionNode createArgumentWrite(final Argument variable,

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -735,11 +735,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             }
 
             node = quickened[bytecodeIndex] =
-                insert(FieldAccessorNode.createIncrement(fieldIdx, obj, 1));
+                insert(FieldAccessorNode.createIncrement(fieldIdx, obj));
             break;
           }
 
-          ((IncrementLongFieldNode) node).increment(obj);
+          ((IncrementLongFieldNode) node).increment(obj, 1);
           break;
         }
 
@@ -772,11 +772,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             }
 
             node = quickened[bytecodeIndex] =
-                insert(FieldAccessorNode.createIncrement(fieldIdx, obj, 1));
+                insert(FieldAccessorNode.createIncrement(fieldIdx, obj));
             break;
           }
 
-          long value = ((IncrementLongFieldNode) node).increment(obj);
+          long value = ((IncrementLongFieldNode) node).increment(obj, 1);
           stackPointer += 1;
           stack[stackPointer] = value;
           break;

--- a/src/trufflesom/interpreter/objectstorage/FieldAccessorNode.java
+++ b/src/trufflesom/interpreter/objectstorage/FieldAccessorNode.java
@@ -28,9 +28,9 @@ public abstract class FieldAccessorNode extends Node {
   }
 
   public static IncrementLongFieldNode createIncrement(final int fieldIndex,
-      final SObject obj, final long incValue) {
+      final SObject obj) {
     final ObjectLayout layout = obj.getObjectLayout();
-    return new IncrementLongFieldNode(fieldIndex, layout, incValue);
+    return new IncrementLongFieldNode(fieldIndex, layout);
   }
 
   private FieldAccessorNode(final int fieldIndex) {
@@ -293,16 +293,13 @@ public abstract class FieldAccessorNode extends Node {
   public static final class IncrementLongFieldNode extends FieldAccessorNode {
     protected final ObjectLayout      layout;
     private final LongStorageLocation storage;
-    private final long                incValue;
 
     @Child protected IncrementLongFieldNode nextInCache;
 
-    public IncrementLongFieldNode(final int fieldIndex, final ObjectLayout layout,
-        final long incValue) {
+    public IncrementLongFieldNode(final int fieldIndex, final ObjectLayout layout) {
       super(fieldIndex);
       this.layout = layout;
       this.storage = (LongStorageLocation) layout.getStorageLocation(fieldIndex);
-      this.incValue = incValue;
     }
 
     protected boolean hasExpectedLayout(final SObject obj)
@@ -311,25 +308,25 @@ public abstract class FieldAccessorNode extends Node {
       return layout == obj.getObjectLayout();
     }
 
-    public long increment(final SObject obj) {
+    public long increment(final SObject obj, final long incValue) {
       try {
         if (hasExpectedLayout(obj)) {
           return storage.increment(obj, incValue);
         } else {
           ensureNext(obj);
-          return nextInCache.increment(obj);
+          return nextInCache.increment(obj, incValue);
         }
       } catch (InvalidAssumptionException e) {
         ensureNext(obj);
         return replace(SOMNode.unwrapIfNeeded(nextInCache)).increment(
-            obj);
+            obj, incValue);
       }
     }
 
     private void ensureNext(final SObject obj) {
       if (nextInCache == null) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        nextInCache = new IncrementLongFieldNode(fieldIndex, obj.getObjectLayout(), incValue);
+        nextInCache = new IncrementLongFieldNode(fieldIndex, obj.getObjectLayout());
       }
     }
   }

--- a/src/trufflesom/interpreter/supernodes/IncLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IncLocalVariableNode.java
@@ -1,0 +1,66 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
+
+import bd.inlining.ScopeAdaptationVisitor;
+import bd.inlining.ScopeAdaptationVisitor.ScopeElement;
+import trufflesom.compiler.Variable.Local;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.LocalVariableNode;
+
+
+@NodeChild(value = "value", type = ExpressionNode.class)
+public abstract class IncLocalVariableNode extends LocalVariableNode {
+
+  protected IncLocalVariableNode(final Local variable) {
+    super(variable);
+  }
+
+  public abstract ExpressionNode getValue();
+
+  @Specialization(guards = "frame.isLong(slot)", rewriteOn = {FrameSlotTypeException.class})
+  public final long doLong(final VirtualFrame frame, final long value)
+      throws FrameSlotTypeException {
+    long current = frame.getLong(slot);
+    long result = Math.addExact(current, value);
+    frame.setLong(slot, result);
+    return result;
+  }
+
+  @Specialization(guards = "frame.isDouble(slot)",
+      rewriteOn = {FrameSlotTypeException.class})
+  public final double doDouble(final VirtualFrame frame, final double value)
+      throws FrameSlotTypeException {
+    double current = frame.getDouble(slot);
+    double result = current + value;
+    frame.setDouble(slot, result);
+    return result;
+  }
+
+  @Specialization(guards = "frame.isObject(slot)",
+      rewriteOn = {FrameSlotTypeException.class})
+  public final Object doString(final VirtualFrame frame, final String value)
+      throws FrameSlotTypeException {
+    String current = (String) frame.getObject(slot);
+    String result = current + value;
+    frame.setObject(slot, result);
+    return result;
+  }
+
+  @Override
+  public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+    ScopeElement<? extends Node> se = inliner.getAdaptedVar(local);
+    if (se.var != local || se.contextLevel < 0) {
+      IncLocalVariableNode newNode =
+          IncLocalVariableNodeGen.create((Local) se.var, getValue());
+      newNode.initialize(sourceCoord);
+      replace(newNode);
+    } else {
+      assert 0 == se.contextLevel;
+    }
+  }
+}

--- a/src/trufflesom/interpreter/supernodes/IncNonLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IncNonLocalVariableNode.java
@@ -1,5 +1,6 @@
 package trufflesom.interpreter.supernodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.NodeChild;
@@ -60,6 +61,7 @@ public abstract class IncNonLocalVariableNode extends NonLocalVariableNode {
   @Fallback
   public final Object fallback(final VirtualFrame frame, final Object value) {
     MaterializedFrame ctx = determineContext(frame);
+    CompilerDirectives.transferToInterpreterAndInvalidate();
 
     AdditionPrim add =
         AdditionPrimFactory.create(local.getReadNode(contextLevel, sourceCoord), getValue());
@@ -68,7 +70,7 @@ public abstract class IncNonLocalVariableNode extends NonLocalVariableNode {
     replace(local.getWriteNode(contextLevel, add, sourceCoord)).adoptChildren();
 
     Object preIncValue = ctx.getValue(slot);
-    Object result = add.executeEvaluated(frame, preIncValue, value);
+    Object result = add.executeEvaluated(null, preIncValue, value);
     ctx.setObject(slot, result);
     return result;
   }

--- a/src/trufflesom/interpreter/supernodes/IncNonLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IncNonLocalVariableNode.java
@@ -1,0 +1,93 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
+
+import bd.inlining.ScopeAdaptationVisitor;
+import bd.inlining.ScopeAdaptationVisitor.ScopeElement;
+import trufflesom.compiler.Variable.Local;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.NonLocalVariableNode;
+import trufflesom.primitives.arithmetic.AdditionPrim;
+import trufflesom.primitives.arithmetic.AdditionPrimFactory;
+
+
+@NodeChild(value = "value", type = ExpressionNode.class)
+public abstract class IncNonLocalVariableNode extends NonLocalVariableNode {
+
+  protected IncNonLocalVariableNode(final int contextLevel, final Local local) {
+    super(contextLevel, local);
+  }
+
+  public abstract ExpressionNode getValue();
+
+  @Specialization(guards = "ctx.isLong(slot)", rewriteOn = {FrameSlotTypeException.class})
+  public final long doLong(final VirtualFrame frame, final long value,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    long current = ctx.getLong(slot);
+    long result = Math.addExact(current, value);
+    ctx.setLong(slot, result);
+    return result;
+  }
+
+  @Specialization(guards = "ctx.isDouble(slot)", rewriteOn = {FrameSlotTypeException.class})
+  public final double doDouble(final VirtualFrame frame, final double value,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    double current = ctx.getDouble(slot);
+    double result = current + value;
+    ctx.setDouble(slot, result);
+    return result;
+  }
+
+  @Specialization(guards = "ctx.isDouble(slot)", rewriteOn = {FrameSlotTypeException.class})
+  public final Object doString(final VirtualFrame frame, final String value,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    String current = (String) ctx.getObject(slot);
+    String result = current + value;
+    ctx.setObject(slot, result);
+    return result;
+  }
+
+  @Fallback
+  public final Object fallback(final VirtualFrame frame, final Object value) {
+    MaterializedFrame ctx = determineContext(frame);
+
+    AdditionPrim add =
+        AdditionPrimFactory.create(local.getReadNode(contextLevel, sourceCoord), getValue());
+    add.initialize(sourceCoord);
+
+    replace(local.getWriteNode(contextLevel, add, sourceCoord)).adoptChildren();
+
+    Object preIncValue = ctx.getValue(slot);
+    Object result = add.executeEvaluated(frame, preIncValue, value);
+    ctx.setObject(slot, result);
+    return result;
+  }
+
+  @Override
+  public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+    ScopeElement<? extends Node> se = inliner.getAdaptedVar(local);
+    if (se.var != local || se.contextLevel < contextLevel) {
+      ExpressionNode node;
+      if (se.contextLevel == 0) {
+        node = IncLocalVariableNodeGen.create((Local) se.var, getValue());
+      } else {
+        node = IncNonLocalVariableNodeGen.create(se.contextLevel, (Local) se.var, getValue());
+      }
+      node.initialize(sourceCoord);
+
+      replace(node);
+    } else {
+      assert contextLevel == se.contextLevel;
+    }
+  }
+}

--- a/src/trufflesom/interpreter/supernodes/IntIncFieldNode.java
+++ b/src/trufflesom/interpreter/supernodes/IntIncFieldNode.java
@@ -2,26 +2,25 @@ package trufflesom.interpreter.supernodes;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.UnexpectedResultException;
 
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.interpreter.nodes.FieldNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.IncrementLongFieldNode;
-import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vmobjects.SObject;
 
 
-final class IncFieldNode extends FieldNode {
+final class IntIncFieldNode extends FieldNode {
   @Child private ExpressionNode         self;
-  @Child private ExpressionNode         valueExpr;
   @Child private IncrementLongFieldNode inc;
 
-  IncFieldNode(final ExpressionNode self, final ExpressionNode valueExpr,
-      final IncrementLongFieldNode inc, final long coord) {
+  private final long incValue;
+
+  IntIncFieldNode(final ExpressionNode self, final IncrementLongFieldNode inc,
+      final long incValue, final long coord) {
     initialize(coord);
     this.self = self;
-    this.valueExpr = valueExpr;
     this.inc = inc;
+    this.incValue = incValue;
   }
 
   @Override
@@ -43,15 +42,6 @@ final class IncFieldNode extends FieldNode {
   @Override
   public long executeLong(final VirtualFrame frame) {
     SObject obj = (SObject) self.executeGeneric(frame);
-    long incValue;
-
-    try {
-      incValue = valueExpr.executeLong(frame);
-    } catch (UnexpectedResultException e) {
-      CompilerDirectives.transferToInterpreterAndInvalidate();
-      throw new NotYetImplementedException();
-    }
-
     return inc.increment(obj, incValue);
   }
 }

--- a/src/trufflesom/interpreter/supernodes/IntIncLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IntIncLocalVariableNode.java
@@ -11,11 +11,11 @@ import trufflesom.compiler.Variable.Local;
 import trufflesom.interpreter.nodes.LocalVariableNode;
 
 
-public abstract class LocalVariableIncNode extends LocalVariableNode {
+public abstract class IntIncLocalVariableNode extends LocalVariableNode {
 
   private final long incValue;
 
-  public LocalVariableIncNode(final Local variable, final long incValue) {
+  public IntIncLocalVariableNode(final Local variable, final long incValue) {
     super(variable);
     this.incValue = incValue;
   }

--- a/src/trufflesom/interpreter/supernodes/IntIncNonLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IntIncNonLocalVariableNode.java
@@ -13,11 +13,11 @@ import trufflesom.compiler.Variable.Local;
 import trufflesom.interpreter.nodes.NonLocalVariableNode;
 
 
-public abstract class NonLocalVariableIncNode extends NonLocalVariableNode {
+public abstract class IntIncNonLocalVariableNode extends NonLocalVariableNode {
 
   private final long incValue;
 
-  public NonLocalVariableIncNode(final int contextLevel, final Local local,
+  public IntIncNonLocalVariableNode(final int contextLevel, final Local local,
       final long incValue) {
     super(contextLevel, local);
     this.incValue = incValue;

--- a/src/trufflesom/interpreter/supernodes/IntIncrementNode.java
+++ b/src/trufflesom/interpreter/supernodes/IntIncrementNode.java
@@ -110,9 +110,9 @@ public abstract class IntIncrementNode extends ExpressionNode {
 
   public ExpressionNode createIncNode(final Local local, final int ctxLevel) {
     if (ctxLevel == 0) {
-      return LocalVariableIncNodeGen.create(local, incValue).initialize(sourceCoord);
+      return IntIncLocalVariableNodeGen.create(local, incValue).initialize(sourceCoord);
     }
-    return NonLocalVariableIncNodeGen.create(ctxLevel, local, incValue)
-                                     .initialize(sourceCoord);
+    return IntIncNonLocalVariableNodeGen.create(ctxLevel, local, incValue)
+                                        .initialize(sourceCoord);
   }
 }

--- a/src/trufflesom/interpreter/supernodes/IntIncrementNode.java
+++ b/src/trufflesom/interpreter/supernodes/IntIncrementNode.java
@@ -105,7 +105,7 @@ public abstract class IntIncrementNode extends ExpressionNode {
 
   public FieldNode createFieldIncNode(final ExpressionNode self, final int fieldIndex,
       final long coord) {
-    return new UninitFieldIncNode(self, fieldIndex, coord, incValue);
+    return new IntUninitIncFieldNode(self, fieldIndex, coord, incValue);
   }
 
   public ExpressionNode createIncNode(final Local local, final int ctxLevel) {
@@ -115,5 +115,4 @@ public abstract class IntIncrementNode extends ExpressionNode {
     return NonLocalVariableIncNodeGen.create(ctxLevel, local, incValue)
                                      .initialize(sourceCoord);
   }
-
 }

--- a/src/trufflesom/interpreter/supernodes/IntUninitIncFieldNode.java
+++ b/src/trufflesom/interpreter/supernodes/IntUninitIncFieldNode.java
@@ -1,0 +1,64 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.FieldNode;
+import trufflesom.interpreter.objectstorage.FieldAccessorNode;
+import trufflesom.interpreter.objectstorage.FieldAccessorNode.IncrementLongFieldNode;
+import trufflesom.vm.NotYetImplementedException;
+import trufflesom.vmobjects.SObject;
+
+
+public final class IntUninitIncFieldNode extends FieldNode {
+
+  @Child private ExpressionNode self;
+  private final int             fieldIndex;
+  private final long            incValue;
+
+  public IntUninitIncFieldNode(final ExpressionNode self, final int fieldIndex,
+      final long coord, final long value) {
+    this.self = self;
+    this.fieldIndex = fieldIndex;
+    this.sourceCoord = coord;
+    this.incValue = value;
+  }
+
+  @Override
+  public ExpressionNode getSelf() {
+    return self;
+  }
+
+  @Override
+  public Object doPreEvaluated(final VirtualFrame frame, final Object[] arguments) {
+    CompilerDirectives.transferToInterpreter();
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object executeGeneric(final VirtualFrame frame) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    SObject obj = (SObject) self.executeGeneric(frame);
+
+    Object val = obj.getField(fieldIndex);
+    if (!(val instanceof Long)) {
+      throw new NotYetImplementedException();
+    }
+
+    long longVal = 0;
+    try {
+      longVal = Math.addExact((Long) val, incValue);
+      obj.setField(fieldIndex, longVal);
+    } catch (ArithmeticException e) {
+      throw new NotYetImplementedException();
+    }
+
+    IncrementLongFieldNode node = FieldAccessorNode.createIncrement(fieldIndex, obj);
+    IntIncFieldNode incNode = new IntIncFieldNode(self, node, incValue, sourceCoord);
+    replace(incNode);
+    node.notifyAsInserted();
+
+    return longVal;
+  }
+}

--- a/tests/trufflesom/supernodes/IncrementOpTests.java
+++ b/tests/trufflesom/supernodes/IncrementOpTests.java
@@ -12,9 +12,10 @@ import trufflesom.interpreter.nodes.SequenceNode;
 import trufflesom.interpreter.nodes.literals.BlockNode;
 import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
 import trufflesom.interpreter.supernodes.IntIncrementNode;
+import trufflesom.interpreter.supernodes.IntUninitIncFieldNode;
 import trufflesom.interpreter.supernodes.LocalVariableIncNode;
 import trufflesom.interpreter.supernodes.NonLocalVariableIncNode;
-import trufflesom.interpreter.supernodes.UninitFieldIncNode;
+import trufflesom.interpreter.supernodes.UninitIncFieldNode;
 import trufflesom.tests.AstTestSetup;
 
 
@@ -80,10 +81,27 @@ public class IncrementOpTests extends AstTestSetup {
 
   @Test
   public void testFieldInc() {
-    basicAddOrSubtract("field := field + 1", 1, UninitFieldIncNode.class);
-    basicAddOrSubtract("field := field - 1", -1, UninitFieldIncNode.class);
-    basicAddOrSubtract("field := field + 1123", 1123, UninitFieldIncNode.class);
-    basicAddOrSubtract("field := field - 234234", -234234, UninitFieldIncNode.class);
+    basicAddOrSubtract("field := field + 1", 1, IntUninitIncFieldNode.class);
+    basicAddOrSubtract("field := field - 1", -1, IntUninitIncFieldNode.class);
+    basicAddOrSubtract("field := field + 1123", 1123, IntUninitIncFieldNode.class);
+    basicAddOrSubtract("field := field - 234234", -234234, IntUninitIncFieldNode.class);
+
+  }
+
+  private void fieldIncWithExpr(final String test, final Class<?> nodeType) {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = ( | var | \n" + test + " )");
+
+    ExpressionNode testExpr = read(seq, "expressions", 0);
+    assertThat(testExpr, instanceOf(nodeType));
+  }
+
+  @Test
+  public void testFieldIncWithExpression() {
+    fieldIncWithExpr("field := field + (23 + 434)", UninitIncFieldNode.class);
+    fieldIncWithExpr("field := field + var", UninitIncFieldNode.class);
+    fieldIncWithExpr("field := field + arg", UninitIncFieldNode.class);
   }
 
   @Test

--- a/tests/trufflesom/supernodes/IncrementOpTests.java
+++ b/tests/trufflesom/supernodes/IncrementOpTests.java
@@ -13,8 +13,8 @@ import trufflesom.interpreter.nodes.literals.BlockNode;
 import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
 import trufflesom.interpreter.supernodes.IntIncrementNode;
 import trufflesom.interpreter.supernodes.IntUninitIncFieldNode;
-import trufflesom.interpreter.supernodes.LocalVariableIncNode;
-import trufflesom.interpreter.supernodes.NonLocalVariableIncNode;
+import trufflesom.interpreter.supernodes.IntIncLocalVariableNode;
+import trufflesom.interpreter.supernodes.IntIncNonLocalVariableNode;
 import trufflesom.interpreter.supernodes.UninitIncFieldNode;
 import trufflesom.tests.AstTestSetup;
 
@@ -106,10 +106,10 @@ public class IncrementOpTests extends AstTestSetup {
 
   @Test
   public void testLocalInc() {
-    basicAddOrSubtract("var := var + 1", 1, LocalVariableIncNode.class);
-    basicAddOrSubtract("var := var - 1", -1, LocalVariableIncNode.class);
-    basicAddOrSubtract("var := var + 1123", 1123, LocalVariableIncNode.class);
-    basicAddOrSubtract("var := var - 234234", -234234, LocalVariableIncNode.class);
+    basicAddOrSubtract("var := var + 1", 1, IntIncLocalVariableNode.class);
+    basicAddOrSubtract("var := var - 1", -1, IntIncLocalVariableNode.class);
+    basicAddOrSubtract("var := var + 1123", 1123, IntIncLocalVariableNode.class);
+    basicAddOrSubtract("var := var - 234234", -234234, IntIncLocalVariableNode.class);
   }
 
   private void inBlock(final String test, final long literalValue,
@@ -128,10 +128,10 @@ public class IncrementOpTests extends AstTestSetup {
 
   @Test
   public void testNonLocalInc() {
-    inBlock("[ var := var + 1 ]", 1, NonLocalVariableIncNode.class);
-    inBlock("[ var := var - 1 ]", -1, NonLocalVariableIncNode.class);
-    inBlock("[ var := var + 1123 ]", 1123, NonLocalVariableIncNode.class);
-    inBlock("[ var := var - 234234 ]", -234234, NonLocalVariableIncNode.class);
+    inBlock("[ var := var + 1 ]", 1, IntIncNonLocalVariableNode.class);
+    inBlock("[ var := var - 1 ]", -1, IntIncNonLocalVariableNode.class);
+    inBlock("[ var := var + 1123 ]", 1123, IntIncNonLocalVariableNode.class);
+    inBlock("[ var := var - 234234 ]", -234234, IntIncNonLocalVariableNode.class);
   }
 
 }

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -34,7 +34,7 @@ import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.TrueIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IntToDoInlinedLiteralsNode;
 import trufflesom.interpreter.nodes.specialized.whileloops.WhileInlinedLiteralsNode;
-import trufflesom.interpreter.supernodes.NonLocalVariableIncNode;
+import trufflesom.interpreter.supernodes.IntIncNonLocalVariableNode;
 import trufflesom.interpreter.supernodes.IntUninitIncFieldNode;
 import trufflesom.primitives.arithmetic.SubtractionPrim;
 import trufflesom.primitives.arrays.DoPrim;
@@ -374,8 +374,8 @@ public class AstInliningTests extends AstTestSetup {
     assertEquals("b", readNode.getInvocationIdentifier().getString());
     assertEquals(1, readNode.argumentIndex);
 
-    NonLocalVariableIncNode writeNode =
-        read(blockBIfTrue, "bodyNode", NonLocalVariableIncNode.class);
+    IntIncNonLocalVariableNode writeNode =
+        read(blockBIfTrue, "bodyNode", IntIncNonLocalVariableNode.class);
     assertEquals(1, writeNode.getContextLevel());
     assertEquals("l2", writeNode.getInvocationIdentifier().getString());
   }

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -35,7 +35,7 @@ import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode
 import trufflesom.interpreter.nodes.specialized.IntToDoInlinedLiteralsNode;
 import trufflesom.interpreter.nodes.specialized.whileloops.WhileInlinedLiteralsNode;
 import trufflesom.interpreter.supernodes.NonLocalVariableIncNode;
-import trufflesom.interpreter.supernodes.UninitFieldIncNode;
+import trufflesom.interpreter.supernodes.IntUninitIncFieldNode;
 import trufflesom.primitives.arithmetic.SubtractionPrim;
 import trufflesom.primitives.arrays.DoPrim;
 
@@ -144,7 +144,7 @@ public class AstInliningTests extends AstTestSetup {
             + "(self key: 5) ifTrue: [ field := field + 1 ]. #end )");
 
     IfInlinedLiteralNode ifNode = (IfInlinedLiteralNode) read(seq, "expressions", 1);
-    UninitFieldIncNode incNode = read(ifNode, "bodyNode", UninitFieldIncNode.class);
+    IntUninitIncFieldNode incNode = read(ifNode, "bodyNode", IntUninitIncFieldNode.class);
 
     int fieldIdx = read(incNode, "fieldIndex", Integer.class);
     assertEquals(0, fieldIdx);
@@ -344,7 +344,7 @@ public class AstInliningTests extends AstTestSetup {
     assertEquals("b", readB.getInvocationIdentifier().getString());
     assertEquals(1, readB.argumentIndex);
 
-    UninitFieldIncNode incNode = read(blockBIfTrue, "bodyNode", UninitFieldIncNode.class);
+    IntUninitIncFieldNode incNode = read(blockBIfTrue, "bodyNode", IntUninitIncFieldNode.class);
     NonLocalArgumentReadNode selfNode = (NonLocalArgumentReadNode) incNode.getSelf();
     assertEquals(2, selfNode.getContextLevel());
     assertEquals(0, (int) read(incNode, "fieldIndex", Integer.class));


### PR DESCRIPTION
This adds the following nodes:

 - `Inc[Non]LocalVariableNode`: can have an arbitrary value expression
 - have `IntIncFieldNode` and `IncFieldNode`: the first has a constant integer (was previously called IncFieldNode), and a new second one that takes an arbitrary expression (now called IncFieldNode)

@OctaveLarose please review.