### PR TITLE
Put string concatenation behind truffle boundary

### DIFF
--- a/src/trufflesom/interpreter/nodes/FieldNode.java
+++ b/src/trufflesom/interpreter/nodes/FieldNode.java
@@ -37,10 +37,8 @@ import trufflesom.interpreter.nodes.dispatch.CachedFieldWriteAndSelf;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
 import trufflesom.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
-import trufflesom.interpreter.objectstorage.FieldAccessorNode.IncrementLongFieldNode;
 import trufflesom.interpreter.objectstorage.ObjectLayout;
 import trufflesom.interpreter.objectstorage.StorageLocation;
-import trufflesom.vm.NotYetImplementedException;
 import trufflesom.vmobjects.SObject;
 
 

--- a/src/trufflesom/interpreter/supernodes/IncLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IncLocalVariableNode.java
@@ -1,5 +1,6 @@
 package trufflesom.interpreter.supernodes;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
@@ -46,9 +47,14 @@ public abstract class IncLocalVariableNode extends LocalVariableNode {
   public final Object doString(final VirtualFrame frame, final String value)
       throws FrameSlotTypeException {
     String current = (String) frame.getObject(slot);
-    String result = current + value;
+    String result = concat(current, value);
     frame.setObject(slot, result);
     return result;
+  }
+
+  @TruffleBoundary
+  private static String concat(final String a, final String b) {
+    return a.concat(b);
   }
 
   @Override

--- a/src/trufflesom/interpreter/supernodes/IncNonLocalVariableNode.java
+++ b/src/trufflesom/interpreter/supernodes/IncNonLocalVariableNode.java
@@ -1,6 +1,7 @@
 package trufflesom.interpreter.supernodes;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.NodeChild;
@@ -48,14 +49,19 @@ public abstract class IncNonLocalVariableNode extends NonLocalVariableNode {
     return result;
   }
 
-  @Specialization(guards = "ctx.isDouble(slot)", rewriteOn = {FrameSlotTypeException.class})
+  @Specialization(guards = "ctx.isObject(slot)", rewriteOn = {FrameSlotTypeException.class})
   public final Object doString(final VirtualFrame frame, final String value,
       @Bind("determineContext(frame)") final MaterializedFrame ctx)
       throws FrameSlotTypeException {
     String current = (String) ctx.getObject(slot);
-    String result = current + value;
+    String result = concat(current, value);
     ctx.setObject(slot, result);
     return result;
+  }
+
+  @TruffleBoundary
+  private static String concat(final String a, final String b) {
+    return a.concat(b);
   }
 
   @Fallback

--- a/tests/trufflesom/supernodes/IncrementOpTests.java
+++ b/tests/trufflesom/supernodes/IncrementOpTests.java
@@ -133,7 +133,7 @@ public class IncrementOpTests extends AstTestSetup {
 
     BlockNode block = (BlockNode) read(seq, "expressions", 0);
     ExpressionNode testExpr =
-        read(block.getMethod().getInvokable(), "expressionOrSequence", ExpressionNode.class);
+        read(block.getMethod().getInvokable(), "body", ExpressionNode.class);
     assertThat(testExpr, instanceOf(nodeType));
     long value = read(testExpr, "incValue", Long.class);
     assertEquals(literalValue, value);
@@ -154,7 +154,7 @@ public class IncrementOpTests extends AstTestSetup {
 
     BlockNode block = (BlockNode) read(seq, "expressions", 0);
     ExpressionNode testExpr =
-        read(block.getMethod().getInvokable(), "expressionOrSequence", ExpressionNode.class);
+        read(block.getMethod().getInvokable(), "body", ExpressionNode.class);
     assertThat(testExpr, instanceOf(nodeType));
   }
 

--- a/tests/trufflesom/supernodes/SquareTests.java
+++ b/tests/trufflesom/supernodes/SquareTests.java
@@ -50,7 +50,7 @@ public class SquareTests extends AstTestSetup {
 
     BlockNode block = (BlockNode) read(seq, "expressions", 0);
     ExpressionNode testExpr =
-        read(block.getMethod().getInvokable(), "expressionOrSequence", ExpressionNode.class);
+        read(block.getMethod().getInvokable(), "body", ExpressionNode.class);
     assertThat(testExpr, instanceOf(expectedNode));
     return (T) testExpr;
   }


### PR DESCRIPTION
String concatenation is black listed on for GraalVM 22.0 native image compilation.

This also fixes an incorrect guard for the IncNonLocal* case.