### PR TITLE
Add support for an explicit path on the EG flag, which points to the graal to be used

### DIFF
--- a/som
+++ b/som
@@ -84,8 +84,9 @@ parser.add_argument('-C', '--no-compilation', help='disable Truffle compilation'
                     dest='no_compilation', action='store_true', default=False)
 parser.add_argument('-G', '--interpreter', help='run without Graal',
                     dest='interpreter', action='store_true', default=False)
-parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal. Settings like JVMCI_BIN and GRAAL_HOME are ignored as long as the embedded Graal is not disabled.',
-                    dest='use_embedded_graal', action='store_false', default=True)
+parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal. When set, USE_EMBEDDED_GRAAL, JVMCI_BIN, or GRAAL_HOME are used.',
+                    dest='use_embedded_graal', action='store', nargs='?',
+                    const=False, default=True)
 parser.add_argument('-LG', '--no-libgraal', help='run without using the embedded libgraal, which is a precompiled Graal',
                     dest='use_libgraal', action='store_false', default=True)
 parser.add_argument('-X', '--java-interpreter', help='run without Graal, and only the Java interpreter',
@@ -151,7 +152,7 @@ if not java_bin:
   java_bin = "java"
 
 
-if args.use_embedded_graal:
+if args.use_embedded_graal is True:
   from subprocess import check_output, STDOUT, CalledProcessError
   try:
     libgraal_jdk_home = check_output(
@@ -172,7 +173,17 @@ if args.use_embedded_graal:
     print e.output
     sys.exit(1)
 else:
-    if JVMCI_BIN:
+    if args.use_embedded_graal is not False:
+      if not os.path.isdir(args.use_embedded_graal):
+        print("USE_EMBEDDED_GRAAL does not seem to exist: " + args.use_embedded_graal)
+        sys.exit(1)
+        
+      if not os.path.isfile(args.use_embedded_graal + '/bin/java'):
+        print("USE_EMBEDDED_GRAAL did not seem to have a bin/java: " + args.use_embedded_graal)
+        sys.exit(1)
+
+      java_bin = args.use_embedded_graal + '/bin/java'
+    if not java_bin and JVMCI_BIN:
       java_bin = JVMCI_BIN
     if not java_bin and GRAAL_HOME and os.path.isfile(GRAAL_HOME + '/bin/java'):
       java_bin = GRAAL_HOME + '/bin/java'


### PR DESCRIPTION
With this change, we can use `-EG ./some/path/to/graal`.
The path needs to contain `bin/java`.