### PR TITLE
Add the #gcStats and #totalCompilationTime primitives to System class

### DIFF
--- a/src/trufflesom/primitives/basics/SystemPrims.java
+++ b/src/trufflesom/primitives/basics/SystemPrims.java
@@ -248,9 +248,6 @@ public final class SystemPrims {
   public abstract static class GcStatsPrim extends UnaryExpressionNode {
     @CompilationFinal private static List<GarbageCollectorMXBean> beans;
 
-    private static long prevTime;
-    private static long prevCount;
-
     @Specialization
     public final SArray doSObject(final Object receiver) {
       if (beans == null) {
@@ -279,19 +276,14 @@ public final class SystemPrims {
         }
       }
 
-      SArray arr = new SArray(new long[] {counts - prevCount, time - prevTime});
-      prevCount = counts;
-      prevTime = time;
-      return arr;
+      return new SArray(new long[] {counts, time});
     }
   }
 
   @GenerateNodeFactory
-  @Primitive(className = "System", primitive = "compilerTime")
+  @Primitive(className = "System", primitive = "totalCompilationTime")
   public abstract static class CompilerStatsPrim extends UnaryExpressionNode {
     @CompilationFinal private static CompilationMXBean bean;
-
-    private static long prevTime;
 
     @Specialization
     public final long doSObject(final Object receiver) {
@@ -300,10 +292,7 @@ public final class SystemPrims {
         bean = ManagementFactory.getCompilationMXBean();
       }
 
-      long time = bean.getTotalCompilationTime();
-      long result = time - prevTime;
-      prevTime = time;
-      return result;
+      return bean.getTotalCompilationTime();
     }
   }
 


### PR DESCRIPTION
This PR implements the primitives for the System class:

- #gcStats: returns an array with GC count and total GC time in milliseconds, based on the Java `GarbageCollectorMXBean`
- #totalCompilationTime: returns an integer with the total time spend compiling, based on that Java `CompilationMXBean`

/cc @OctaveLarose here the primitives for TruffleSOM to get extra statistics.