### PR TITLE
Improve bytecode loop performance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,8 @@ benchmark-y1:
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria
+  after_script:
+    - sudo reown-project.sh
 
 benchmark-y2:
   stage: benchmark
@@ -108,6 +110,8 @@ benchmark-y2:
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria2
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria2
+  after_script:
+    - sudo reown-project.sh
 
 benchmark-y3:
   stage: benchmark
@@ -129,6 +133,8 @@ benchmark-y3:
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria3
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria3
+  after_script:
+    - sudo reown-project.sh
 
 report-completion:
   stage: benchmark-completion

--- a/build.xml
+++ b/build.xml
@@ -79,9 +79,10 @@ kernel:           ${kernel}</echo>
 Native Image Targets
 ====================
 
--Dno.jit      compile a native image with JIT compilation disabled
+-Dno.jit=true compile a native image with JIT compilation disabled
 -Ddump.method=MethodFilter  dump compiler graphs for the selected methods
-  for MethodFilter syntax see https://github.com/oracle/graal/blob/master/compiler/src/org.graalvm.compiler.debug/src/org/graalvm/compiler/debug/doc-files/MethodFilterHelp.txt</echo>
+  for MethodFilter syntax see https://github.com/oracle/graal/blob/master/compiler/src/org.graalvm.compiler.debug/src/org/graalvm/compiler/debug/doc-files/MethodFilterHelp.txt
+-Ddbg=true    when building a native image, wait for debugger to attach</echo>
     </target>
 
     <target name="clean-som" description="Remove build directories and generated code">
@@ -409,6 +410,7 @@ Native Image Targets
             <exec executable="@{exe}" dir="@{dir}" failonerror="true">
               <env key="JAVA_HOME" value="@{java-home}" />
               <arg line="native-image" if:true="@{is-ce}" />
+              <arg line="-J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000" if:true="${dbg}" />
               <arg line="--macro:truffle --no-fallback" />
               
               <arg line="--initialize-at-build-time='bd,tools,trufflesom,org.graalvm.graphio'" if:set="dump.method" />

--- a/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -138,6 +138,10 @@ public class Bytecodes {
     return PADDED_BYTECODE_NAMES[bytecode];
   }
 
+  public static final byte LEN_NO_ARG     = 1;
+  public static final byte LEN_TWO_ARGS   = 2;
+  public static final byte LEN_THREE_ARGS = 3;
+
   public static int getBytecodeLength(final byte bytecode) {
     return BYTECODE_LENGTH[bytecode];
   }

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -303,6 +303,13 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
     return longVal;
   }
 
+  @InliningCutoff
+  private void missingBytecode(final byte bytecode) {
+    CompilerDirectives.transferToInterpreter();
+    throw new NotYetImplementedException("The bytecode " + bytecode + " ("
+        + Bytecodes.getBytecodeName(bytecode) + ") is not yet implemented.");
+  }
+
   @Override
   @ExplodeLoop(kind = LoopExplosionKind.MERGE_EXPLODE)
   @BytecodeInterpreterSwitch
@@ -1105,9 +1112,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         }
 
         default:
-          CompilerDirectives.transferToInterpreter();
-          throw new NotYetImplementedException("The bytecode " + bytecode + " ("
-              + Bytecodes.getBytecodeName(bytecode) + ") is not yet implemented.");
+          missingBytecode(bytecode);
       }
     }
   }

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -254,8 +254,10 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
     final byte[] bytecodes = bytecodesField;
     final Node[] quickened = quickenedField;
     final Object[] literalsAndConstants = literalsAndConstantsField;
+    final Object[] arguments = frame.getArguments();
 
-    if (bytecodes == null || quickened == null || literalsAndConstants == null) {
+    if (bytecodes == null || quickened == null || literalsAndConstants == null || frame == null
+        || arguments == null) {
       return throwIllegaleState();
     }
 
@@ -338,19 +340,19 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
         case PUSH_SELF: {
           stackPointer += 1;
-          stack[stackPointer] = frame.getArguments()[0];
+          stack[stackPointer] = arguments[0];
           bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case PUSH_ARG1: {
           stackPointer += 1;
-          stack[stackPointer] = frame.getArguments()[1];
+          stack[stackPointer] = arguments[1];
           bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case PUSH_ARG2: {
           stackPointer += 1;
-          stack[stackPointer] = frame.getArguments()[2];
+          stack[stackPointer] = arguments[2];
           bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
@@ -386,7 +388,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
           stackPointer += 1;
           stack[stackPointer] =
-              ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+              ((AbstractReadFieldNode) node).read((SObject) arguments[0]);
           bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
@@ -400,7 +402,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
           stackPointer += 1;
           stack[stackPointer] =
-              ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+              ((AbstractReadFieldNode) node).read((SObject) arguments[0]);
           bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
@@ -576,7 +578,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             quickened[bytecodeIndex] = node = insert(FieldAccessorNode.createWrite(0));
           }
 
-          ((AbstractWriteFieldNode) node).write((SObject) frame.getArguments()[0],
+          ((AbstractWriteFieldNode) node).write((SObject) arguments[0],
               stack[stackPointer]);
 
           stackPointer -= 1;
@@ -590,7 +592,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             quickened[bytecodeIndex] = node = insert(FieldAccessorNode.createWrite(1));
           }
 
-          ((AbstractWriteFieldNode) node).write((SObject) frame.getArguments()[0],
+          ((AbstractWriteFieldNode) node).write((SObject) arguments[0],
               stack[stackPointer]);
 
           stackPointer -= 1;
@@ -688,7 +690,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
         case RETURN_SELF: {
           LoopNode.reportLoopCount(this, backBranchesTaken);
-          return frame.getArguments()[0];
+          return arguments[0];
         }
 
         case RETURN_FIELD_0: {
@@ -698,7 +700,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(0));
           }
 
-          return ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+          return ((AbstractReadFieldNode) node).read((SObject) arguments[0]);
         }
         case RETURN_FIELD_1: {
           Node node = quickened[bytecodeIndex];
@@ -707,7 +709,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(1));
           }
 
-          return ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+          return ((AbstractReadFieldNode) node).read((SObject) arguments[0]);
         }
         case RETURN_FIELD_2: {
           Node node = quickened[bytecodeIndex];
@@ -716,7 +718,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(2));
           }
 
-          return ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+          return ((AbstractReadFieldNode) node).read((SObject) arguments[0]);
         }
 
         case INC: {

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -256,8 +256,6 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
     while (true) {
       byte bytecode = bytecodes[bytecodeIndex];
-      final int bytecodeLength = getBytecodeLength(bytecode);
-      int nextBytecodeIndex = bytecodeIndex + bytecodeLength;
 
       CompilerAsserts.partialEvaluationConstant(bytecodeIndex);
       CompilerAsserts.partialEvaluationConstant(bytecode);
@@ -272,6 +270,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object top = stack[stackPointer];
           stackPointer += 1;
           stack[stackPointer] = top;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -287,22 +286,26 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object value = currentOrContext.getObject(localIdx);
           stackPointer += 1;
           stack[stackPointer] = value;
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
         case PUSH_LOCAL_0: {
           stackPointer += 1;
           stack[stackPointer] = frame.getObject(0);
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case PUSH_LOCAL_1: {
           stackPointer += 1;
           stack[stackPointer] = frame.getObject(1);
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case PUSH_LOCAL_2: {
           stackPointer += 1;
           stack[stackPointer] = frame.getObject(2);
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -319,48 +322,26 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object value = currentOrContext.getArguments()[argIdx];
           stackPointer += 1;
           stack[stackPointer] = value;
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
         case PUSH_SELF: {
           stackPointer += 1;
           stack[stackPointer] = frame.getArguments()[0];
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case PUSH_ARG1: {
           stackPointer += 1;
           stack[stackPointer] = frame.getArguments()[1];
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case PUSH_ARG2: {
           stackPointer += 1;
           stack[stackPointer] = frame.getArguments()[2];
-          break;
-        }
-
-        case PUSH_FIELD_0: {
-          Node node = quickened[bytecodeIndex];
-          if (node == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(0));
-          }
-
-          stackPointer += 1;
-          stack[stackPointer] =
-              ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
-          break;
-        }
-
-        case PUSH_FIELD_1: {
-          Node node = quickened[bytecodeIndex];
-          if (node == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(1));
-          }
-
-          stackPointer += 1;
-          stack[stackPointer] =
-              ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -382,6 +363,35 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           stackPointer += 1;
           stack[stackPointer] = ((AbstractReadFieldNode) node).read(
               (SObject) currentOrContext.getArguments()[0]);
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
+          break;
+        }
+
+        case PUSH_FIELD_0: {
+          Node node = quickened[bytecodeIndex];
+          if (node == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(0));
+          }
+
+          stackPointer += 1;
+          stack[stackPointer] =
+              ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
+          break;
+        }
+
+        case PUSH_FIELD_1: {
+          Node node = quickened[bytecodeIndex];
+          if (node == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            node = quickened[bytecodeIndex] = insert(FieldAccessorNode.createRead(1));
+          }
+
+          stackPointer += 1;
+          stack[stackPointer] =
+              ((AbstractReadFieldNode) node).read((SObject) frame.getArguments()[0]);
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -391,6 +401,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           stackPointer += 1;
           stack[stackPointer] = new SBlock(blockMethod,
               Classes.getBlockClass(blockMethod.getNumberOfArguments()), frame.materialize());
+          bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           break;
         }
 
@@ -400,48 +411,56 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           stackPointer += 1;
           stack[stackPointer] = new SBlock(blockMethod,
               Classes.getBlockClass(blockMethod.getNumberOfArguments()), null);
+          bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           break;
         }
 
         case PUSH_CONSTANT: {
           stackPointer += 1;
           stack[stackPointer] = literalsAndConstants[bytecodes[bytecodeIndex + 1]];
+          bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           break;
         }
 
         case PUSH_CONSTANT_0: {
           stackPointer += 1;
           stack[stackPointer] = literalsAndConstants[0];
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
         case PUSH_CONSTANT_1: {
           stackPointer += 1;
           stack[stackPointer] = literalsAndConstants[1];
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
         case PUSH_CONSTANT_2: {
           stackPointer += 1;
           stack[stackPointer] = literalsAndConstants[2];
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
         case PUSH_0: {
           stackPointer += 1;
           stack[stackPointer] = 0L;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
         case PUSH_1: {
           stackPointer += 1;
           stack[stackPointer] = 1L;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
         case PUSH_NIL: {
           stackPointer += 1;
           stack[stackPointer] = Nil.nilObject;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -457,11 +476,13 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
           stackPointer += 1;
           stack[stackPointer] = quick.executeGeneric(frame);
+          bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           break;
         }
 
         case POP: {
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -478,22 +499,26 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           stackPointer -= 1;
 
           currentOrContext.setObject(localIdx, value);
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
         case POP_LOCAL_0: {
           frame.setObject(0, stack[stackPointer]);
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case POP_LOCAL_1: {
           frame.setObject(1, stack[stackPointer]);
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case POP_LOCAL_2: {
           frame.setObject(2, stack[stackPointer]);
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -508,6 +533,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
           currentOrContext.getArguments()[argIdx] = stack[stackPointer];
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
@@ -529,6 +555,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           ((AbstractWriteFieldNode) node).write((SObject) currentOrContext.getArguments()[0],
               stack[stackPointer]);
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
@@ -543,6 +570,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
               stack[stackPointer]);
 
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
         case POP_FIELD_1: {
@@ -556,6 +584,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
               stack[stackPointer]);
 
           stackPointer -= 1;
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -576,8 +605,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
             stackPointer += 1;
             stack[stackPointer] = result;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RestartLoopException e) {
-            nextBytecodeIndex = 0;
+            bytecodeIndex = 0;
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
@@ -588,6 +618,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
             stackPointer += 1;
             stack[stackPointer] = result;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
         }
@@ -612,8 +643,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
             stackPointer += 1;
             stack[stackPointer] = result;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RestartLoopException e) {
-            nextBytecodeIndex = 0;
+            bytecodeIndex = 0;
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
@@ -625,6 +657,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
             stackPointer += 1;
             stack[stackPointer] = result;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
         }
@@ -640,7 +673,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object result = stack[stackPointer];
           // stackPointer -= 1;
           doReturnNonLocal(frame, bytecodeIndex, result);
-          break;
+          return Nil.nilObject;
         }
 
         case RETURN_SELF: {
@@ -693,6 +726,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
               throw new NotYetImplementedException();
             }
           }
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -708,6 +742,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
               throw new NotYetImplementedException();
             }
           }
+          bytecodeIndex += Bytecodes.LEN_NO_ARG;
           break;
         }
 
@@ -739,10 +774,12 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
             node = quickened[bytecodeIndex] =
                 insert(FieldAccessorNode.createIncrement(fieldIdx, obj));
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
             break;
           }
 
           ((IncrementLongFieldNode) node).increment(obj);
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
@@ -776,18 +813,20 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
             node = quickened[bytecodeIndex] =
                 insert(FieldAccessorNode.createIncrement(fieldIdx, obj));
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
             break;
           }
 
           long value = ((IncrementLongFieldNode) node).increment(obj);
           stackPointer += 1;
           stack[stackPointer] = value;
+          bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           break;
         }
 
         case JUMP: {
           int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
-          nextBytecodeIndex = bytecodeIndex + offset;
+          bytecodeIndex += offset;
           break;
         }
 
@@ -795,10 +834,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object val = stack[stackPointer];
           if (val == Boolean.TRUE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
             stack[stackPointer] = Nil.nilObject;
           } else {
             stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           break;
         }
@@ -807,10 +847,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object val = stack[stackPointer];
           if (val == Boolean.FALSE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
             stack[stackPointer] = Nil.nilObject;
           } else {
             stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           break;
         }
@@ -819,7 +860,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object val = stack[stackPointer];
           if (val == Boolean.TRUE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           stackPointer -= 1;
           break;
@@ -829,7 +872,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Object val = stack[stackPointer];
           if (val == Boolean.FALSE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           stackPointer -= 1;
           break;
@@ -837,14 +882,14 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
         case JUMP_BACKWARDS: {
           int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
-          nextBytecodeIndex = bytecodeIndex - offset;
+          bytecodeIndex -= offset;
           break;
         }
 
         case JUMP2: {
           int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
               + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
-          nextBytecodeIndex = bytecodeIndex + offset;
+          bytecodeIndex += offset;
 
           if (CompilerDirectives.inInterpreter()) {
             backBranchesTaken += 1;
@@ -857,10 +902,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           if (val == Boolean.TRUE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
                 + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
             stack[stackPointer] = Nil.nilObject;
           } else {
             stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           break;
         }
@@ -870,10 +916,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           if (val == Boolean.FALSE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
                 + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
             stack[stackPointer] = Nil.nilObject;
           } else {
             stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           break;
         }
@@ -883,7 +930,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           if (val == Boolean.TRUE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
                 + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           stackPointer -= 1;
           break;
@@ -894,7 +943,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           if (val == Boolean.FALSE) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
                 + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
-            nextBytecodeIndex = bytecodeIndex + offset;
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_THREE_ARGS;
           }
           stackPointer -= 1;
           break;
@@ -903,7 +954,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         case JUMP2_BACKWARDS: {
           int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
               + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
-          nextBytecodeIndex = bytecodeIndex - offset;
+          bytecodeIndex -= offset;
 
           if (CompilerDirectives.inInterpreter()) {
             backBranchesTaken += 1;
@@ -914,6 +965,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         case Q_PUSH_GLOBAL: {
           stackPointer += 1;
           stack[stackPointer] = ((GlobalNode) quickened[bytecodeIndex]).executeGeneric(frame);
+          bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           break;
         }
 
@@ -927,8 +979,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
 
           try {
             stack[stackPointer] = node.doPreEvaluated(frame, callArgs);
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RestartLoopException e) {
-            nextBytecodeIndex = 0;
+            bytecodeIndex = 0;
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
@@ -936,7 +989,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
             stack[stackPointer] =
                 SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
+
           break;
         }
 
@@ -946,8 +1001,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           try {
             UnaryExpressionNode node = (UnaryExpressionNode) quickened[bytecodeIndex];
             stack[stackPointer] = node.executeEvaluated(frame, rcvr);
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RestartLoopException e) {
-            nextBytecodeIndex = 0;
+            bytecodeIndex = 0;
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
@@ -955,10 +1011,12 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
             stack[stackPointer] =
                 SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RespecializeException r) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             quickenBytecode(bytecodeIndex, Q_SEND, r.send);
             stack[stackPointer] = r.send.doPreEvaluated(frame, new Object[] {rcvr});
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
         }
@@ -972,8 +1030,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           try {
             BinaryExpressionNode node = (BinaryExpressionNode) quickened[bytecodeIndex];
             stack[stackPointer] = node.executeEvaluated(frame, rcvr, arg);
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RestartLoopException e) {
-            nextBytecodeIndex = 0;
+            bytecodeIndex = 0;
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
@@ -981,10 +1040,12 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
             stack[stackPointer] =
                 SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RespecializeException r) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             quickenBytecode(bytecodeIndex, Q_SEND, r.send);
             stack[stackPointer] = r.send.doPreEvaluated(frame, new Object[] {rcvr, arg});
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
         }
@@ -999,8 +1060,9 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           try {
             TernaryExpressionNode node = (TernaryExpressionNode) quickened[bytecodeIndex];
             stack[stackPointer] = node.executeEvaluated(frame, rcvr, arg1, arg2);
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RestartLoopException e) {
-            nextBytecodeIndex = 0;
+            bytecodeIndex = 0;
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
@@ -1008,11 +1070,13 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
             stack[stackPointer] =
                 SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RespecializeException r) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             quickenBytecode(bytecodeIndex, Q_SEND, r.send);
             stack[stackPointer] =
                 r.send.doPreEvaluated(frame, new Object[] {rcvr, arg1, arg2});
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
         }
@@ -1022,8 +1086,6 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           throw new NotYetImplementedException("The bytecode " + bytecode + " ("
               + Bytecodes.getBytecodeName(bytecode) + ") is not yet implemented.");
       }
-
-      bytecodeIndex = nextBytecodeIndex;
     }
   }
 

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -89,6 +89,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives.BytecodeInterpreterSwitch;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
@@ -239,6 +240,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
     quickenedField[bytecodeIndex] = insert(node);
   }
 
+  @InliningCutoff
+  private Object throwIllegaleState() {
+    throw new IllegalStateException("Not all required fields initialized in bytecode loop.");
+  }
+
   @Override
   @ExplodeLoop(kind = LoopExplosionKind.MERGE_EXPLODE)
   @BytecodeInterpreterSwitch
@@ -248,6 +254,10 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
     final byte[] bytecodes = bytecodesField;
     final Node[] quickened = quickenedField;
     final Object[] literalsAndConstants = literalsAndConstantsField;
+
+    if (bytecodes == null || quickened == null || literalsAndConstants == null) {
+      return throwIllegaleState();
+    }
 
     int stackPointer = -1;
     int bytecodeIndex = 0;

--- a/src/trufflesom/interpreter/objectstorage/FieldAccessorNode.java
+++ b/src/trufflesom/interpreter/objectstorage/FieldAccessorNode.java
@@ -1,6 +1,7 @@
 package trufflesom.interpreter.objectstorage;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
@@ -18,14 +19,17 @@ import trufflesom.vmobjects.SObject;
 public abstract class FieldAccessorNode extends Node {
   protected final int fieldIndex;
 
+  @InliningCutoff
   public static AbstractReadFieldNode createRead(final int fieldIndex) {
     return new UninitializedReadFieldNode(fieldIndex);
   }
 
+  @InliningCutoff
   public static AbstractWriteFieldNode createWrite(final int fieldIndex) {
     return new UninitializedWriteFieldNode(fieldIndex);
   }
 
+  @InliningCutoff
   public static IncrementLongFieldNode createIncrement(final int fieldIndex,
       final SObject obj) {
     final ObjectLayout layout = obj.getObjectLayout();
@@ -66,6 +70,7 @@ public abstract class FieldAccessorNode extends Node {
       return specialize(obj, reason, next).read(obj);
     }
 
+    @InliningCutoff
     protected final AbstractReadFieldNode specialize(final SObject obj,
         final String reason, final AbstractReadFieldNode next) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -86,6 +91,7 @@ public abstract class FieldAccessorNode extends Node {
     }
 
     @Override
+    @InliningCutoff
     public Object read(final SObject obj) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       return specializeAndRead(obj, "uninitalized node",
@@ -134,8 +140,14 @@ public abstract class FieldAccessorNode extends Node {
           return respecializedNodeOrNext(obj).read(obj);
         }
       } catch (InvalidAssumptionException e) {
-        return replace(SOMNode.unwrapIfNeeded(nextInCache)).read(obj);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        return dropAndReadNext(obj);
       }
+    }
+
+    @InliningCutoff
+    private Object dropAndReadNext(final SObject obj) {
+      return replace(SOMNode.unwrapIfNeeded(nextInCache)).read(obj);
     }
   }
 
@@ -157,8 +169,14 @@ public abstract class FieldAccessorNode extends Node {
           return respecializedNodeOrNext(obj).readLong(obj);
         }
       } catch (InvalidAssumptionException e) {
-        return replace(SOMNode.unwrapIfNeeded(nextInCache)).readLong(obj);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        return dropAndReadNext(obj);
       }
+    }
+
+    @InliningCutoff
+    private long dropAndReadNext(final SObject obj) throws UnexpectedResultException {
+      return replace(SOMNode.unwrapIfNeeded(nextInCache)).readLong(obj);
     }
 
     @Override
@@ -189,8 +207,14 @@ public abstract class FieldAccessorNode extends Node {
           return respecializedNodeOrNext(obj).readDouble(obj);
         }
       } catch (InvalidAssumptionException e) {
-        return replace(SOMNode.unwrapIfNeeded(nextInCache)).readDouble(obj);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        return dropAndReadNext(obj);
       }
+    }
+
+    @InliningCutoff
+    private double dropAndReadNext(final SObject obj) throws UnexpectedResultException {
+      return replace(SOMNode.unwrapIfNeeded(nextInCache)).readDouble(obj);
     }
 
     @Override
@@ -221,8 +245,14 @@ public abstract class FieldAccessorNode extends Node {
           return respecializedNodeOrNext(obj).read(obj);
         }
       } catch (InvalidAssumptionException e) {
-        return replace(SOMNode.unwrapIfNeeded(nextInCache)).read(obj);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        return dropAndReadNext(obj);
       }
+    }
+
+    @InliningCutoff
+    private Object dropAndReadNext(final SObject obj) {
+      return replace(SOMNode.unwrapIfNeeded(nextInCache)).read(obj);
     }
   }
 
@@ -243,6 +273,7 @@ public abstract class FieldAccessorNode extends Node {
       return value;
     }
 
+    @InliningCutoff
     protected final void writeAndRespecialize(final SObject obj, final Object value,
         final String reason, final AbstractWriteFieldNode next) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -262,6 +293,7 @@ public abstract class FieldAccessorNode extends Node {
     }
 
     @Override
+    @InliningCutoff
     public Object write(final SObject obj, final Object value) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       writeAndRespecialize(obj, value, "initialize write field node",
@@ -316,12 +348,18 @@ public abstract class FieldAccessorNode extends Node {
           return nextInCache.increment(obj);
         }
       } catch (InvalidAssumptionException e) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
         ensureNext(obj);
-        return replace(SOMNode.unwrapIfNeeded(nextInCache)).increment(
-            obj);
+        return dropAndIncrementNext(obj);
       }
     }
 
+    @InliningCutoff
+    private long dropAndIncrementNext(final SObject obj) {
+      return replace(SOMNode.unwrapIfNeeded(nextInCache)).increment(obj);
+    }
+
+    @InliningCutoff
     private void ensureNext(final SObject obj) {
       if (nextInCache == null) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -352,9 +390,15 @@ public abstract class FieldAccessorNode extends Node {
           }
         }
       } catch (InvalidAssumptionException e) {
-        replace(SOMNode.unwrapIfNeeded(nextInCache)).write(obj, value);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        dropAndWriteNext(obj, value);
       }
       return value;
+    }
+
+    @InliningCutoff
+    private void dropAndWriteNext(final SObject obj, final long value) {
+      replace(SOMNode.unwrapIfNeeded(nextInCache)).write(obj, value);
     }
 
     @Override
@@ -394,9 +438,15 @@ public abstract class FieldAccessorNode extends Node {
           }
         }
       } catch (InvalidAssumptionException e) {
-        replace(SOMNode.unwrapIfNeeded(nextInCache)).write(obj, value);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        dropAndWriteNext(obj, value);
       }
       return value;
+    }
+
+    @InliningCutoff
+    private void dropAndWriteNext(final SObject obj, final double value) {
+      replace(SOMNode.unwrapIfNeeded(nextInCache)).write(obj, value);
     }
 
     @Override
@@ -436,9 +486,15 @@ public abstract class FieldAccessorNode extends Node {
           }
         }
       } catch (InvalidAssumptionException e) {
-        replace(SOMNode.unwrapIfNeeded(nextInCache)).write(obj, value);
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        dropAndWriteNext(obj, value);
       }
       return value;
+    }
+
+    @InliningCutoff
+    private void dropAndWriteNext(final SObject obj, final Object value) {
+      replace(SOMNode.unwrapIfNeeded(nextInCache)).write(obj, value);
     }
   }
 }

--- a/src/trufflesom/vmobjects/SAbstractObject.java
+++ b/src/trufflesom/vmobjects/SAbstractObject.java
@@ -4,6 +4,7 @@ import static trufflesom.vm.SymbolTable.symbolFor;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
@@ -45,6 +46,7 @@ public abstract class SAbstractObject implements TruffleObject {
   }
 
   @TruffleBoundary
+  @InliningCutoff
   public static final Object sendEscapedBlock(final Object receiver, final SBlock block) {
     Object[] arguments = {receiver, block};
     return send("escapedBlock:", arguments);


### PR DESCRIPTION
This PR introduces some changes into the bytecode loop to improve the interpreted performance on native image.

Most relevant changes are:
- check objects for being null before the loop
- move error and node-creation cut behind a `@InliningCutoff`

In addition, instead of reading the bytecode length from the array, encode it directly in the switch/case. This seems to have only minimal impact, if at all.

Also add a `-Ddbg=true` flag to the native-image ant script, to allow debugging of the native image compiler.