### PR TITLE
Make specializations static for Operations DSL

### DIFF
--- a/src/trufflesom/interpreter/nodes/specialized/NotMessageNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/NotMessageNode.java
@@ -14,7 +14,7 @@ import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
 @Primitive(selector = "not", receiverType = Boolean.class)
 public abstract class NotMessageNode extends UnaryExpressionNode {
   @Specialization
-  public final boolean doNot(final VirtualFrame frame, final boolean receiver) {
+  public static final boolean doNot(final VirtualFrame frame, final boolean receiver) {
     return !receiver;
   }
 }

--- a/src/trufflesom/primitives/arithmetic/AdditionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/AdditionPrim.java
@@ -24,89 +24,89 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization(rewriteOn = ArithmeticException.class)
-  public final long doLong(final long left, final long argument) {
+  public static final long doLong(final long left, final long argument) {
     return Math.addExact(left, argument);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLongWithOverflow(final long left, final long argument) {
+  public static final Object doLongWithOverflow(final long left, final long argument) {
     return reduceToLongIfPossible(BigInteger.valueOf(left).add(BigInteger.valueOf(argument)));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger argument) {
+  public static final Object doLong(final long left, final BigInteger argument) {
     return doBigInteger(BigInteger.valueOf(left), argument);
   }
 
   @Specialization
-  public final double doLong(final long left, final double argument) {
+  public static final double doLong(final long left, final double argument) {
     return doDouble(left, argument);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.add(right);
     return reduceToLongIfPossible(result);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doDouble(final BigInteger left, final double right) {
+  public static final Object doDouble(final BigInteger left, final double right) {
     return left.doubleValue() + right;
   }
 
   @Specialization
-  public final double doDouble(final double left, final double right) {
+  public static final double doDouble(final double left, final double right) {
     return right + left;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doDouble(final double left, final BigInteger right) {
+  public static final Object doDouble(final double left, final BigInteger right) {
     return left + right.doubleValue();
   }
 
   @Specialization
-  public final double doDouble(final double left, final long right) {
+  public static final double doDouble(final double left, final long right) {
     return left + right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final String doString(final String left, final String right) {
+  public static final String doString(final String left, final String right) {
     return left + right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final String doString(final String left, final SClass right) {
+  public static final String doString(final String left, final SClass right) {
     return left + right.getName().getString();
   }
 
   @Specialization
   @TruffleBoundary
-  public final String doString(final String left, final SSymbol right) {
+  public static final String doString(final String left, final SSymbol right) {
     return left + right.getString();
   }
 
   @Specialization
   @TruffleBoundary
-  public final String doSSymbol(final SSymbol left, final SSymbol right) {
+  public static final String doSSymbol(final SSymbol left, final SSymbol right) {
     return left.getString() + right.getString();
   }
 
   @Specialization
   @TruffleBoundary
-  public final String doSSymbol(final SSymbol left, final String right) {
+  public static final String doSSymbol(final SSymbol left, final String right) {
     return left.getString() + right;
   }
 }

--- a/src/trufflesom/primitives/arithmetic/ArithmeticPrim.java
+++ b/src/trufflesom/primitives/arithmetic/ArithmeticPrim.java
@@ -6,7 +6,7 @@ import trufflesom.interpreter.nodes.nary.BinaryMsgExprNode;
 
 
 public abstract class ArithmeticPrim extends BinaryMsgExprNode {
-  protected final Number reduceToLongIfPossible(final BigInteger result) {
+  protected static final Number reduceToLongIfPossible(final BigInteger result) {
     if (result.bitLength() > Long.SIZE - 1) {
       return result;
     } else {

--- a/src/trufflesom/primitives/arithmetic/BitXorPrim.java
+++ b/src/trufflesom/primitives/arithmetic/BitXorPrim.java
@@ -12,7 +12,7 @@ import trufflesom.vmobjects.SSymbol;
 @Primitive(className = "Integer", primitive = "bitXor:", selector = "bitXor:")
 public abstract class BitXorPrim extends ArithmeticPrim {
   @Specialization
-  public final long doLong(final long receiver, final long right) {
+  public static final long doLong(final long receiver, final long right) {
     return receiver ^ right;
   }
 

--- a/src/trufflesom/primitives/arithmetic/DividePrim.java
+++ b/src/trufflesom/primitives/arithmetic/DividePrim.java
@@ -20,31 +20,31 @@ public abstract class DividePrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final long doLong(final long left, final long right) {
+  public static final long doLong(final long left, final long right) {
     return left / right;
   }
 
   @Specialization
-  public final long doLong(final long left, final double right) {
+  public static final long doLong(final long left, final double right) {
     return (long) (left / right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger right) {
+  public static final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.divide(right);
     return reduceToLongIfPossible(result);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 }

--- a/src/trufflesom/primitives/arithmetic/DoubleDivPrim.java
+++ b/src/trufflesom/primitives/arithmetic/DoubleDivPrim.java
@@ -25,28 +25,28 @@ public abstract class DoubleDivPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final double doDouble(final double left, final double right) {
+  public static final double doDouble(final double left, final double right) {
     return left / right;
   }
 
   @Specialization
-  public final double doDouble(final double left, final long right) {
+  public static final double doDouble(final double left, final long right) {
     return doDouble(left, (double) right);
   }
 
   @Specialization
-  public final double doLong(final long left, final long right) {
+  public static final double doLong(final long left, final long right) {
     return ((double) left) / right;
   }
 
   @Specialization
-  public final double doLong(final long left, final double right) {
+  public static final double doLong(final long left, final double right) {
     return left / right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final SAbstractObject doLong(final long left, final BigInteger right) {
+  public static final SAbstractObject doLong(final long left, final BigInteger right) {
     CompilerAsserts.neverPartOfCompilation("DoubleDiv100");
     // TODO: need to implement the "/" case here directly... :
     // return resendAsBigInteger("/", left, (SBigInteger) rightObj, frame.pack());

--- a/src/trufflesom/primitives/arithmetic/GreaterThanOrEqualPrim.java
+++ b/src/trufflesom/primitives/arithmetic/GreaterThanOrEqualPrim.java
@@ -22,40 +22,40 @@ public abstract class GreaterThanOrEqualPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left >= right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doLong(final long left, final BigInteger right) {
+  public static final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final boolean doLong(final long left, final double right) {
+  public static final boolean doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final long right) {
+  public static final boolean doDouble(final double left, final long right) {
     return doDouble(left, right);
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left >= right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) >= 0;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final long right) {
+  public static final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 }

--- a/src/trufflesom/primitives/arithmetic/GreaterThanPrim.java
+++ b/src/trufflesom/primitives/arithmetic/GreaterThanPrim.java
@@ -22,46 +22,46 @@ public abstract class GreaterThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left > right;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final double right) {
+  public static final boolean doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doLong(final long left, final BigInteger right) {
+  public static final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final long right) {
+  public static final boolean doDouble(final double left, final long right) {
     return doDouble(left, (double) right);
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left > right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doDouble(final double left, final BigInteger right) {
+  public static final boolean doDouble(final double left, final BigInteger right) {
     return left > right.doubleValue();
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) > 0;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final long right) {
+  public static final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 }

--- a/src/trufflesom/primitives/arithmetic/LessThanOrEqualPrim.java
+++ b/src/trufflesom/primitives/arithmetic/LessThanOrEqualPrim.java
@@ -22,40 +22,40 @@ public abstract class LessThanOrEqualPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left <= right;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final double right) {
+  public static final boolean doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doLong(final long left, final BigInteger right) {
+  public static final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) <= 0;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final long right) {
+  public static final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left <= right;
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final long right) {
+  public static final boolean doDouble(final double left, final long right) {
     return doDouble(left, right);
   }
 }

--- a/src/trufflesom/primitives/arithmetic/LessThanPrim.java
+++ b/src/trufflesom/primitives/arithmetic/LessThanPrim.java
@@ -22,40 +22,40 @@ public abstract class LessThanPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left < right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doLong(final long left, final BigInteger right) {
+  public static final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final boolean doLong(final long left, final double right) {
+  public static final boolean doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) < 0;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final long right) {
+  public static final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left < right;
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final long right) {
+  public static final boolean doDouble(final double left, final long right) {
     return doDouble(left, (double) right);
   }
 }

--- a/src/trufflesom/primitives/arithmetic/LogicAndPrim.java
+++ b/src/trufflesom/primitives/arithmetic/LogicAndPrim.java
@@ -20,25 +20,25 @@ public abstract class LogicAndPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final long doLong(final long left, final long right) {
+  public static final long doLong(final long left, final long right) {
     return left & right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger right) {
+  public static final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.and(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 }

--- a/src/trufflesom/primitives/arithmetic/ModuloPrim.java
+++ b/src/trufflesom/primitives/arithmetic/ModuloPrim.java
@@ -22,40 +22,40 @@ public abstract class ModuloPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final double doDouble(final double left, final double right) {
+  public static final double doDouble(final double left, final double right) {
     return left % right;
   }
 
   @Specialization
-  public final double doDouble(final double left, final long right) {
+  public static final double doDouble(final double left, final long right) {
     return doDouble(left, (double) right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.mod(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger right) {
+  public static final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final double doLong(final long left, final double right) {
+  public static final double doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization
-  public final long doLong(final long left, final long right) {
+  public static final long doLong(final long left, final long right) {
     return Math.floorMod(left, right);
   }
 }

--- a/src/trufflesom/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/trufflesom/primitives/arithmetic/MultiplicationPrim.java
@@ -22,60 +22,60 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization(rewriteOn = ArithmeticException.class)
-  public final long doLong(final long left, final long right) {
+  public static final long doLong(final long left, final long right) {
     return Math.multiplyExact(left, right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLongWithOverflow(final long left, final long right) {
+  public static final Object doLongWithOverflow(final long left, final long right) {
     return reduceToLongIfPossible(
         BigInteger.valueOf(left).multiply(BigInteger.valueOf(right)));
   }
 
   @Specialization
-  public final double doLong(final long left, final double right) {
+  public static final double doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger right) {
+  public static final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doDouble(final BigInteger left, final double right) {
+  public static final Object doDouble(final BigInteger left, final double right) {
     return left.doubleValue() * right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.multiply(right);
     return reduceToLongIfPossible(result);
   }
 
   @Specialization
-  public final double doDouble(final double left, final double right) {
+  public static final double doDouble(final double left, final double right) {
     return left * right;
   }
 
   @Specialization
-  public final double doDouble(final double left, final long right) {
+  public static final double doDouble(final double left, final long right) {
     return left * right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doDouble(final double left, final BigInteger right) {
+  public static final Object doDouble(final double left, final BigInteger right) {
     return left * right.doubleValue();
   }
 }

--- a/src/trufflesom/primitives/arithmetic/RemainderPrim.java
+++ b/src/trufflesom/primitives/arithmetic/RemainderPrim.java
@@ -20,40 +20,40 @@ public abstract class RemainderPrim extends ArithmeticPrim {
   }
 
   @Specialization
-  public final double doDouble(final double left, final double right) {
+  public static final double doDouble(final double left, final double right) {
     return left % right;
   }
 
   @Specialization
-  public final double doDouble(final double left, final long right) {
+  public static final double doDouble(final double left, final long right) {
     return doDouble(left, (double) right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.remainder(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger right) {
+  public static final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final double doLong(final long left, final double right) {
+  public static final double doLong(final long left, final double right) {
     return doDouble(left, right);
   }
 
   @Specialization(rewriteOn = ArithmeticException.class)
-  public final long doLong(final long left, final long right) {
+  public static final long doLong(final long left, final long right) {
     return left % right;
   }
 }

--- a/src/trufflesom/primitives/arithmetic/SubtractionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/SubtractionPrim.java
@@ -22,60 +22,60 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization(rewriteOn = ArithmeticException.class)
-  public final long doLong(final long left, final long right) {
+  public static final long doLong(final long left, final long right) {
     return Math.subtractExact(left, right);
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLongWithOverflow(final long left, final long right) {
+  public static final Object doLongWithOverflow(final long left, final long right) {
     return reduceToLongIfPossible(
         BigInteger.valueOf(left).subtract(BigInteger.valueOf(right)));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doLong(final long left, final BigInteger right) {
+  public static final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final double doLong(final long left, final double right) {
+  public static final double doLong(final long left, final double right) {
     return left - right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final long right) {
+  public static final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doDouble(final BigInteger left, final double right) {
+  public static final Object doDouble(final BigInteger left, final double right) {
     return left.doubleValue() - right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.subtract(right);
     return reduceToLongIfPossible(result);
   }
 
   @Specialization
-  public final double doDouble(final double left, final double right) {
+  public static final double doDouble(final double left, final double right) {
     return left - right;
   }
 
   @Specialization
-  public final double doDouble(final double left, final long right) {
+  public static final double doDouble(final double left, final long right) {
     return left - right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final Object doDouble(final double left, final BigInteger right) {
+  public static final Object doDouble(final double left, final BigInteger right) {
     return left - right.doubleValue();
   }
 }

--- a/src/trufflesom/primitives/arrays/AtPrim.java
+++ b/src/trufflesom/primitives/arrays/AtPrim.java
@@ -21,34 +21,34 @@ public abstract class AtPrim extends BinaryMsgExprNode {
   }
 
   @Specialization(guards = "receiver.isEmptyType()")
-  public final Object doEmptySArray(final SArray receiver, final long idx) {
+  public static final Object doEmptySArray(final SArray receiver, final long idx) {
     assert idx > 0;
     assert idx <= receiver.getEmptyStorage();
     return Nil.nilObject;
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
-  public final Object doPartiallyEmptySArray(final SArray receiver, final long idx) {
+  public static final Object doPartiallyEmptySArray(final SArray receiver, final long idx) {
     return receiver.getPartiallyEmptyStorage().get(idx - 1);
   }
 
   @Specialization(guards = "receiver.isObjectType()")
-  public final Object doObjectSArray(final SArray receiver, final long idx) {
+  public static final Object doObjectSArray(final SArray receiver, final long idx) {
     return receiver.getObjectStorage()[(int) idx - 1];
   }
 
   @Specialization(guards = "receiver.isLongType()")
-  public final long doLongSArray(final SArray receiver, final long idx) {
+  public static final long doLongSArray(final SArray receiver, final long idx) {
     return receiver.getLongStorage()[(int) idx - 1];
   }
 
   @Specialization(guards = "receiver.isDoubleType()")
-  public final double doDoubleSArray(final SArray receiver, final long idx) {
+  public static final double doDoubleSArray(final SArray receiver, final long idx) {
     return receiver.getDoubleStorage()[(int) idx - 1];
   }
 
   @Specialization(guards = "receiver.isBooleanType()")
-  public final boolean doBooleanSArray(final SArray receiver, final long idx) {
+  public static final boolean doBooleanSArray(final SArray receiver, final long idx) {
     return receiver.getBooleanStorage()[(int) idx - 1];
   }
 }

--- a/src/trufflesom/primitives/arrays/AtPutPrim.java
+++ b/src/trufflesom/primitives/arrays/AtPutPrim.java
@@ -44,7 +44,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isEmptyType()"})
-  public final long doEmptySArray(final SArray receiver, final long index,
+  public static final long doEmptySArray(final SArray receiver, final long index,
       final long value) {
     long idx = index - 1;
     assert idx >= 0;
@@ -55,7 +55,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isEmptyType()"})
-  public final Object doEmptySArray(final SArray receiver, final long index,
+  public static final Object doEmptySArray(final SArray receiver, final long index,
       final double value) {
     long idx = index - 1;
     assert idx >= 0;
@@ -66,7 +66,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isEmptyType()"})
-  public final Object doEmptySArray(final SArray receiver, final long index,
+  public static final Object doEmptySArray(final SArray receiver, final long index,
       final boolean value) {
     long idx = index - 1;
     assert idx >= 0;
@@ -78,7 +78,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
 
   @Specialization(guards = {"receiver.isEmptyType()", "valueIsNotNil(value)",
       "valueNotLongDoubleBoolean(value)"})
-  public final Object doEmptySArray(final SArray receiver, final long index,
+  public static final Object doEmptySArray(final SArray receiver, final long index,
       final Object value) {
     int idx = (int) index - 1;
     assert idx >= 0;
@@ -95,7 +95,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isEmptyType()", "valueIsNil(value)"})
-  public final Object doEmptySArrayWithNil(final SArray receiver, final long index,
+  public static final Object doEmptySArrayWithNil(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
     assert idx >= 0;
@@ -103,7 +103,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  private void setValue(final long idx, final Object value,
+  private static void setValue(final long idx, final Object value,
       final PartiallyEmptyArray storage) {
     assert idx >= 0;
     assert idx < storage.getLength();
@@ -115,28 +115,28 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
-  public final long doPartiallyEmptySArray(final SArray receiver,
+  public static final long doPartiallyEmptySArray(final SArray receiver,
       final long index, final long value) {
     setAndPossiblyTransition(receiver, index, value, PartiallyEmptyArray.Type.LONG);
     return value;
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
-  public final double doPartiallyEmptySArray(final SArray receiver,
+  public static final double doPartiallyEmptySArray(final SArray receiver,
       final long index, final double value) {
     setAndPossiblyTransition(receiver, index, value, PartiallyEmptyArray.Type.DOUBLE);
     return value;
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
-  public final boolean doPartiallyEmptySArray(final SArray receiver,
+  public static final boolean doPartiallyEmptySArray(final SArray receiver,
       final long index, final boolean value) {
     setAndPossiblyTransition(receiver, index, value, PartiallyEmptyArray.Type.BOOLEAN);
     return value;
   }
 
   @Specialization(guards = {"receiver.isPartiallyEmptyType()", "valueIsNil(value)"})
-  public final Object doPartiallyEmptySArrayWithNil(final SArray receiver,
+  public static final Object doPartiallyEmptySArrayWithNil(final SArray receiver,
       final long index, final Object value) {
     long idx = index - 1;
     PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage();
@@ -151,14 +151,14 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isPartiallyEmptyType()", "valueIsNotNil(value)"})
-  public final Object doPartiallyEmptySArray(final SArray receiver,
+  public static final Object doPartiallyEmptySArray(final SArray receiver,
       final long index, final Object value) {
     setAndPossiblyTransition(receiver, index, value, PartiallyEmptyArray.Type.OBJECT);
     return value;
   }
 
   @Specialization(guards = "receiver.isObjectType()")
-  public final Object doObjectSArray(final SArray receiver, final long index,
+  public static final Object doObjectSArray(final SArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
     receiver.getObjectStorage()[(int) idx] = value;
@@ -166,7 +166,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = "receiver.isLongType()")
-  public final Object doObjectSArray(final SArray receiver, final long index,
+  public static final Object doObjectSArray(final SArray receiver, final long index,
       final long value) {
     long idx = index - 1;
     receiver.getLongStorage()[(int) idx] = value;
@@ -174,7 +174,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isLongType()", "valueIsNotLong(value)"})
-  public final Object doLongSArray(final SArray receiver, final long index,
+  public static final Object doLongSArray(final SArray receiver, final long index,
       final Object value) {
     long[] storage = receiver.getLongStorage();
     Object[] newStorage = new Object[storage.length];
@@ -186,7 +186,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = "receiver.isDoubleType()")
-  public final Object doDoubleSArray(final SArray receiver, final long index,
+  public static final Object doDoubleSArray(final SArray receiver, final long index,
       final double value) {
     long idx = index - 1;
     receiver.getDoubleStorage()[(int) idx] = value;
@@ -194,7 +194,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isDoubleType()", "valueIsNotDouble(value)"})
-  public final Object doDoubleSArray(final SArray receiver, final long index,
+  public static final Object doDoubleSArray(final SArray receiver, final long index,
       final Object value) {
     double[] storage = receiver.getDoubleStorage();
     Object[] newStorage = new Object[storage.length];
@@ -206,7 +206,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = "receiver.isBooleanType()")
-  public final Object doBooleanSArray(final SArray receiver, final long index,
+  public static final Object doBooleanSArray(final SArray receiver, final long index,
       final boolean value) {
     long idx = index - 1;
     receiver.getBooleanStorage()[(int) idx] = value;
@@ -214,7 +214,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   }
 
   @Specialization(guards = {"receiver.isBooleanType()", "valueIsNotBoolean(value)"})
-  public final Object doBooleanSArray(final SArray receiver, final long index,
+  public static final Object doBooleanSArray(final SArray receiver, final long index,
       final Object value) {
     boolean[] storage = receiver.getBooleanStorage();
     Object[] newStorage = new Object[storage.length];
@@ -225,7 +225,8 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return transitionAndSet(receiver, index, value, newStorage);
   }
 
-  private Object transitionAndSet(final SArray receiver, final long index, final Object value,
+  private static Object transitionAndSet(final SArray receiver, final long index,
+      final Object value,
       final Object[] newStorage) {
     long idx = index - 1;
     receiver.transitionTo(newStorage);
@@ -233,7 +234,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
     return value;
   }
 
-  private void setAndPossiblyTransition(final SArray receiver,
+  private static void setAndPossiblyTransition(final SArray receiver,
       final long index, final Object value, final PartiallyEmptyArray.Type expectedType) {
     PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage();
     setValue(index - 1, value, storage);

--- a/src/trufflesom/primitives/arrays/NewPrim.java
+++ b/src/trufflesom/primitives/arrays/NewPrim.java
@@ -35,7 +35,7 @@ public abstract class NewPrim extends BinaryMsgExprNode {
   }
 
   @Specialization(guards = "receiver == arrayClass")
-  public final SArray doSClass(final SClass receiver, final long length) {
+  public static final SArray doSClass(final SClass receiver, final long length) {
     return new SArray(length);
   }
 

--- a/src/trufflesom/primitives/basics/BlockPrims.java
+++ b/src/trufflesom/primitives/basics/BlockPrims.java
@@ -62,7 +62,7 @@ public abstract class BlockPrims {
     @Specialization(
         guards = {"receiver.getMethod() == method", "!method.isTrivial()"},
         limit = "InlineCacheSize")
-    public final Object doSBlock(final SBlock receiver,
+    public static final Object doSBlock(final SBlock receiver,
         @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("createCallNode(method)") final DirectCallNode call) {
       return call.call(receiver);
@@ -71,7 +71,7 @@ public abstract class BlockPrims {
     @Specialization(
         guards = {"receiver.getMethod() == method", "method.isTrivial()"},
         limit = "InlineCacheSize")
-    public final Object doTrivial(final SBlock receiver,
+    public static final Object doTrivial(final SBlock receiver,
         @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("method.copyTrivialNode()") final PreevaluatedExpression expr) {
       return expr.doPreEvaluated(null, new Object[] {receiver});
@@ -79,12 +79,12 @@ public abstract class BlockPrims {
 
     @Specialization
     @Megamorphic
-    public final Object generic(final SBlock receiver) {
+    public static final Object generic(final SBlock receiver) {
       return receiver.getMethod().invoke(new Object[] {receiver});
     }
 
     @Specialization
-    public final boolean doBoolean(final boolean receiver) {
+    public static final boolean doBoolean(final boolean receiver) {
       return receiver;
     }
 
@@ -107,7 +107,7 @@ public abstract class BlockPrims {
     @Specialization(
         guards = {"receiver.getMethod() == method", "!method.isTrivial()"},
         limit = "InlineCacheSize")
-    public final Object doSBlock(final SBlock receiver, final Object arg,
+    public static final Object doSBlock(final SBlock receiver, final Object arg,
         @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("createCallNode(method)") final DirectCallNode call) {
       return call.call(receiver, arg);
@@ -116,7 +116,7 @@ public abstract class BlockPrims {
     @Specialization(
         guards = {"receiver.getMethod() == method", "method.isTrivial()"},
         limit = "InlineCacheSize")
-    public final Object doTrivial(final SBlock receiver, final Object arg,
+    public static final Object doTrivial(final SBlock receiver, final Object arg,
         @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("method.copyTrivialNode()") final PreevaluatedExpression expr) {
       return expr.doPreEvaluated(null, new Object[] {receiver, arg});
@@ -124,7 +124,7 @@ public abstract class BlockPrims {
 
     @Specialization
     @Megamorphic
-    public final Object generic(final SBlock receiver, final Object arg) {
+    public static final Object generic(final SBlock receiver, final Object arg) {
       return receiver.getMethod().invoke(new Object[] {receiver, arg});
     }
 
@@ -152,7 +152,8 @@ public abstract class BlockPrims {
     @Specialization(
         guards = {"receiver.getMethod() == method", "!method.isTrivial()"},
         limit = "InlineCacheSize")
-    public final Object doSBlock(final SBlock receiver, final Object arg1, final Object arg2,
+    public static final Object doSBlock(final SBlock receiver, final Object arg1,
+        final Object arg2,
         @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("createCallNode(method)") final DirectCallNode call) {
       return call.call(receiver, arg1, arg2);
@@ -161,7 +162,8 @@ public abstract class BlockPrims {
     @Specialization(
         guards = {"receiver.getMethod() == method", "method.isTrivial()"},
         limit = "InlineCacheSize")
-    public final Object doTrivial(final SBlock receiver, final Object arg1, final Object arg2,
+    public static final Object doTrivial(final SBlock receiver, final Object arg1,
+        final Object arg2,
         @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("method.copyTrivialNode()") final PreevaluatedExpression expr) {
       return expr.doPreEvaluated(null, new Object[] {receiver, arg1, arg2});
@@ -169,7 +171,8 @@ public abstract class BlockPrims {
 
     @Specialization
     @Megamorphic
-    public final Object generic(final SBlock receiver, final Object arg1, final Object arg2) {
+    public static final Object generic(final SBlock receiver, final Object arg1,
+        final Object arg2) {
       return receiver.getMethod().invoke(new Object[] {receiver, arg1, arg2});
     }
   }
@@ -178,7 +181,7 @@ public abstract class BlockPrims {
   @Primitive(className = "Block4", primitive = "value:with:with:")
   public abstract static class ValueMorePrim extends QuaternaryExpressionNode {
     @Specialization
-    public final Object doSBlock(final VirtualFrame frame,
+    public static final Object doSBlock(final VirtualFrame frame,
         final SBlock receiver, final Object firstArg, final Object secondArg,
         final Object thirdArg) {
       CompilerDirectives.transferToInterpreter();

--- a/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsEqualsPrim.java
@@ -16,17 +16,17 @@ import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 @Primitive(selector = "==")
 public abstract class EqualsEqualsPrim extends BinaryExpressionNode {
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left == right;
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left == right;
   }
 
   @Fallback
-  public final boolean fallback(final Object receiver, final Object argument) {
+  public static final boolean fallback(final Object receiver, final Object argument) {
     return receiver == argument;
   }
 }

--- a/src/trufflesom/primitives/basics/EqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsPrim.java
@@ -25,111 +25,111 @@ public abstract class EqualsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
-  public final boolean doBoolean(final boolean left, final boolean right) {
+  public static final boolean doBoolean(final boolean left, final boolean right) {
     return left == right;
   }
 
   @Specialization
-  public final boolean doBoolean(final boolean left, final SObject right) {
+  public static final boolean doBoolean(final boolean left, final SObject right) {
     return false;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left == right;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final double right) {
+  public static final boolean doLong(final long left, final double right) {
     return left == right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doLong(final long left, final BigInteger right) {
+  public static final boolean doLong(final long left, final BigInteger right) {
     return BigInteger.valueOf(left).compareTo(right) == 0;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final String right) {
+  public static final boolean doLong(final long left, final String right) {
     return false;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final SObject right) {
+  public static final boolean doLong(final long left, final SObject right) {
     return false;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final SSymbol right) {
+  public static final boolean doLong(final long left, final SSymbol right) {
     return false;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final long right) {
+  public static final boolean doBigInteger(final BigInteger left, final long right) {
     return left.compareTo(BigInteger.valueOf(right)) == 0;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) == 0;
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left == right;
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final long right) {
+  public static final boolean doDouble(final double left, final long right) {
     return left == right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doDouble(final double left, final BigInteger right) {
+  public static final boolean doDouble(final double left, final BigInteger right) {
     return left == right.doubleValue();
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final String argument) {
+  public static final boolean doString(final String receiver, final String argument) {
     return receiver.equals(argument);
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final SSymbol argument) {
+  public static final boolean doString(final String receiver, final SSymbol argument) {
     return receiver.equals(argument.getString());
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final long argument) {
+  public static final boolean doString(final String receiver, final long argument) {
     return false;
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final SObject argument) {
+  public static final boolean doString(final String receiver, final SObject argument) {
     return false;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol left, final SSymbol right) {
+  public static final boolean doSSymbol(final SSymbol left, final SSymbol right) {
     return left == right;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol receiver, final String argument) {
+  public static final boolean doSSymbol(final SSymbol receiver, final String argument) {
     return false;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol receiver, final long argument) {
+  public static final boolean doSSymbol(final SSymbol receiver, final long argument) {
     return false;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol receiver, final SObject argument) {
+  public static final boolean doSSymbol(final SSymbol receiver, final SObject argument) {
     return false;
   }
 }

--- a/src/trufflesom/primitives/basics/IntegerPrims.java
+++ b/src/trufflesom/primitives/basics/IntegerPrims.java
@@ -27,7 +27,7 @@ public abstract class IntegerPrims {
   @Primitive(className = "Integer", primitive = "atRandom")
   public abstract static class RandomPrim extends UnaryExpressionNode {
     @Specialization
-    public final long doLong(final long receiver) {
+    public static final long doLong(final long receiver) {
       return (long) (receiver * Math.random());
     }
   }
@@ -37,13 +37,13 @@ public abstract class IntegerPrims {
   @Primitive(selector = "as32BitSignedValue")
   public abstract static class As32BitSignedValue extends UnaryExpressionNode {
     @Specialization
-    public final long doLong(final long receiver) {
+    public static final long doLong(final long receiver) {
       return (int) receiver;
     }
 
     @Specialization
     @TruffleBoundary
-    public final long doBig(final BigInteger receiver) {
+    public static final long doBig(final BigInteger receiver) {
       return receiver.intValue();
     }
   }
@@ -53,13 +53,13 @@ public abstract class IntegerPrims {
   @Primitive(selector = "as32BitUnsignedValue")
   public abstract static class As32BitUnsignedValue extends UnaryExpressionNode {
     @Specialization
-    public final long doLong(final long receiver) {
+    public static final long doLong(final long receiver) {
       return Integer.toUnsignedLong((int) receiver);
     }
 
     @Specialization
     @TruffleBoundary
-    public final long doBig(final BigInteger receiver) {
+    public static final long doBig(final BigInteger receiver) {
       return Integer.toUnsignedLong(receiver.intValue());
     }
   }
@@ -69,13 +69,13 @@ public abstract class IntegerPrims {
   @Primitive(selector = "asDouble")
   public abstract static class AsDoubleValue extends UnaryExpressionNode {
     @Specialization
-    public final double doLong(final long receiver) {
+    public static final double doLong(final long receiver) {
       return receiver;
     }
 
     @Specialization
     @TruffleBoundary
-    public final double doBig(final BigInteger receiver) {
+    public static final double doBig(final BigInteger receiver) {
       return receiver.doubleValue();
     }
   }
@@ -86,18 +86,18 @@ public abstract class IntegerPrims {
   @Primitive(selector = "negated")
   public abstract static class NegatedValue extends UnaryExpressionNode {
     @Specialization
-    public final long doLong(final long receiver) {
+    public static final long doLong(final long receiver) {
       return -receiver;
     }
 
     @Specialization
-    public final double doDouble(final double receiver) {
+    public static final double doDouble(final double receiver) {
       return -receiver;
     }
 
     @Specialization
     @TruffleBoundary
-    public final BigInteger doBig(final BigInteger receiver) {
+    public static final BigInteger doBig(final BigInteger receiver) {
       return receiver.negate();
     }
   }
@@ -109,7 +109,7 @@ public abstract class IntegerPrims {
 
     @TruffleBoundary
     @Specialization(guards = "receiver == integerClass")
-    public final Object doString(final SClass receiver, final String argument) {
+    public static final Object doString(final SClass receiver, final String argument) {
       try {
         return Long.parseLong(argument);
       } catch (NumberFormatException e) {
@@ -118,7 +118,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization(guards = "receiver == integerClass")
-    public final Object doSymbol(final SClass receiver, final SSymbol argument) {
+    public static final Object doSymbol(final SClass receiver, final SSymbol argument) {
       return doString(receiver, argument.getString());
     }
   }
@@ -146,7 +146,7 @@ public abstract class IntegerPrims {
 
     @Specialization
     @TruffleBoundary
-    public final BigInteger doLongWithOverflow(final long receiver, final long right) {
+    public static final BigInteger doLongWithOverflow(final long receiver, final long right) {
       assert right >= 0; // currently not defined for negative values of right
       assert right <= Integer.MAX_VALUE;
 
@@ -163,7 +163,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
-    public final long doLong(final long receiver, final long right) {
+    public static final long doLong(final long receiver, final long right) {
       return receiver >>> right;
     }
   }
@@ -178,25 +178,25 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
-    public final long doLong(final long receiver, final long right) {
+    public static final long doLong(final long receiver, final long right) {
       return Math.min(receiver, right);
     }
 
     @Specialization
     @TruffleBoundary
-    public BigInteger doLongBig(final long left, final BigInteger right) {
+    public static BigInteger doLongBig(final long left, final BigInteger right) {
       return BigInteger.valueOf(left).min(right);
     }
 
     @Specialization
     @TruffleBoundary
-    public BigInteger doBigLong(final BigInteger left, final long right) {
+    public static BigInteger doBigLong(final BigInteger left, final long right) {
       return left.min(BigInteger.valueOf(right));
     }
 
     @Specialization
     @TruffleBoundary
-    public BigInteger doBig(final BigInteger left, final BigInteger right) {
+    public static BigInteger doBig(final BigInteger left, final BigInteger right) {
       return left.min(right);
     }
   }
@@ -211,25 +211,25 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
-    public final long doLong(final long receiver, final long right) {
+    public static final long doLong(final long receiver, final long right) {
       return Math.max(receiver, right);
     }
 
     @Specialization
     @TruffleBoundary
-    public BigInteger doLongBig(final long left, final BigInteger right) {
+    public static BigInteger doLongBig(final long left, final BigInteger right) {
       return BigInteger.valueOf(left).max(right);
     }
 
     @Specialization
     @TruffleBoundary
-    public BigInteger doBigLong(final BigInteger left, final long right) {
+    public static BigInteger doBigLong(final BigInteger left, final long right) {
       return left.max(BigInteger.valueOf(right));
     }
 
     @Specialization
     @TruffleBoundary
-    public BigInteger doBig(final BigInteger left, final BigInteger right) {
+    public static BigInteger doBig(final BigInteger left, final BigInteger right) {
       return left.max(right);
     }
   }
@@ -244,7 +244,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
-    public final SArray doLong(final long receiver, final long right) {
+    public static final SArray doLong(final long receiver, final long right) {
       int cnt = (int) right - (int) receiver + 1;
       long[] arr = new long[cnt];
       for (int i = 0; i < cnt; i++) {
@@ -266,19 +266,19 @@ public abstract class IntegerPrims {
      * Math.abs(MIN_VALUE) == MIN_VALUE, which is wrong.
      */
     @Specialization(guards = "!minLong(receiver)")
-    public final long doLong(final long receiver) {
+    public static final long doLong(final long receiver) {
       return Math.abs(receiver);
     }
 
     @Specialization(guards = "minLong(receiver)")
     @TruffleBoundary
-    public final BigInteger doLongMinValue(final long receiver) {
+    public static final BigInteger doLongMinValue(final long receiver) {
       return BigInteger.valueOf(Long.MIN_VALUE).abs();
     }
 
     @Specialization
     @TruffleBoundary
-    public final BigInteger doBig(final BigInteger receiver) {
+    public static final BigInteger doBig(final BigInteger receiver) {
       return receiver.abs();
     }
 

--- a/src/trufflesom/primitives/basics/LengthPrim.java
+++ b/src/trufflesom/primitives/basics/LengthPrim.java
@@ -21,44 +21,44 @@ import trufflesom.vmobjects.SSymbol;
 public abstract class LengthPrim extends UnaryExpressionNode {
 
   @Specialization(guards = "receiver.isEmptyType()")
-  public final long doEmptySArray(final SArray receiver) {
+  public static final long doEmptySArray(final SArray receiver) {
     return receiver.getEmptyStorage();
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
-  public final long doPartialEmptySArray(final SArray receiver) {
+  public static final long doPartialEmptySArray(final SArray receiver) {
     return receiver.getPartiallyEmptyStorage().getLength();
   }
 
   @Specialization(guards = "receiver.isObjectType()")
-  public final long doObjectSArray(final SArray receiver) {
+  public static final long doObjectSArray(final SArray receiver) {
     return receiver.getObjectStorage().length;
   }
 
   @Specialization(guards = "receiver.isLongType()")
-  public final long doLongSArray(final SArray receiver) {
+  public static final long doLongSArray(final SArray receiver) {
     return receiver.getLongStorage().length;
   }
 
   @Specialization(guards = "receiver.isDoubleType()")
-  public final long doDoubleSArray(final SArray receiver) {
+  public static final long doDoubleSArray(final SArray receiver) {
     return receiver.getDoubleStorage().length;
   }
 
   @Specialization(guards = "receiver.isBooleanType()")
-  public final long doBooleanSArray(final SArray receiver) {
+  public static final long doBooleanSArray(final SArray receiver) {
     return receiver.getBooleanStorage().length;
   }
 
   public abstract long executeEvaluated(VirtualFrame frame, SArray receiver);
 
   @Specialization
-  public final long doString(final String receiver) {
+  public static final long doString(final String receiver) {
     return receiver.length();
   }
 
   @Specialization
-  public final long doSSymbol(final SSymbol receiver) {
+  public static final long doSSymbol(final SSymbol receiver) {
     return receiver.getString().length();
   }
 

--- a/src/trufflesom/primitives/basics/StringPrims.java
+++ b/src/trufflesom/primitives/basics/StringPrims.java
@@ -29,25 +29,25 @@ public class StringPrims {
 
     @Specialization
     @TruffleBoundary
-    public final String doString(final String receiver, final String argument) {
+    public static final String doString(final String receiver, final String argument) {
       return receiver + argument;
     }
 
     @Specialization
     @TruffleBoundary
-    public final String doString(final String receiver, final SSymbol argument) {
+    public static final String doString(final String receiver, final SSymbol argument) {
       return receiver + argument.getString();
     }
 
     @Specialization
     @TruffleBoundary
-    public final String doSSymbol(final SSymbol receiver, final String argument) {
+    public static final String doSSymbol(final SSymbol receiver, final String argument) {
       return receiver.getString() + argument;
     }
 
     @Specialization
     @TruffleBoundary
-    public final String doSSymbol(final SSymbol receiver, final SSymbol argument) {
+    public static final String doSSymbol(final SSymbol receiver, final SSymbol argument) {
       return receiver.getString() + argument.getString();
     }
   }
@@ -102,7 +102,7 @@ public class StringPrims {
     }
 
     @Specialization
-    public final SAbstractObject doSSymbol(final SSymbol receiver) {
+    public static final SAbstractObject doSSymbol(final SSymbol receiver) {
       return receiver;
     }
   }
@@ -111,7 +111,7 @@ public class StringPrims {
   @Primitive(className = "String", primitive = "primSubstringFrom:to:")
   public abstract static class SubstringPrim extends TernaryExpressionNode {
     @Specialization
-    public final String doString(final String receiver, final long start,
+    public static final String doString(final String receiver, final long start,
         final long end) {
       try {
         return receiver.substring((int) start - 1, (int) end);
@@ -121,7 +121,7 @@ public class StringPrims {
     }
 
     @Specialization
-    public final String doSSymbol(final SSymbol receiver, final long start,
+    public static final String doSSymbol(final SSymbol receiver, final long start,
         final long end) {
       return doString(receiver.getString(), start, end);
     }
@@ -132,18 +132,18 @@ public class StringPrims {
   public abstract static class IsWhiteSpacePrim extends UnaryExpressionNode {
     @TruffleBoundary
     @Specialization(guards = "receiver.length() == 1")
-    public final boolean doChar(final String receiver) {
+    public static final boolean doChar(final String receiver) {
       return Character.isWhitespace(receiver.charAt(0));
     }
 
     @Specialization(guards = "receiver.getString().length() == 1")
-    public final boolean doChar(final SSymbol receiver) {
+    public static final boolean doChar(final SSymbol receiver) {
       return doChar(receiver.getString());
     }
 
     @TruffleBoundary
     @Specialization(guards = "receiver.length() != 1")
-    public final boolean doString(final String receiver) {
+    public static final boolean doString(final String receiver) {
       for (int i = 0; i < receiver.length(); i++) {
         if (!Character.isWhitespace(receiver.charAt(i))) {
           return false;
@@ -158,7 +158,7 @@ public class StringPrims {
     }
 
     @Specialization(guards = "receiver.getString().length() != 1")
-    public final boolean doSSymbol(final SSymbol receiver) {
+    public static final boolean doSSymbol(final SSymbol receiver) {
       return doString(receiver.getString());
     }
   }
@@ -168,18 +168,18 @@ public class StringPrims {
   public abstract static class IsLettersPrim extends UnaryExpressionNode {
     @TruffleBoundary
     @Specialization(guards = "receiver.length() == 1")
-    public final boolean doChar(final String receiver) {
+    public static final boolean doChar(final String receiver) {
       return Character.isLetter(receiver.charAt(0));
     }
 
     @Specialization(guards = "receiver.getString().length() == 1")
-    public final boolean doChar(final SSymbol receiver) {
+    public static final boolean doChar(final SSymbol receiver) {
       return doChar(receiver.getString());
     }
 
     @TruffleBoundary
     @Specialization(guards = "receiver.length() != 1")
-    public final boolean doString(final String receiver) {
+    public static final boolean doString(final String receiver) {
       for (int i = 0; i < receiver.length(); i++) {
         if (!Character.isLetter(receiver.charAt(i))) {
           return false;
@@ -194,7 +194,7 @@ public class StringPrims {
     }
 
     @Specialization(guards = "receiver.getString().length() != 1")
-    public final boolean doSSymbol(final SSymbol receiver) {
+    public static final boolean doSSymbol(final SSymbol receiver) {
       return doString(receiver.getString());
     }
   }
@@ -204,18 +204,18 @@ public class StringPrims {
   public abstract static class IsDigitsPrim extends UnaryExpressionNode {
     @TruffleBoundary
     @Specialization(guards = "receiver.length() == 1")
-    public final boolean doChar(final String receiver) {
+    public static final boolean doChar(final String receiver) {
       return Character.isDigit(receiver.charAt(0));
     }
 
     @Specialization(guards = "receiver.getString().length() == 1")
-    public final boolean doChar(final SSymbol receiver) {
+    public static final boolean doChar(final SSymbol receiver) {
       return doChar(receiver.getString());
     }
 
     @TruffleBoundary
     @Specialization(guards = "receiver.length() != 1")
-    public final boolean doString(final String receiver) {
+    public static final boolean doString(final String receiver) {
       for (int i = 0; i < receiver.length(); i++) {
         if (!Character.isDigit(receiver.charAt(i))) {
           return false;
@@ -230,7 +230,7 @@ public class StringPrims {
     }
 
     @Specialization(guards = "receiver.getString().length() != 1")
-    public final boolean doSSymbol(final SSymbol receiver) {
+    public static final boolean doSSymbol(final SSymbol receiver) {
       return doString(receiver.getString());
     }
   }

--- a/src/trufflesom/primitives/basics/UnequalUnequalPrim.java
+++ b/src/trufflesom/primitives/basics/UnequalUnequalPrim.java
@@ -15,17 +15,17 @@ import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 @Primitive(selector = "~=")
 public abstract class UnequalUnequalPrim extends BinaryExpressionNode {
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left != right;
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left != right;
   }
 
   @Fallback
-  public final boolean fallback(final Object receiver, final Object argument) {
+  public static final boolean fallback(final Object receiver, final Object argument) {
     return receiver != argument;
   }
 }

--- a/src/trufflesom/primitives/basics/UnequalsPrim.java
+++ b/src/trufflesom/primitives/basics/UnequalsPrim.java
@@ -24,95 +24,95 @@ public abstract class UnequalsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
-  public final boolean doBoolean(final boolean left, final boolean right) {
+  public static final boolean doBoolean(final boolean left, final boolean right) {
     return left != right;
   }
 
   @Specialization
-  public final boolean doBoolean(final boolean left, final SObject right) {
+  public static final boolean doBoolean(final boolean left, final SObject right) {
     return true;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final long right) {
+  public static final boolean doLong(final long left, final long right) {
     return left != right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
+  public static final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) != 0;
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final String argument) {
+  public static final boolean doString(final String receiver, final String argument) {
     return !receiver.equals(argument);
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final double right) {
+  public static final boolean doDouble(final double left, final double right) {
     return left != right;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol left, final SSymbol right) {
+  public static final boolean doSSymbol(final SSymbol left, final SSymbol right) {
     return left != right;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final double right) {
+  public static final boolean doLong(final long left, final double right) {
     return left != right;
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doBigInteger(final BigInteger left, final long right) {
+  public static final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
   @TruffleBoundary
-  public final boolean doLong(final long left, final BigInteger right) {
+  public static final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
-  public final boolean doDouble(final double left, final long right) {
+  public static final boolean doDouble(final double left, final long right) {
     return doDouble(left, (double) right);
   }
 
   @Specialization
-  public final boolean doLong(final long left, final String right) {
+  public static final boolean doLong(final long left, final String right) {
     return true;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final SObject right) {
+  public static final boolean doLong(final long left, final SObject right) {
     return true;
   }
 
   @Specialization
-  public final boolean doLong(final long left, final SSymbol right) {
+  public static final boolean doLong(final long left, final SSymbol right) {
     return true;
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final long argument) {
+  public static final boolean doString(final String receiver, final long argument) {
     return true;
   }
 
   @Specialization
-  public final boolean doString(final String receiver, final SObject argument) {
+  public static final boolean doString(final String receiver, final SObject argument) {
     return true;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol receiver, final long argument) {
+  public static final boolean doSSymbol(final SSymbol receiver, final long argument) {
     return true;
   }
 
   @Specialization
-  public final boolean doSSymbol(final SSymbol receiver, final SObject argument) {
+  public static final boolean doSSymbol(final SSymbol receiver, final SObject argument) {
     return true;
   }
 }

--- a/src/trufflesom/primitives/reflection/MethodPrims.java
+++ b/src/trufflesom/primitives/reflection/MethodPrims.java
@@ -29,7 +29,7 @@ public final class MethodPrims {
   @Primitive(className = "Primitive", primitive = "signature")
   public abstract static class SignaturePrim extends UnaryExpressionNode {
     @Specialization
-    public final SAbstractObject doSMethod(final SInvokable receiver) {
+    public static final SAbstractObject doSMethod(final SInvokable receiver) {
       return receiver.getSignature();
     }
   }
@@ -39,7 +39,7 @@ public final class MethodPrims {
   @Primitive(className = "Primitive", primitive = "holder")
   public abstract static class HolderPrim extends UnaryExpressionNode {
     @Specialization
-    public final SAbstractObject doSMethod(final SInvokable receiver) {
+    public static final SAbstractObject doSMethod(final SInvokable receiver) {
       return receiver.getHolder();
     }
   }
@@ -76,7 +76,7 @@ public final class MethodPrims {
 
     @Specialization(guards = "receiver == cachedReceiver",
         limit = "" + AbstractDispatchNode.INLINE_CACHE_SIZE)
-    public final Object doCached(
+    public static final Object doCached(
         final SInvokable receiver, final Object target, final SArray somArr,
         final Object[] argArr,
         @Cached("receiver") final SInvokable cachedReceiver,
@@ -85,7 +85,7 @@ public final class MethodPrims {
     }
 
     @Specialization(replaces = "doCached")
-    public final Object doUncached(
+    public static final Object doUncached(
         final SInvokable receiver, final Object target, final SArray somArr,
         final Object[] argArr,
         @Cached("createIndirect()") final IndirectCallNode callNode) {

--- a/src/trufflesom/primitives/reflection/ObjectPrims.java
+++ b/src/trufflesom/primitives/reflection/ObjectPrims.java
@@ -97,7 +97,7 @@ public final class ObjectPrims {
 
     @Specialization
     @TruffleBoundary
-    public final Object doSObject(final SObject receiver, final SSymbol fieldName) {
+    public static final Object doSObject(final SObject receiver, final SSymbol fieldName) {
       CompilerAsserts.neverPartOfCompilation();
       return receiver.getField(receiver.getFieldIndex(fieldName));
     }
@@ -107,7 +107,7 @@ public final class ObjectPrims {
   @Primitive(className = "Object", primitive = "halt")
   public abstract static class HaltPrim extends UnaryExpressionNode {
     @Specialization
-    public final Object doSAbstractObject(final Object receiver) {
+    public static final Object doSAbstractObject(final Object receiver) {
       Universe.errorPrintln("BREAKPOINT");
       return receiver;
     }
@@ -120,63 +120,63 @@ public final class ObjectPrims {
     public abstract SClass executeEvaluated(Object rcvr);
 
     @Specialization
-    public final SClass getSomClass(final SArray receiver) {
+    public static final SClass getSomClass(final SArray receiver) {
       return arrayClass;
     }
 
     @Specialization
-    public final SClass getSomClass(final SBlock receiver) {
+    public static final SClass getSomClass(final SBlock receiver) {
       return receiver.getSOMClass();
     }
 
     @Specialization
-    public final SClass getSomClass(final SObject receiver) {
+    public static final SClass getSomClass(final SObject receiver) {
       return receiver.getSOMClass();
     }
 
     @Specialization
-    public final SClass getSomClass(final SMethod receiver) {
+    public static final SClass getSomClass(final SMethod receiver) {
       return methodClass;
     }
 
     @Specialization
-    public final SClass getSomClass(final SPrimitive receiver) {
+    public static final SClass getSomClass(final SPrimitive receiver) {
       return primitiveClass;
     }
 
     @Specialization
-    public final SClass getSomClass(final SSymbol receiver) {
+    public static final SClass getSomClass(final SSymbol receiver) {
       return symbolClass;
     }
 
     @Specialization(guards = "receiver")
-    public final SClass getTrueClass(final boolean receiver) {
+    public static final SClass getTrueClass(final boolean receiver) {
       return trueClass;
     }
 
     @Specialization(guards = "!receiver")
-    public final SClass getFalseClass(final boolean receiver) {
+    public static final SClass getFalseClass(final boolean receiver) {
       return falseClass;
     }
 
     @Specialization
-    public final SClass getSomClass(final long receiver) {
+    public static final SClass getSomClass(final long receiver) {
       return integerClass;
     }
 
     @Specialization
-    public final SClass getSomClass(final BigInteger receiver) {
+    public static final SClass getSomClass(final BigInteger receiver) {
       return integerClass;
     }
 
     @Specialization
-    public final SClass getSomClass(final String receiver) {
+    public static final SClass getSomClass(final String receiver) {
       return stringClass;
     }
 
     @TruffleBoundary
     @Specialization
-    public final SClass getSomClass(final double receiver) {
+    public static final SClass getSomClass(final double receiver) {
       return doubleClass;
     }
   }
@@ -185,7 +185,7 @@ public final class ObjectPrims {
   @Primitive(selector = "isNil")
   public abstract static class IsNilNode extends UnaryExpressionNode {
     @Specialization
-    public final boolean isNil(final Object receiver) {
+    public static final boolean isNil(final Object receiver) {
       return receiver == Nil.nilObject;
     }
   }
@@ -194,7 +194,7 @@ public final class ObjectPrims {
   @Primitive(selector = "notNil")
   public abstract static class NotNilNode extends UnaryExpressionNode {
     @Specialization
-    public final boolean notNil(final Object receiver) {
+    public static final boolean notNil(final Object receiver) {
       return receiver != Nil.nilObject;
     }
   }


### PR DESCRIPTION
This is a bit of preparation for experiments with the upcoming Truffle Operations DSL.

This PR turns some of the specializations needed into static methods, simply by adding the `static` keyword. It doesn't change anything else.

This is expected to be performance neutral on Graal and native image.
As far as I can tell, there's only noise: https://rebench.stefan-marr.de/compare/TruffleSOM/f5bc03835789dd12bf4f67b9308434a99ec4bab2/5c530df24ddd2d9702e8eebc252d8f567b8e1057