### PR TITLE
Fix splitting of blocks: Replace block node with independent method

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "core-lib"]
 	path = core-lib
 	url = https://github.com/SOM-st/SOM.git
+	ignore = untracked
 [submodule "libs/truffle"]
 	path = libs/truffle
 	url = https://github.com/smarr/Truffle.git
+	ignore = untracked
 [submodule "libs/mx"]
 	path = libs/mx
 	url = https://github.com/graalvm/mx.git
+	ignore = untracked

--- a/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/compiler/MethodGenerationContext.java
@@ -79,6 +79,7 @@ public class MethodGenerationContext
   protected boolean throwsNonLocalReturn;
 
   protected boolean accessesVariablesOfOuterScope;
+  protected boolean accessesLocalsOfOuterScope;
 
   protected final LinkedHashMap<SSymbol, Argument> arguments;
   protected final LinkedHashMap<SSymbol, Local>    locals;
@@ -385,6 +386,9 @@ public class MethodGenerationContext
       Variable outerVar = outerGenc.getVariable(varName);
       if (outerVar != null) {
         accessesVariablesOfOuterScope = true;
+        if (outerVar instanceof Local) {
+          accessesLocalsOfOuterScope = true;
+        }
       }
       return outerVar;
     }
@@ -409,6 +413,7 @@ public class MethodGenerationContext
       Local outerLocal = outerGenc.getLocal(varName);
       if (outerLocal != null) {
         accessesVariablesOfOuterScope = true;
+        accessesLocalsOfOuterScope = true;
       }
       return outerLocal;
     }

--- a/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/compiler/ParserAst.java
@@ -425,9 +425,11 @@ public class ParserAst extends Parser<MethodGenerationContext> {
         mgenc.addEmbeddedBlockMethod(blockMethod);
 
         if (bgenc.requiresContext()) {
-          return new BlockNodeWithContext(blockMethod).initialize(getCoordWithLength(coord));
+          return new BlockNodeWithContext(blockMethod,
+              bgenc.accessesLocalsOfOuterScope).initialize(getCoordWithLength(coord));
         } else {
-          return new BlockNode(blockMethod).initialize(getCoordWithLength(coord));
+          return new BlockNode(blockMethod, bgenc.accessesLocalsOfOuterScope).initialize(
+              getCoordWithLength(coord));
         }
       }
       default: {

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -97,11 +97,13 @@ public final class Method extends Invokable {
   public Method cloneAndAdaptAfterScopeChange(final BytecodeMethodGenContext mgenc,
       final LexicalScope adaptedScope, final int appliesTo,
       final boolean cloneAdaptedAsUninitialized,
-      final boolean requiresChangesToContextLevels) {
+      final boolean requiresChangesToContextLevels,
+      final boolean isSplittingOperation) {
     Scope<?, ?> scope = mgenc == null ? adaptedScope : mgenc;
     ExpressionNode adaptedBody =
         ScopeAdaptationVisitor.adapt(uninitializedBody, scope, currentLexicalScope,
-            appliesTo, requiresChangesToContextLevels, getLanguage(SomLanguage.class));
+            appliesTo, requiresChangesToContextLevels, isSplittingOperation,
+            getLanguage(SomLanguage.class));
 
     ExpressionNode uninit;
     if (cloneAdaptedAsUninitialized) {
@@ -127,7 +129,7 @@ public final class Method extends Invokable {
   public Node deepCopy() {
     LexicalScope splitScope = currentLexicalScope.split();
     assert currentLexicalScope != splitScope;
-    return cloneAndAdaptAfterScopeChange(null, splitScope, 0, false, false);
+    return cloneAndAdaptAfterScopeChange(null, splitScope, 0, false, false, true);
   }
 
   @Override
@@ -135,7 +137,7 @@ public final class Method extends Invokable {
       final SMethod toBeInlined) {
     mgenc.mergeIntoScope(currentLexicalScope, toBeInlined);
     return ScopeAdaptationVisitor.adapt(uninitializedBody, mgenc, currentLexicalScope, 0, true,
-        getLanguage(SomLanguage.class));
+        false, getLanguage(SomLanguage.class));
   }
 
   @Override

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -78,7 +78,6 @@ import static trufflesom.interpreter.bc.Bytecodes.SEND;
 import static trufflesom.interpreter.bc.Bytecodes.SUPER_SEND;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeLength;
 import static trufflesom.interpreter.bc.Bytecodes.getBytecodeName;
-import trufflesom.vm.Universe;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -134,6 +133,7 @@ import trufflesom.interpreter.objectstorage.FieldAccessorNode.IncrementLongField
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.Classes;
 import trufflesom.vm.NotYetImplementedException;
+import trufflesom.vm.Universe;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SAbstractObject;
 import trufflesom.vmobjects.SBlock;
@@ -1426,7 +1426,7 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Method blockIvk = (Method) blockMethod.getInvokable();
           Method adapted = blockIvk.cloneAndAdaptAfterScopeChange(null,
               mgenc.getCurrentLexicalScope().getScope(blockIvk),
-              targetContextLevel + 1, true, true);
+              targetContextLevel + 1, true, true, false);
           SMethod newMethod = new SMethod(blockMethod.getSignature(), adapted,
               blockMethod.getEmbeddedBlocks());
           newMethod.setHolder(blockMethod.getHolder());
@@ -1674,7 +1674,8 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           Method blockIvk = (Method) blockMethod.getInvokable();
           Method adapted =
               blockIvk.cloneAndAdaptAfterScopeChange(null, inliner.getScope(blockIvk),
-                  inliner.contextLevel + 1, true, requiresChangesToContextLevels);
+                  inliner.contextLevel + 1, true, requiresChangesToContextLevels,
+                  inliner.isSplittingOperation);
           blockMethod.updateAfterScopeChange(adapted);
           break;
         }

--- a/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/vm/Universe.java
@@ -347,6 +347,8 @@ public final class Universe {
   @TruffleBoundary
   public static void initializeObjectSystem() {
     CompilerAsserts.neverPartOfCompilation();
+    assert classPath != null : "The classpath hasn't been initialized. Was setupClassPath() called?";
+
     if (alreadyInitialized) {
       return;
     } else {

--- a/src/trufflesom/vmobjects/SInvokable.java
+++ b/src/trufflesom/vmobjects/SInvokable.java
@@ -69,6 +69,8 @@ public abstract class SInvokable extends SAbstractObject {
     }
 
     public SMethod[] getEmbeddedBlocks() {
+      // this being `null` might mean there are no blocks, or that the method was split.
+      // See comment in `BlockNode.replaceAfterScopeChange(..)`.
       return embeddedBlocks;
     }
 

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -4,19 +4,11 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static trufflesom.vm.SymbolTable.symSelf;
-import static trufflesom.vm.SymbolTable.symbolFor;
 
 import org.junit.Test;
 
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.Source;
 
-import bdt.basic.ProgramDefinitionError;
-import trufflesom.compiler.ClassGenerationContext;
-import trufflesom.compiler.MethodGenerationContext;
-import trufflesom.compiler.ParserAst;
-import trufflesom.interpreter.SomLanguage;
 import trufflesom.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
 import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalArgumentReadNode;
 import trufflesom.interpreter.nodes.ExpressionNode;
@@ -48,27 +40,7 @@ import trufflesom.primitives.arithmetic.SubtractionPrim;
 import trufflesom.primitives.arrays.DoPrim;
 
 
-public class AstInliningTests extends TruffleTestSetup {
-
-  protected MethodGenerationContext mgenc;
-
-  protected ExpressionNode parseMethod(final String source) {
-    Source s = SomLanguage.getSyntheticSource(source, "test");
-
-    cgenc = new ClassGenerationContext(s, null);
-    cgenc.setName(symbolFor("Test"));
-    addAllFields();
-
-    mgenc = new MethodGenerationContext(cgenc, probe);
-    mgenc.addArgumentIfAbsent(symSelf, 0);
-
-    ParserAst parser = new ParserAst(source, s, null);
-    try {
-      return parser.method(mgenc);
-    } catch (ProgramDefinitionError e) {
-      throw new RuntimeException(e);
-    }
-  }
+public class AstInliningTests extends AstTestSetup {
 
   private void accessArgFromInlinedBlock(final String argName, final int argIdx) {
     SequenceNode seq =

--- a/tests/trufflesom/tests/AstTestSetup.java
+++ b/tests/trufflesom/tests/AstTestSetup.java
@@ -1,0 +1,44 @@
+package trufflesom.tests;
+
+import static trufflesom.vm.SymbolTable.symSelf;
+import static trufflesom.vm.SymbolTable.symbolFor;
+
+import org.junit.Ignore;
+
+import com.oracle.truffle.api.source.Source;
+
+import bdt.basic.ProgramDefinitionError;
+import trufflesom.compiler.ClassGenerationContext;
+import trufflesom.compiler.MethodGenerationContext;
+import trufflesom.compiler.ParserAst;
+import trufflesom.interpreter.SomLanguage;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.vmobjects.SInvokable.SMethod;
+
+
+@Ignore("provides just setup")
+public abstract class AstTestSetup extends TruffleTestSetup {
+  protected MethodGenerationContext mgenc;
+
+  protected ExpressionNode parseMethod(final String source) {
+    Source s = SomLanguage.getSyntheticSource(source, "test");
+
+    cgenc = new ClassGenerationContext(s, null);
+    cgenc.setName(symbolFor("Test"));
+    addAllFields();
+
+    mgenc = new MethodGenerationContext(cgenc, probe);
+    mgenc.addArgumentIfAbsent(symSelf, 0);
+
+    ParserAst parser = new ParserAst(source, s, null);
+    try {
+      return parser.method(mgenc);
+    } catch (ProgramDefinitionError e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected SMethod assembleLastMethod(final ExpressionNode body) {
+    return (SMethod) mgenc.assemble(body, 0);
+  }
+}

--- a/tests/trufflesom/tests/SplittingTests.java
+++ b/tests/trufflesom/tests/SplittingTests.java
@@ -1,0 +1,53 @@
+package trufflesom.tests;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import trufflesom.interpreter.Invokable;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.vm.Universe;
+import trufflesom.vm.constants.Nil;
+import trufflesom.vmobjects.SInvokable.SMethod;
+
+
+public class SplittingTests extends AstTestSetup {
+
+  @BeforeClass
+  public static void init() {
+    Universe.setupClassPath("Smalltalk");
+
+    enterContext();
+    Universe.initializeObjectSystem();
+  }
+
+  @AfterClass
+  public static void close() {
+    closeContext();
+  }
+
+  @Test
+  public void testCorrectFrameDescriptorUpdatesInBlocks() {
+
+    ExpressionNode body = parseMethod("""
+        methodToBeSplit = (
+          | local |
+          [ local := #sym ] value.
+          ^ local
+        )
+        """);
+
+    SMethod method = assembleLastMethod(body);
+    Invokable mOrg = method.getInvokable();
+    Object sym = mOrg.getCallTarget().call(Nil.nilObject);
+
+    Invokable splitM = (Invokable) mOrg.deepCopy();
+    Object sym2 = splitM.getCallTarget().call(Nil.nilObject);
+
+    assertNotSame("Expect the split method to return #sym, and not nil", Nil.nilObject, sym2);
+    assertSame(sym, sym2);
+  }
+}

--- a/tests/trufflesom/tests/TruffleTestSetup.java
+++ b/tests/trufflesom/tests/TruffleTestSetup.java
@@ -31,6 +31,8 @@ import trufflesom.vmobjects.SSymbol;
 
 @Ignore("provides just setup")
 public class TruffleTestSetup {
+  private static final Context truffleContext;
+
   protected ClassGenerationContext cgenc;
 
   protected final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe;
@@ -44,7 +46,7 @@ public class TruffleTestSetup {
     argNames = new ArrayList<>();
   }
 
-  private static void initTruffle() {
+  private static Context initTruffle() {
     StorageAnalyzer.initAccessors();
 
     if (VmSettings.UseAstInterp) {
@@ -61,6 +63,15 @@ public class TruffleTestSetup {
 
     Universe.selfSource = SomLanguage.getSyntheticSource("self", "self");
     Universe.selfCoord = SourceCoordinate.createEmpty();
+    return context;
+  }
+
+  protected static void enterContext() {
+    truffleContext.enter();
+  }
+
+  protected static void closeContext() {
+    truffleContext.close();
   }
 
   protected void addField(final String name) {
@@ -118,6 +129,6 @@ public class TruffleTestSetup {
   }
 
   static {
-    initTruffle();
+    truffleContext = initTruffle();
   }
 }


### PR DESCRIPTION
At some point, we "optimized out" the proper replacing of block nodes when going over the split copy of a method.
Because we currently do so much AST-level inlining, this was hidden.

However, when splitting, we can't just update the `SMethod` object in place.
Instead, we need to replace the `BlockNode` with an new `SMethod` object and its independent copy.
Otherwise, we run in the situation that the block may use the frame descriptor of a wrong copy of the outer lexical scope.

This can be observed when using the frame descriptor to communicate whether a field was ever written to, which we use to track basic initialization state of fields.
If the two frame descriptors of inner and outer lexical scope don't match, then the information that a frame slot was written to gets lost and we read a `nil`, the default uninitialized value.

@sophie-kaleba you're work a lot on splitting, so, just a pointer.

@OctaveLarose once the benchmarks ran, this fix will be integrated into main branch of TruffleSOM

Reviews welcome.
