### PR TITLE
Experiments to avoid possible Graal limitations for bytecode loops

### DIFF
--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -241,6 +241,10 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
   private static final int RETURN_FROM_METHOD = -1;
 
+  private static final class BackBranchCounter {
+    int backBranchesTaken;
+  }
+
   @Override
   @ExplodeLoop(kind = LoopExplosionKind.MERGE_EXPLODE)
   @BytecodeInterpreterSwitch
@@ -254,7 +258,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
     int stackPointer = -1;
     int bytecodeIndex = 0;
 
-    int backBranchesTaken = 0;
+    BackBranchCounter c = new BackBranchCounter();
 
     Object returnValue = null;
 
@@ -636,14 +640,14 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         }
 
         case RETURN_LOCAL: {
-          LoopNode.reportLoopCount(this, backBranchesTaken);
+          LoopNode.reportLoopCount(this, c.backBranchesTaken);
           returnValue = stack[stackPointer];
           nextBytecodeIndex = RETURN_FROM_METHOD;
           break;
         }
 
         case RETURN_NON_LOCAL: {
-          LoopNode.reportLoopCount(this, backBranchesTaken);
+          LoopNode.reportLoopCount(this, c.backBranchesTaken);
 
           Object result = stack[stackPointer];
           // stackPointer -= 1;
@@ -652,7 +656,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         }
 
         case RETURN_SELF: {
-          LoopNode.reportLoopCount(this, backBranchesTaken);
+          LoopNode.reportLoopCount(this, c.backBranchesTaken);
           returnValue = frame.getArguments()[0];
           nextBytecodeIndex = RETURN_FROM_METHOD;
           break;
@@ -863,7 +867,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           nextBytecodeIndex = bytecodeIndex + offset;
 
           if (CompilerDirectives.inInterpreter()) {
-            backBranchesTaken += 1;
+            c.backBranchesTaken += 1;
           }
           break;
         }
@@ -922,7 +926,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           nextBytecodeIndex = bytecodeIndex - offset;
 
           if (CompilerDirectives.inInterpreter()) {
-            backBranchesTaken += 1;
+            c.backBranchesTaken += 1;
           }
           break;
         }


### PR DESCRIPTION
As suggested by @fniephaus, there may be Graal limitations worth to work around.

Graal may not like having multiple return statements in the same bytecode loop.
The solution here would be to assign the return value to a variable, and break the bytecode loop by checking the next bytecode index for a known value (`-1`).

The performance impact seems overall negative from this, especially interpreter performance suffers: https://rebench.stefan-marr.de/compare/TruffleSOM/c0ca77fed790812838ba35bf29eac9b2f2349a05/f0f3207559c1e2cd8962f8e324fbd7636ff4309a

The next possible limitation is around Graal's logic to determine the program counter, which may get confused by the counter for taken back branches. Hiding the counter in an object may avoid the confusion.

Performance results on this are not indicating a change either way. It seems all within the normal noise. https://rebench.stefan-marr.de/compare/TruffleSOM/f0f3207559c1e2cd8962f8e324fbd7636ff4309a/d9f4c917cccaf1c399d997614b34c8e7a547fdd3

Have not further investigated these experiments, but they do not seem urgent at this point, so, this PR is mostly to document the results, and reevaluate in the future.