### PR TITLE
Update JDK to version 19

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
     xmlns:if="ant:if"
     xmlns:jacoco="antlib:org.jacoco.ant">
 
-    <property name="labs-jdk" value="labsjdk-ce-17" />
+    <property name="labs-jdk" value="labsjdk-ce-19" />
 
     <condition property="kernel" value="darwin-amd64" else="linux-amd64">
         <os family="mac"/>
@@ -25,8 +25,8 @@ kernel:           ${kernel}</echo>
     <property name="svm.dir"     location="${lib.dir}/truffle/substratevm" />
     <property name="vm.dir"        location="${lib.dir}/truffle/vm" />
     <property name="compiler.dir"   location="${lib.dir}/truffle/compiler" />
-    <property name="truffle.build" location="${truffle.dir}/mxbuild/jdk17/dists" />
-    <property name="sdk.build"   location="${sdk.dir}/mxbuild/jdk17/dists" />
+    <property name="truffle.build" location="${truffle.dir}/mxbuild/jdk19/dists" />
+    <property name="sdk.build"   location="${sdk.dir}/mxbuild/jdk19/dists" />
     <property name="junit.version" value="4.12" />
 
     <property name="checkstyle.version" value="8.36" />
@@ -42,7 +42,7 @@ kernel:           ${kernel}</echo>
 
     <path id="boot.cp">
         <pathelement location="${sdk.build}/jdk11/graal-sdk.jar" />
-        <pathelement location="${truffle.build}/jdk17/truffle-api.jar" />
+        <pathelement location="${truffle.build}/jdk19/truffle-api.jar" />
     </path>
     
     <path id="common.cp">

--- a/som
+++ b/som
@@ -194,11 +194,11 @@ else:
 ##
 ## Defining Necessary Parameter Bits
 ##
-TRUFFLE_API_JAR = TRUFFLE_DIR + '/truffle/mxbuild/jdk17/dists/jdk17/truffle-api.jar'
-GRAAL_SDK_JAR   = TRUFFLE_DIR + '/sdk/mxbuild/jdk17/dists/jdk11/graal-sdk.jar'
-LIBGRAAL_JAR    = TRUFFLE_DIR + '/compiler/mxbuild/jdk17/dists/jdk11/graal-truffle-compiler-libgraal.jar'
-COVERAGE_JAR    = TRUFFLE_DIR + '/tools/mxbuild/jdk17/dists/jdk11/truffle-coverage.jar'
-PROFILER_JAR    = TRUFFLE_DIR + '/tools/mxbuild/jdk17/dists/jdk11/truffle-profiler.jar'
+TRUFFLE_API_JAR = TRUFFLE_DIR + '/truffle/mxbuild/jdk19/dists/jdk19/truffle-api.jar'
+GRAAL_SDK_JAR   = TRUFFLE_DIR + '/sdk/mxbuild/jdk19/dists/jdk11/graal-sdk.jar'
+LIBGRAAL_JAR    = TRUFFLE_DIR + '/compiler/mxbuild/jdk19/dists/jdk11/graal-truffle-compiler-libgraal.jar'
+COVERAGE_JAR    = TRUFFLE_DIR + '/tools/mxbuild/jdk19/dists/jdk11/truffle-coverage.jar'
+PROFILER_JAR    = TRUFFLE_DIR + '/tools/mxbuild/jdk19/dists/jdk11/truffle-profiler.jar'
 
 classpath = (BASE_DIR + '/build/classes:'
            + BASE_DIR + '/libs/black-diamonds/build/classes:'

--- a/src/trufflesom/primitives/basics/StringPrims.java
+++ b/src/trufflesom/primitives/basics/StringPrims.java
@@ -52,6 +52,11 @@ public class StringPrims {
     }
   }
 
+  @TruffleBoundary
+  private static String substring(final String str, final int start, final int end) {
+    return str.substring(start, end);
+  }
+
   @GenerateNodeFactory
   @Primitive(className = "String", primitive = "charAt:", selector = "charAt:")
   public abstract static class CharAtPrim extends BinaryMsgExprNode {
@@ -67,7 +72,7 @@ public class StringPrims {
     public final String doString(final String receiver, final long idx) {
       int index = (int) idx;
       if (0 < index && index <= receiver.length()) {
-        return receiver.substring(index - 1, index);
+        return substring(receiver, index - 1, index);
       }
 
       if (!branchTaken) {
@@ -82,7 +87,7 @@ public class StringPrims {
       int index = (int) idx;
       String s = receiver.getString();
       if (0 < index && index <= s.length()) {
-        return s.substring(index - 1, index);
+        return substring(s, index - 1, index);
       }
 
       if (!branchTaken) {
@@ -114,7 +119,7 @@ public class StringPrims {
     public static final String doString(final String receiver, final long start,
         final long end) {
       try {
-        return receiver.substring((int) start - 1, (int) end);
+        return substring(receiver, (int) start - 1, (int) end);
       } catch (StringIndexOutOfBoundsException e) {
         return "Error - index out of bounds";
       }


### PR DESCRIPTION
The latest version of Graal/Truffle seems to want version 19.

This update seems to cause some performance regressions.
The bytecode interpreter seems to see 8% longer run times on the SomSom benchmarks.
Json (on the JIT+AST) seems to suffer a little, which might be the additional boundary.
They bytecode interpreter speed seems to be impacted.

