### PR TITLE
Extract the exceptional cases out of the send bytecode handlers

### DIFF
--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -78,6 +78,7 @@ import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeLength;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeName;
+import trufflesom.vm.Universe;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -304,10 +305,48 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
   }
 
   @InliningCutoff
-  private void missingBytecode(final byte bytecode) {
+  private Object handleEscapedBlock(final VirtualFrame frame, final EscapedBlockException e) {
     CompilerDirectives.transferToInterpreter();
+    VirtualFrame outer = determineOuterContext(frame);
+    SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
+    return SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+  }
+
+  @InliningCutoff
+  private Object quickenAndEvaluate(final VirtualFrame frame, final int bytecodeIndex,
+      final RespecializeException r, final Object rcvr) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    quickenBytecode(bytecodeIndex, Q_SEND, r.send);
+    return r.send.doPreEvaluated(frame, new Object[] {rcvr});
+  }
+
+  @InliningCutoff
+  private Object quickenAndEvaluate(final VirtualFrame frame, final int bytecodeIndex,
+      final RespecializeException r, final Object rcvr, final Object arg) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    quickenBytecode(bytecodeIndex, Q_SEND, r.send);
+    return r.send.doPreEvaluated(frame, new Object[] {rcvr, arg});
+  }
+
+  @InliningCutoff
+  private Object quickenAndEvaluate(final VirtualFrame frame, final int bytecodeIndex,
+      final RespecializeException r, final Object rcvr, final Object arg1, final Object arg2) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    quickenBytecode(bytecodeIndex, Q_SEND, r.send);
+    return r.send.doPreEvaluated(frame, new Object[] {rcvr, arg1, arg2});
+  }
+
+  @InliningCutoff
+  private void missingBytecode(final byte bytecode) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
     throw new NotYetImplementedException("The bytecode " + bytecode + " ("
         + Bytecodes.getBytecodeName(bytecode) + ") is not yet implemented.");
+  }
+
+  @InliningCutoff
+  private void printBytecode(final byte bytecode) {
+    CompilerDirectives.transferToInterpreter();
+    Universe.println(Bytecodes.getBytecodeName(bytecode));
   }
 
   @Override
@@ -673,13 +712,8 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
-            VirtualFrame outer = determineOuterContext(frame);
-            SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
-            Object result =
-                SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
-
             stackPointer += 1;
-            stack[stackPointer] = result;
+            stack[stackPointer] = handleEscapedBlock(frame, e);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
@@ -711,14 +745,8 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
-            VirtualFrame outer = determineOuterContext(frame);
-            SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
-
-            Object result =
-                SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
-
             stackPointer += 1;
-            stack[stackPointer] = result;
+            stack[stackPointer] = handleEscapedBlock(frame, e);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
@@ -1015,10 +1043,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
-            VirtualFrame outer = determineOuterContext(frame);
-            SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
-            stack[stackPointer] =
-                SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            stack[stackPointer] = handleEscapedBlock(frame, e);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
 
@@ -1037,15 +1062,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
-            VirtualFrame outer = determineOuterContext(frame);
-            SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
-            stack[stackPointer] =
-                SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            stack[stackPointer] = handleEscapedBlock(frame, e);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RespecializeException r) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-            quickenBytecode(bytecodeIndex, Q_SEND, r.send);
-            stack[stackPointer] = r.send.doPreEvaluated(frame, new Object[] {rcvr});
+            stack[stackPointer] = quickenAndEvaluate(frame, bytecodeIndex, r, rcvr);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
@@ -1066,15 +1087,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
-            VirtualFrame outer = determineOuterContext(frame);
-            SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
-            stack[stackPointer] =
-                SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            stack[stackPointer] = handleEscapedBlock(frame, e);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RespecializeException r) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-            quickenBytecode(bytecodeIndex, Q_SEND, r.send);
-            stack[stackPointer] = r.send.doPreEvaluated(frame, new Object[] {rcvr, arg});
+            stack[stackPointer] = quickenAndEvaluate(frame, bytecodeIndex, r, rcvr, arg);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;
@@ -1096,16 +1113,12 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
             stackPointer = -1;
           } catch (EscapedBlockException e) {
             CompilerDirectives.transferToInterpreter();
-            VirtualFrame outer = determineOuterContext(frame);
-            SObject sendOfBlockValueMsg = (SObject) outer.getArguments()[0];
-            stack[stackPointer] =
-                SAbstractObject.sendEscapedBlock(sendOfBlockValueMsg, e.getBlock());
+            stack[stackPointer] = handleEscapedBlock(frame, e);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           } catch (RespecializeException r) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-            quickenBytecode(bytecodeIndex, Q_SEND, r.send);
             stack[stackPointer] =
-                r.send.doPreEvaluated(frame, new Object[] {rcvr, arg1, arg2});
+                quickenAndEvaluate(frame, bytecodeIndex, r, rcvr, arg1, arg2);
             bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
           }
           break;


### PR DESCRIPTION
This gives up to 19% in tight loops on the bytecode interpreter.

https://rebench.dev/TruffleSOM/compare/ab5d088e282dbd5f85b9f407ca0163dfebd33a2a..2b64d5a99b96f35f401796ab8004798c75f4c227#micro-somsom-SomSom-native-interp-bc

/cc @OctaveLarose This is something that should be part of your baseline please :) 