### PR TITLE
The #= on Symbol and String should be symmetric

### DIFF
--- a/src/trufflesom/primitives/arithmetic/AdditionPrim.java
+++ b/src/trufflesom/primitives/arithmetic/AdditionPrim.java
@@ -100,13 +100,13 @@ public abstract class AdditionPrim extends ArithmeticPrim {
 
   @Specialization
   @TruffleBoundary
-  public static final String doSSymbol(final SSymbol left, final SSymbol right) {
-    return left.getString() + right.getString();
+  public static final SSymbol doSSymbol(final SSymbol left, final SSymbol right) {
+    return SymbolTable.symbolFor(left.getString() + right.getString());
   }
 
   @Specialization
   @TruffleBoundary
-  public static final String doSSymbol(final SSymbol left, final String right) {
-    return left.getString() + right;
+  public static final SSymbol doSSymbol(final SSymbol left, final String right) {
+    return SymbolTable.symbolFor(left.getString() + right);
   }
 }

--- a/src/trufflesom/primitives/basics/EqualsPrim.java
+++ b/src/trufflesom/primitives/basics/EqualsPrim.java
@@ -120,7 +120,7 @@ public abstract class EqualsPrim extends BinaryMsgExprNode {
 
   @Specialization
   public static final boolean doSSymbol(final SSymbol receiver, final String argument) {
-    return false;
+    return receiver.getString().equals(argument);
   }
 
   @Specialization


### PR DESCRIPTION
- it’s only defined in String
- there’s no hint that it should behave differently in Symbol which is a subclass
- so, we really should just consider the string content when comparing #foobar = ‘foobar’

- `#a + #b == #ab` should hold