### PR TITLE
Enable inlining of getNumberOfArguments()

### DIFF
--- a/src/trufflesom/interpreter/nodes/AbstractMessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/AbstractMessageSendNode.java
@@ -12,9 +12,11 @@ public abstract class AbstractMessageSendNode extends ExpressionNode
     implements PreevaluatedExpression, Invocation<SSymbol> {
 
   @Children protected final ExpressionNode[] argumentNodes;
+  private final int                          numArguments;
 
-  protected AbstractMessageSendNode(final ExpressionNode[] arguments) {
+  protected AbstractMessageSendNode(final int numArguments, final ExpressionNode[] arguments) {
     this.argumentNodes = arguments;
+    this.numArguments = numArguments;
   }
 
   @Override
@@ -33,5 +35,7 @@ public abstract class AbstractMessageSendNode extends ExpressionNode
     return arguments;
   }
 
-  public abstract int getNumberOfArguments();
+  public final int getNumberOfArguments() {
+    return numArguments;
+  }
 }

--- a/src/trufflesom/interpreter/nodes/GenericMessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/GenericMessageSendNode.java
@@ -15,25 +15,22 @@ import trufflesom.vmobjects.SSymbol;
 public class GenericMessageSendNode extends AbstractMessageSendNode {
 
   private final SSymbol selector;
-  private final int     numberOfSignatureArguments;
 
   @Child private AbstractDispatchNode dispatchNode;
 
   GenericMessageSendNode(final SSymbol selector, final ExpressionNode[] arguments,
       final AbstractDispatchNode dispatchNode) {
-    super(arguments);
+    super(selector.getNumberOfSignatureArguments(), arguments);
     this.selector = selector;
     this.dispatchNode = dispatchNode;
-    this.numberOfSignatureArguments = selector.getNumberOfSignatureArguments();
   }
 
   /**
    * Only used for GenericMessageSendNodeWrapper.
    */
   protected GenericMessageSendNode() {
-    super(null);
+    super(0, null);
     selector = null;
-    numberOfSignatureArguments = 0;
   }
 
   @Override
@@ -61,11 +58,6 @@ public class GenericMessageSendNode extends AbstractMessageSendNode {
   @Override
   public SSymbol getInvocationIdentifier() {
     return selector;
-  }
-
-  @Override
-  public int getNumberOfArguments() {
-    return numberOfSignatureArguments;
   }
 
   public void notifyDispatchInserted() {

--- a/src/trufflesom/interpreter/nodes/MessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/MessageSendNode.java
@@ -62,16 +62,14 @@ public final class MessageSendNode {
 
   public static final class SuperSendNode extends AbstractMessageSendNode {
     private final SSymbol selector;
-    private final int     numberOfSignatureArguments;
 
     @Child private DirectCallNode cachedSuperMethod;
 
     private SuperSendNode(final SSymbol selector, final ExpressionNode[] arguments,
         final DirectCallNode superMethod) {
-      super(arguments);
+      super(selector.getNumberOfSignatureArguments(), arguments);
       this.selector = selector;
       this.cachedSuperMethod = superMethod;
-      this.numberOfSignatureArguments = selector.getNumberOfSignatureArguments();
     }
 
     @Override
@@ -89,25 +87,18 @@ public final class MessageSendNode {
     public String toString() {
       return "SuperSend(" + selector.getString() + ")";
     }
-
-    @Override
-    public int getNumberOfArguments() {
-      return numberOfSignatureArguments;
-    }
   }
 
   private static final class SuperExprNode extends AbstractMessageSendNode {
     private final SSymbol selector;
-    private final int     numberOfSignatureArguments;
 
     @Child private ExpressionNode expr;
 
     private SuperExprNode(final SSymbol selector, final ExpressionNode[] arguments,
         final PreevaluatedExpression expr) {
-      super(arguments);
+      super(selector.getNumberOfSignatureArguments(), arguments);
       this.selector = selector;
       this.expr = (ExpressionNode) expr;
-      this.numberOfSignatureArguments = selector.getNumberOfSignatureArguments();
     }
 
     @Override
@@ -124,11 +115,6 @@ public final class MessageSendNode {
     @Override
     public String toString() {
       return "SendExpr(" + selector.getString() + ")";
-    }
-
-    @Override
-    public int getNumberOfArguments() {
-      return numberOfSignatureArguments;
     }
   }
 }

--- a/src/trufflesom/interpreter/nodes/UninitializedMessageSendNode.java
+++ b/src/trufflesom/interpreter/nodes/UninitializedMessageSendNode.java
@@ -17,7 +17,7 @@ public final class UninitializedMessageSendNode extends AbstractMessageSendNode 
 
   protected UninitializedMessageSendNode(final SSymbol selector,
       final ExpressionNode[] arguments) {
-    super(arguments);
+    super(selector.getNumberOfSignatureArguments(), arguments);
     this.selector = selector;
   }
 
@@ -67,10 +67,5 @@ public final class UninitializedMessageSendNode extends AbstractMessageSendNode 
   @Override
   public SSymbol getInvocationIdentifier() {
     return selector;
-  }
-
-  @Override
-  public int getNumberOfArguments() {
-    return selector.getNumberOfSignatureArguments();
   }
 }

--- a/src/trufflesom/vmobjects/SInvokable.java
+++ b/src/trufflesom/vmobjects/SInvokable.java
@@ -45,9 +45,16 @@ import trufflesom.vm.Classes;
 
 public abstract class SInvokable extends SAbstractObject {
 
+  protected final Invokable invokable;
+  protected final SSymbol   signature;
+  protected final int       numArguments;
+
+  @CompilationFinal protected SClass holder;
+
   public SInvokable(final SSymbol signature, final Invokable invokable) {
     this.signature = signature;
     this.invokable = invokable;
+    this.numArguments = signature.getNumberOfSignatureArguments();
   }
 
   public static final class SMethod extends SInvokable {
@@ -154,7 +161,7 @@ public abstract class SInvokable extends SAbstractObject {
   }
 
   public final int getNumberOfArguments() {
-    return getSignature().getNumberOfSignatureArguments();
+    return numArguments;
   }
 
   public final Object invoke(final Object[] arguments) {
@@ -169,19 +176,14 @@ public abstract class SInvokable extends SAbstractObject {
   public final String toString() {
     // TODO: fixme: remove special case if possible, I think it indicates a bug
     if (holder == null) {
-      return "Method(nil>>" + getSignature().toString() + ")";
+      return "Method(nil>>" + signature.toString() + ")";
     }
 
-    return "Method(" + getHolder().getName().getString() + ">>" + getSignature().toString()
+    return "Method(" + getHolder().getName().getString() + ">>" + signature.toString()
         + ")";
   }
 
   public abstract String getIdentifier();
-
-  protected final Invokable invokable;
-  protected final SSymbol   signature;
-
-  @CompilationFinal protected SClass holder;
 
   public boolean isTrivial() {
     return invokable.isTrivial();


### PR DESCRIPTION
These changes enable the inlining of `getNumberOfArguments()` in bytecode loop, and avoid the extra indirection via the symbol in other cases.

Microbenchmarks show some nice gains on the bytecode interpreter: https://rebench.stefan-marr.de/compare/TruffleSOM/bace2c4d3ebe38d0b0ba8d491c1fa071f7a9ace2/f5bc03835789dd12bf4f67b9308434a99ec4bab2
