### PR TITLE
Update to Truffle with Object Inlining

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,18 +33,19 @@ build:native-interp-ast:
     - ${ANT} compile native-ast -Dno.jit=true
     - ./som-native-interp-ast -cp Smalltalk TestSuite/TestHarness.som
 
-    - ${ANT} compile-native-ast-ee -Dno.jit=true
-    - ./som-native-interp-ast-ee -cp Smalltalk TestSuite/TestHarness.som
+    # - ${ANT} compile-native-ast-ee -Dno.jit=true
+    # - ./som-native-interp-ast-ee -cp Smalltalk TestSuite/TestHarness.som
     
     # Package and Upload
     - lz4 som-native-interp-ast som-native-interp-ast.lz4
-    - lz4 som-native-interp-ast-ee som-native-interp-ast-ee.lz4
+    # - lz4 som-native-interp-ast-ee som-native-interp-ast-ee.lz4
     - |
       sftp tmp-artifacts << EOF
         -mkdir incoming/${CI_PIPELINE_ID}/
         put som-native-interp-ast.lz4 incoming/${CI_PIPELINE_ID}/
-        put som-native-interp-ast-ee.lz4 incoming/${CI_PIPELINE_ID}/
       EOF
+
+#         put som-native-interp-ast-ee.lz4 incoming/${CI_PIPELINE_ID}/
 
 build:native-interp-bc:
   stage: build-and-test
@@ -54,17 +55,17 @@ build:native-interp-bc:
     - ${ANT} compile native-bc -Dno.jit=true
     - ./som-native-interp-bc -cp Smalltalk TestSuite/TestHarness.som
 
-    - ${ANT} compile-native-bc-ee -Dno.jit=true
-    - ./som-native-interp-bc-ee -cp Smalltalk TestSuite/TestHarness.som
+    # - ${ANT} compile-native-bc-ee -Dno.jit=true
+    # - ./som-native-interp-bc-ee -cp Smalltalk TestSuite/TestHarness.som
     
     - lz4 som-native-interp-bc som-native-interp-bc.lz4
-    - lz4 som-native-interp-bc-ee som-native-interp-bc-ee.lz4
+    # - lz4 som-native-interp-bc-ee som-native-interp-bc-ee.lz4
     - |
       sftp tmp-artifacts << EOF
         -mkdir incoming/${CI_PIPELINE_ID}/
         put som-native-interp-bc.lz4 incoming/${CI_PIPELINE_ID}/
-        put som-native-interp-bc-ee.lz4 incoming/${CI_PIPELINE_ID}/
       EOF
+#         put som-native-interp-bc-ee.lz4 incoming/${CI_PIPELINE_ID}/
 
 
 benchmark-y1:
@@ -75,13 +76,13 @@ benchmark-y1:
     - ${ANT} compile
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
-    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast-ee.lz4
-    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc-ee.lz4
+    # - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast-ee.lz4
+    # - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc-ee.lz4
     
     - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
     - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
-    - lz4 -d som-native-interp-ast-ee.lz4 som-native-interp-ast-ee
-    - lz4 -d som-native-interp-bc-ee.lz4  som-native-interp-bc-ee
+    # - lz4 -d som-native-interp-ast-ee.lz4 som-native-interp-ast-ee
+    # - lz4 -d som-native-interp-bc-ee.lz4  som-native-interp-bc-ee
 
     # Profile
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria
@@ -98,13 +99,13 @@ benchmark-y2:
     - ${ANT} compile
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
-    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast-ee.lz4
-    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc-ee.lz4
+    # - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast-ee.lz4
+    # - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc-ee.lz4
     
     - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
     - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
-    - lz4 -d som-native-interp-ast-ee.lz4 som-native-interp-ast-ee
-    - lz4 -d som-native-interp-bc-ee.lz4  som-native-interp-bc-ee
+    # - lz4 -d som-native-interp-ast-ee.lz4 som-native-interp-ast-ee
+    # - lz4 -d som-native-interp-bc-ee.lz4  som-native-interp-bc-ee
 
     # Profile
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria2
@@ -121,13 +122,13 @@ benchmark-y3:
     - ${ANT} compile
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc.lz4
-    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast-ee.lz4
-    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc-ee.lz4
+    # - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-ast-ee.lz4
+    # - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-native-interp-bc-ee.lz4
     
     - lz4 -d som-native-interp-ast.lz4 som-native-interp-ast
     - lz4 -d som-native-interp-bc.lz4  som-native-interp-bc
-    - lz4 -d som-native-interp-ast-ee.lz4 som-native-interp-ast-ee
-    - lz4 -d som-native-interp-bc-ee.lz4  som-native-interp-bc-ee
+    # - lz4 -d som-native-interp-ast-ee.lz4 som-native-interp-ast-ee
+    # - lz4 -d som-native-interp-bc-ee.lz4  som-native-interp-bc-ee
 
     # Profile
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf profiling m:yuria3

--- a/rebench.conf
+++ b/rebench.conf
@@ -243,22 +243,22 @@ experiments:
                 suites:
                   - micro-somsom
 
-            - TruffleSOM-native-interp-ast-ee:
-                suites:
-                  - micro-startup
-                  - macro-startup
-                  - som-parse
-            - TruffleSOM-native-interp-bc-ee:
-                suites:
-                  - micro-startup
-                  - macro-startup
-                  - som-parse
-            - SomSom-native-interp-ast-ee:
-                suites:
-                  - micro-somsom
-            - SomSom-native-interp-bc-ee:
-                suites:
-                  - micro-somsom
+            # - TruffleSOM-native-interp-ast-ee:
+            #     suites:
+            #       - micro-startup
+            #       - macro-startup
+            #       - som-parse
+            # - TruffleSOM-native-interp-bc-ee:
+            #     suites:
+            #       - micro-startup
+            #       - macro-startup
+            #       - som-parse
+            # - SomSom-native-interp-ast-ee:
+            #     suites:
+            #       - micro-somsom
+            # - SomSom-native-interp-bc-ee:
+            #     suites:
+            #       - micro-somsom
     
     profiling:
       description: Profile Native Image Interpreters

--- a/src/trufflesom/interpreter/nodes/specialized/IfInlinedLiteralNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IfInlinedLiteralNode.java
@@ -5,7 +5,7 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
 import bdt.inlining.Inline;
 import bdt.inlining.Inline.False;
@@ -18,7 +18,7 @@ import trufflesom.vm.constants.Nil;
 @Inline(selector = "ifTrue:", inlineableArgIdx = 1, additionalArgs = True.class)
 @Inline(selector = "ifFalse:", inlineableArgIdx = 1, additionalArgs = False.class)
 public final class IfInlinedLiteralNode extends NoPreEvalExprNode {
-  private final ConditionProfile condProf = ConditionProfile.createCountingProfile();
+  private final CountingConditionProfile condProf = CountingConditionProfile.create();
 
   @Child private ExpressionNode conditionNode;
   @Child private ExpressionNode bodyNode;

--- a/src/trufflesom/interpreter/nodes/specialized/IfNilInlinedLiteralNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IfNilInlinedLiteralNode.java
@@ -1,7 +1,7 @@
 package trufflesom.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
 import bdt.inlining.Inline;
 import trufflesom.interpreter.nodes.ExpressionNode;
@@ -11,7 +11,7 @@ import trufflesom.vm.constants.Nil;
 
 @Inline(selector = "ifNil:", inlineableArgIdx = 1)
 public final class IfNilInlinedLiteralNode extends NoPreEvalExprNode {
-  private final ConditionProfile condProf = ConditionProfile.createCountingProfile();
+  private final CountingConditionProfile condProf = CountingConditionProfile.create();
 
   @Child private ExpressionNode rcvr;
   @Child private ExpressionNode arg1;

--- a/src/trufflesom/interpreter/nodes/specialized/IfNotNilInlinedLiteralNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IfNotNilInlinedLiteralNode.java
@@ -1,7 +1,7 @@
 package trufflesom.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
 import bdt.inlining.Inline;
 import trufflesom.interpreter.nodes.ExpressionNode;
@@ -11,7 +11,7 @@ import trufflesom.vm.constants.Nil;
 
 @Inline(selector = "ifNotNil:", inlineableArgIdx = 1)
 public final class IfNotNilInlinedLiteralNode extends NoPreEvalExprNode {
-  private final ConditionProfile condProf = ConditionProfile.createCountingProfile();
+  private final CountingConditionProfile condProf = CountingConditionProfile.create();
 
   @Child private ExpressionNode rcvr;
   @Child private ExpressionNode arg1;

--- a/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseInlinedLiteralsNode.java
+++ b/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseInlinedLiteralsNode.java
@@ -4,7 +4,7 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
 import bdt.inlining.Inline;
 import trufflesom.interpreter.nodes.ExpressionNode;
@@ -21,7 +21,7 @@ import trufflesom.interpreter.nodes.NoPreEvalExprNode;
  * @author Stefan Marr
  */
 public abstract class IfTrueIfFalseInlinedLiteralsNode extends NoPreEvalExprNode {
-  private final ConditionProfile condProf = ConditionProfile.createCountingProfile();
+  private final CountingConditionProfile condProf = CountingConditionProfile.create();
 
   @Child private ExpressionNode conditionNode;
   @Child private ExpressionNode trueNode;


### PR DESCRIPTION
This change adopts the Truffle version with object inlining.
This doesn't really use object inlining, except for a few cases of inlined profiles.

For the moment, this needs to disable enterprise edition, because it doesn't have the object inlining yet. 