### PR TITLE
Minor improvements preparing for Object Inlining

### DIFF
--- a/src/bdt/inlining/InlinableNodes.java
+++ b/src/bdt/inlining/InlinableNodes.java
@@ -11,9 +11,6 @@ import com.oracle.truffle.api.source.SourceSection;
 import bdt.basic.IdProvider;
 import bdt.basic.ProgramDefinitionError;
 import bdt.inlining.Inliner.FactoryInliner;
-import trufflesom.compiler.MethodGenerationContext;
-import trufflesom.interpreter.nodes.ExpressionNode;
-import trufflesom.vmobjects.SSymbol;
 
 
 /**

--- a/src/bdt/inlining/Inliner.java
+++ b/src/bdt/inlining/Inliner.java
@@ -2,7 +2,6 @@ package bdt.inlining;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.nodes.Node;

--- a/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/compiler/Parser.java
@@ -84,7 +84,8 @@ import trufflesom.vmobjects.SSymbol;
 
 public abstract class Parser<MGenC extends MethodGenerationContext> {
 
-  protected final Lexer  lexer;
+  protected final Lexer lexer;
+
   protected final Source source;
 
   protected final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe;
@@ -129,7 +130,8 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
 
     private final int startIndex;
 
-    private final Source source;
+    private final transient Source source;
+
     private final String text;
     private final String rawBuffer;
     private final String fileName;
@@ -193,8 +195,8 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
   }
 
   public static class ParseErrorWithSymbolList extends ParseError {
-    private static final long  serialVersionUID = 561313162441723955L;
-    private final List<Symbol> expectedSymbols;
+    private static final long            serialVersionUID = 561313162441723955L;
+    private final transient List<Symbol> expectedSymbols;
 
     ParseErrorWithSymbolList(final String message, final List<Symbol> expected,
         final Parser<?> parser) {

--- a/src/trufflesom/interpreter/EscapedBlockException.java
+++ b/src/trufflesom/interpreter/EscapedBlockException.java
@@ -8,7 +8,7 @@ import trufflesom.vmobjects.SBlock;
 public class EscapedBlockException extends ControlFlowException {
   private static final long serialVersionUID = 1124756129738412293L;
 
-  private final SBlock block;
+  private final transient SBlock block;
 
   public EscapedBlockException(final SBlock block) {
     this.block = block;

--- a/src/trufflesom/interpreter/ReturnException.java
+++ b/src/trufflesom/interpreter/ReturnException.java
@@ -27,8 +27,8 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 public final class ReturnException extends ControlFlowException {
   private static final long serialVersionUID = 8003954137724716L;
 
-  private final Object             result;
-  private final FrameOnStackMarker target;
+  private final transient Object             result;
+  private final transient FrameOnStackMarker target;
 
   public ReturnException(final Object result, final FrameOnStackMarker target) {
     this.result = result;

--- a/src/trufflesom/interpreter/bc/RespecializeException.java
+++ b/src/trufflesom/interpreter/bc/RespecializeException.java
@@ -8,7 +8,7 @@ import trufflesom.interpreter.nodes.GenericMessageSendNode;
 public class RespecializeException extends ControlFlowException {
   private static final long serialVersionUID = 8098665542946983677L;
 
-  public final GenericMessageSendNode send;
+  public final transient GenericMessageSendNode send;
 
   public RespecializeException(final GenericMessageSendNode send) {
     this.send = send;

--- a/src/trufflesom/interpreter/nodes/specialized/IntDownToDoMessageNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IntDownToDoMessageNode.java
@@ -3,8 +3,8 @@ package trufflesom.interpreter.nodes.specialized;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -25,14 +25,6 @@ import trufflesom.vmobjects.SSymbol;
 @Primitive(selector = "downTo:do:", disabled = true, inParser = false)
 public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
 
-  protected static final DirectCallNode createCallNode(final CallTarget ct) {
-    return Truffle.getRuntime().createDirectCallNode(ct);
-  }
-
-  protected static final IndirectCallNode createIndirectCall() {
-    return Truffle.getRuntime().createIndirectCallNode();
-  }
-
   @Override
   public SSymbol getSelector() {
     return SymbolTable.symbolFor("downTo:do:");
@@ -41,7 +33,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
   @Specialization(guards = {"block.getMethod() == cachedMethod"})
   public final long doIntCached(final long receiver, final long limit, final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,
-      @Cached("createCallNode(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
+      @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
     try {
       if (receiver >= limit) {
         callNode.call(new Object[] {block, receiver});
@@ -59,7 +51,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
 
   @Specialization(replaces = "doIntCached")
   public final long doIntUncached(final long receiver, final long limit, final SBlock block,
-      @Cached("createIndirectCall()") final IndirectCallNode callNode) {
+      @Shared("all") @Cached final IndirectCallNode callNode) {
     CallTarget ct = block.getMethod().getCallTarget();
     try {
       if (receiver >= limit) {
@@ -79,7 +71,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
   @Specialization(guards = {"block.getMethod() == cachedMethod"})
   public final long doDoubleCached(final long receiver, final double limit, final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,
-      @Cached("createCallNode(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
+      @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
     try {
       if (receiver >= limit) {
         callNode.call(new Object[] {block, receiver});
@@ -98,7 +90,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
   @Specialization(replaces = "doDoubleCached")
   public final double doDoubleUncached(final double receiver, final double limit,
       final SBlock block,
-      @Cached("createIndirectCall()") final IndirectCallNode callNode) {
+      @Shared("all") @Cached final IndirectCallNode callNode) {
     CallTarget ct = block.getMethod().getCallTarget();
     try {
       if (receiver >= limit) {

--- a/src/trufflesom/interpreter/nodes/specialized/IntDownToDoMessageNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IntDownToDoMessageNode.java
@@ -24,13 +24,14 @@ import trufflesom.vmobjects.SSymbol;
 @GenerateNodeFactory
 @Primitive(selector = "downTo:do:", disabled = true, inParser = false)
 public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
+  protected static final int LIMIT = 3;
 
   @Override
   public SSymbol getSelector() {
     return SymbolTable.symbolFor("downTo:do:");
   }
 
-  @Specialization(guards = {"block.getMethod() == cachedMethod"})
+  @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doIntCached(final long receiver, final long limit, final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
@@ -68,7 +69,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
     return receiver;
   }
 
-  @Specialization(guards = {"block.getMethod() == cachedMethod"})
+  @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doDoubleCached(final long receiver, final double limit, final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {

--- a/src/trufflesom/interpreter/nodes/specialized/IntToDoMessageNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IntToDoMessageNode.java
@@ -24,13 +24,14 @@ import trufflesom.vmobjects.SSymbol;
 @GenerateNodeFactory
 @Primitive(selector = "to:do:", disabled = true, inParser = false)
 public abstract class IntToDoMessageNode extends TernaryMsgExprNode {
+  protected static final int LIMIT = 3;
 
   @Override
   public SSymbol getSelector() {
     return SymbolTable.symbolFor("to:do:");
   }
 
-  @Specialization(guards = {"block.getMethod() == cachedMethod"})
+  @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doIntCached(final long receiver, final long limit, final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
@@ -57,7 +58,7 @@ public abstract class IntToDoMessageNode extends TernaryMsgExprNode {
     return receiver;
   }
 
-  @Specialization(guards = {"block.getMethod() == cachedMethod"})
+  @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doDoubleCached(final long receiver, final double dLimit,
       final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,
@@ -94,7 +95,7 @@ public abstract class IntToDoMessageNode extends TernaryMsgExprNode {
     }
   }
 
-  @Specialization(guards = {"block.getMethod() == cachedMethod"})
+  @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final double doDoubleDoubleCached(final double receiver, final double limit,
       final SBlock block,
       @Cached("block.getMethod()") final SInvokable cachedMethod,

--- a/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileFalsePrimitiveNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileFalsePrimitiveNode.java
@@ -26,8 +26,8 @@ public abstract class WhileFalsePrimitiveNode extends WhilePrimitiveNode {
   public final SObject doCached(final SBlock loopCondition, final SBlock loopBody,
       @Cached("loopCondition.getMethod()") final SInvokable cachedLoopCondition,
       @Cached("loopBody.getMethod()") final SInvokable cachedLoopBody,
-      @Cached("createCallNode(cachedLoopCondition.getCallTarget())") final DirectCallNode conditionNode,
-      @Cached("createCallNode(cachedLoopBody.getCallTarget())") final DirectCallNode bodyNode) {
+      @Cached("create(cachedLoopCondition.getCallTarget())") final DirectCallNode conditionNode,
+      @Cached("create(cachedLoopBody.getCallTarget())") final DirectCallNode bodyNode) {
     return doWhileCached(loopCondition, loopBody, conditionNode, bodyNode);
   }
 

--- a/src/trufflesom/interpreter/nodes/specialized/whileloops/WhilePrimitiveNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/whileloops/WhilePrimitiveNode.java
@@ -1,9 +1,7 @@
 package trufflesom.interpreter.nodes.specialized.whileloops;
 
-import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 
@@ -21,10 +19,6 @@ public abstract class WhilePrimitiveNode extends BinaryExpressionNode {
 
   protected WhilePrimitiveNode(final boolean predicateBool) {
     this.predicateBool = predicateBool;
-  }
-
-  protected static DirectCallNode createCallNode(final CallTarget ct) {
-    return Truffle.getRuntime().createDirectCallNode(ct);
   }
 
   private static boolean obj2bool(final Object o) {

--- a/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileTruePrimitiveNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileTruePrimitiveNode.java
@@ -26,8 +26,8 @@ public abstract class WhileTruePrimitiveNode extends WhilePrimitiveNode {
   public final SObject doCached(final SBlock loopCondition, final SBlock loopBody,
       @Cached("loopCondition.getMethod()") final SInvokable cachedLoopCondition,
       @Cached("loopBody.getMethod()") final SInvokable cachedLoopBody,
-      @Cached("createCallNode(cachedLoopCondition.getCallTarget())") final DirectCallNode conditionNode,
-      @Cached("createCallNode(cachedLoopBody.getCallTarget())") final DirectCallNode bodyNode) {
+      @Cached("create(cachedLoopCondition.getCallTarget())") final DirectCallNode conditionNode,
+      @Cached("create(cachedLoopBody.getCallTarget())") final DirectCallNode bodyNode) {
     return doWhileCached(loopCondition, loopBody, conditionNode, bodyNode);
   }
 

--- a/src/trufflesom/primitives/basics/NewObjectPrim.java
+++ b/src/trufflesom/primitives/basics/NewObjectPrim.java
@@ -19,8 +19,10 @@ import trufflesom.vmobjects.SObject;
 @GenerateNodeFactory
 @Primitive(className = "Class", primitive = "new")
 public abstract class NewObjectPrim extends UnaryExpressionNode {
+  protected static final int LIMIT = 3;
+
   @Specialization(assumptions = "layout.getAssumption()",
-      guards = "layout.layoutForSameClass(receiver)")
+      guards = "layout.layoutForSameClass(receiver)", limit = "LIMIT")
   public final SAbstractObject doCached(final SClass receiver,
       @Cached("receiver.getLayoutForInstances()") final ObjectLayout layout) {
     return new SObject(receiver, layout);
@@ -46,6 +48,7 @@ public abstract class NewObjectPrim extends UnaryExpressionNode {
       final AbstractDispatchNode next) {
     SClass clazz = (SClass) rcvr;
     ObjectLayout layout = clazz.getLayoutForInstances();
-    return new CachedNewObject(clazz.getObjectLayout(), layout.getAssumption(), layout, source, next);
+    return new CachedNewObject(clazz.getObjectLayout(), layout.getAssumption(), layout, source,
+        next);
   }
 }

--- a/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
@@ -125,7 +125,7 @@ public abstract class AbstractSymbolDispatch extends Node
   @TruffleBoundary
   @Specialization(replaces = "doCachedWithoutArgArr", guards = "argsArr == null")
   public Object doUncached(final Object receiver, final SSymbol selector, final Object argsArr,
-      @Cached("create()") final IndirectCallNode call) {
+      @Cached final IndirectCallNode call) {
     SInvokable invokable = Types.getClassOf(receiver).lookupInvokable(selector);
 
     Object[] arguments = {receiver};
@@ -136,7 +136,7 @@ public abstract class AbstractSymbolDispatch extends Node
   @TruffleBoundary
   @Specialization(replaces = "doCached")
   public Object doUncached(final Object receiver, final SSymbol selector, final SArray argsArr,
-      @Cached("create()") final IndirectCallNode call,
+      @Cached final IndirectCallNode call,
       @Cached("createArgArrayNode()") final ToArgumentsArrayNode toArgArray) {
     SInvokable invokable = Types.getClassOf(receiver).lookupInvokable(selector);
 

--- a/src/trufflesom/primitives/reflection/MethodPrims.java
+++ b/src/trufflesom/primitives/reflection/MethodPrims.java
@@ -1,7 +1,5 @@
 package trufflesom.primitives.reflection;
 
-import com.oracle.truffle.api.CallTarget;
-import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
@@ -60,14 +58,6 @@ public final class MethodPrims {
     public abstract Object executeEvaluated(VirtualFrame frame, SInvokable receiver,
         Object target, SArray somArr);
 
-    public static DirectCallNode create(final CallTarget ct) {
-      return Truffle.getRuntime().createDirectCallNode(ct);
-    }
-
-    public static IndirectCallNode createIndirect() {
-      return Truffle.getRuntime().createIndirectCallNode();
-    }
-
     @Override
     public final Object doPreEvaluated(final VirtualFrame frame,
         final Object[] args) {
@@ -88,7 +78,7 @@ public final class MethodPrims {
     public static final Object doUncached(
         final SInvokable receiver, final Object target, final SArray somArr,
         final Object[] argArr,
-        @Cached("createIndirect()") final IndirectCallNode callNode) {
+        @Cached final IndirectCallNode callNode) {
       return callNode.call(receiver.getCallTarget(), argArr);
     }
   }

--- a/src/trufflesom/primitives/reflection/PerformInSuperclassPrim.java
+++ b/src/trufflesom/primitives/reflection/PerformInSuperclassPrim.java
@@ -2,7 +2,7 @@ package trufflesom.primitives.reflection;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
@@ -18,12 +18,12 @@ import trufflesom.vmobjects.SSymbol;
 @GenerateNodeFactory
 @Primitive(className = "Object", primitive = "perform:inSuperclass:")
 public abstract class PerformInSuperclassPrim extends TernaryExpressionNode {
-  @Child private IndirectCallNode call = Truffle.getRuntime().createIndirectCallNode();
 
   @Specialization
   @TruffleBoundary
-  public final Object doSAbstractObject(final SAbstractObject receiver, final SSymbol selector,
-      final SClass clazz) {
+  public static final Object doSAbstractObject(final SAbstractObject receiver,
+      final SSymbol selector, final SClass clazz,
+      @Cached final IndirectCallNode call) {
     CompilerAsserts.neverPartOfCompilation("PerformInSuperclassPrim");
     SInvokable invokable = clazz.lookupInvokable(selector);
     return call.call(invokable.getCallTarget(), new Object[] {receiver});

--- a/src/trufflesom/primitives/reflection/PerformWithArgumentsInSuperclassPrim.java
+++ b/src/trufflesom/primitives/reflection/PerformWithArgumentsInSuperclassPrim.java
@@ -2,7 +2,7 @@ package trufflesom.primitives.reflection;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
@@ -18,12 +18,12 @@ import trufflesom.vmobjects.SSymbol;
 @GenerateNodeFactory
 @Primitive(className = "Object", primitive = "perform:withArguments:inSuperclass:")
 public abstract class PerformWithArgumentsInSuperclassPrim extends QuaternaryExpressionNode {
-  @Child private IndirectCallNode call = Truffle.getRuntime().createIndirectCallNode();
 
   @TruffleBoundary
   @Specialization
-  public final Object doSAbstractObject(final Object receiver, final SSymbol selector,
-      final Object[] argArr, final SClass clazz) {
+  public static final Object doSAbstractObject(final Object receiver, final SSymbol selector,
+      final Object[] argArr, final SClass clazz,
+      @Cached final IndirectCallNode call) {
     CompilerAsserts.neverPartOfCompilation(
         "PerformWithArgumentsInSuperclassPrim.doSAbstractObject()");
     SInvokable invokable = clazz.lookupInvokable(selector);

--- a/src/trufflesom/primitives/reflection/PerformWithArgumentsPrim.java
+++ b/src/trufflesom/primitives/reflection/PerformWithArgumentsPrim.java
@@ -17,6 +17,7 @@ public abstract class PerformWithArgumentsPrim extends TernaryExpressionNode {
 
   @Child protected AbstractSymbolDispatch dispatch;
 
+  @SuppressWarnings("unchecked")
   @Override
   public PerformWithArgumentsPrim initialize(final long coord) {
     super.initialize(coord);


### PR DESCRIPTION
- using `@Cached` and `@Shared` instead of fields
- avoid unnecessary helper methods
- add explicit limits
- handle non-serializable field warnings