### PR TITLE
Blocks with a field read nested in a block are not yet supported

### DIFF
--- a/som
+++ b/som
@@ -201,7 +201,6 @@ COVERAGE_JAR    = TRUFFLE_DIR + '/tools/mxbuild/dists/truffle-coverage.jar'
 PROFILER_JAR    = TRUFFLE_DIR + '/tools/mxbuild/dists/truffle-profiler.jar'
 
 classpath = (BASE_DIR + '/build/classes:'
-           + BASE_DIR + '/libs/black-diamonds/build/classes:'
            + GRAAL_SDK_JAR + ':'
            + TRUFFLE_API_JAR)
 

--- a/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -966,4 +966,8 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
   public ArrayList<Byte> getBytecodes() {
     return bytecode;
   }
+
+  public Object[] getLiteralsArray() {
+    return literals.toArray();
+  }
 }

--- a/src/trufflesom/interpreter/Method.java
+++ b/src/trufflesom/interpreter/Method.java
@@ -150,6 +150,9 @@ public final class Method extends Invokable {
 
   @Override
   public PreevaluatedExpression copyTrivialNode() {
+    if (currentLexicalScope.isBlock()) {
+      return body.copyTrivialNodeInBlock();
+    }
     return body.copyTrivialNode();
   }
 

--- a/src/trufflesom/interpreter/nodes/ExpressionNode.java
+++ b/src/trufflesom/interpreter/nodes/ExpressionNode.java
@@ -71,6 +71,20 @@ public abstract class ExpressionNode extends SOMNode
     return null;
   }
 
+  public PreevaluatedExpression copyTrivialNodeInSequence() {
+    // Some of the subclasses may be trivial and implement this
+    return null;
+  }
+
+  public PreevaluatedExpression copyTrivialNodeInBlock() {
+    return copyTrivialNode();
+  }
+
+  public PreevaluatedExpression copyTrivialNodeInSequenceInBlock() {
+    // Some of the subclasses may be trivial and implement this
+    return null;
+  }
+
   public AbstractDispatchNode asDispatchNode(final Object rcvr, final Source source,
       final AbstractDispatchNode next) {
     // Some of the subclasses may be trivial and implement this

--- a/src/trufflesom/interpreter/nodes/ExpressionNode.java
+++ b/src/trufflesom/interpreter/nodes/ExpressionNode.java
@@ -62,6 +62,10 @@ public abstract class ExpressionNode extends SOMNode
     return isTrivial();
   }
 
+  public boolean isTrivialInSequenceInBlock() {
+    return false;
+  }
+
   public PreevaluatedExpression copyTrivialNode() {
     // Some of the subclasses may be trivial and implement this
     return null;

--- a/src/trufflesom/interpreter/nodes/FieldNode.java
+++ b/src/trufflesom/interpreter/nodes/FieldNode.java
@@ -124,6 +124,19 @@ public abstract class FieldNode extends ExpressionNode {
     }
 
     @Override
+    public PreevaluatedExpression copyTrivialNodeInBlock() {
+      if (self instanceof NonLocalArgumentReadNode arg) {
+        // it works if we are just 1 level in, but at 2 levels, we get a block
+        // object, and this is currently not handled by our trivial method logic
+        if (arg.contextLevel < 2) {
+          return copyTrivialNode();
+        }
+        return null;
+      }
+      return copyTrivialNode();
+    }
+
+    @Override
     public AbstractDispatchNode asDispatchNode(final Object rcvr, final Source source,
         final AbstractDispatchNode next) {
       ObjectLayout layout = ((SObject) rcvr).getObjectLayout();
@@ -178,6 +191,11 @@ public abstract class FieldNode extends ExpressionNode {
             FieldWriteNodeGen.create(write.getFieldIndex(), null, null));
       }
       return null;
+    }
+
+    @Override
+    public PreevaluatedExpression copyTrivialNodeInSequence() {
+      return copyTrivialNode();
     }
 
     @Override

--- a/src/trufflesom/interpreter/nodes/FieldNode.java
+++ b/src/trufflesom/interpreter/nodes/FieldNode.java
@@ -31,6 +31,7 @@ import com.oracle.truffle.api.source.Source;
 import bdt.primitives.nodes.PreevaluatedExpression;
 import trufflesom.compiler.Variable.Argument;
 import trufflesom.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
+import trufflesom.interpreter.nodes.ArgumentReadNode.NonLocalArgumentReadNode;
 import trufflesom.interpreter.nodes.FieldNodeFactory.FieldWriteNodeGen;
 import trufflesom.interpreter.nodes.dispatch.AbstractDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.CachedFieldRead;
@@ -98,6 +99,16 @@ public abstract class FieldNode extends ExpressionNode {
 
     @Override
     public boolean isTrivial() {
+      return true;
+    }
+
+    @Override
+    public boolean isTrivialInBlock() {
+      if (self instanceof NonLocalArgumentReadNode arg) {
+        // it works if we are just 1 level in, but at 2 levels, we get a block
+        // object, and this is currently not handled by our trivial method logic
+        return arg.contextLevel < 2;
+      }
       return true;
     }
 

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -224,6 +224,20 @@ public abstract class GlobalNode extends ExpressionNode
       }
       return assoc.getValue();
     }
+
+    @Override
+    public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+      Object scope = inliner.getCurrentScope();
+
+      if (scope instanceof BytecodeMethodGenContext) {
+        BytecodeMethodGenContext mgenc = (BytecodeMethodGenContext) scope;
+        try {
+          BytecodeGenerator.emitPUSHGLOBAL(mgenc, globalName, null);
+        } catch (ParseError e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
   }
 
   public static final class TrueGlobalNode extends GlobalNode {

--- a/src/trufflesom/interpreter/nodes/GlobalNode.java
+++ b/src/trufflesom/interpreter/nodes/GlobalNode.java
@@ -180,6 +180,11 @@ public abstract class GlobalNode extends ExpressionNode
     }
 
     @Override
+    public PreevaluatedExpression copyTrivialNodeInBlock() {
+      return null;
+    }
+
+    @Override
     public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
       Object scope = inliner.getCurrentScope();
 

--- a/src/trufflesom/interpreter/nodes/SequenceNode.java
+++ b/src/trufflesom/interpreter/nodes/SequenceNode.java
@@ -70,6 +70,22 @@ public final class SequenceNode extends NoPreEvalExprNode {
   }
 
   @Override
+  public boolean isTrivialInBlock() {
+    // has exactly two expressions
+    if (expressions.length != 2) {
+      return false;
+    }
+
+    // and the last/second one is the self return
+    if (expressions[1].getClass() == LocalArgumentReadNode.class
+        && ((LocalArgumentReadNode) expressions[1]).isSelfRead()) {
+      return expressions[0].isTrivialInSequenceInBlock();
+    }
+
+    return false;
+  }
+
+  @Override
   public PreevaluatedExpression copyTrivialNode() {
     if (isTrivial()) {
       return expressions[0].copyTrivialNode();

--- a/src/trufflesom/interpreter/nodes/SequenceNode.java
+++ b/src/trufflesom/interpreter/nodes/SequenceNode.java
@@ -94,6 +94,14 @@ public final class SequenceNode extends NoPreEvalExprNode {
   }
 
   @Override
+  public PreevaluatedExpression copyTrivialNodeInBlock() {
+    if (isTrivialInBlock()) {
+      return expressions[0].copyTrivialNodeInBlock();
+    }
+    return null;
+  }
+
+  @Override
   public AbstractDispatchNode asDispatchNode(final Object rcvr, final Source source,
       final AbstractDispatchNode next) {
     if (isTrivial()) {

--- a/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1237,6 +1237,10 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
     return list;
   }
 
+  public Object[] getLiterals() {
+    return literalsAndConstantsField;
+  }
+
   public byte[] getBytecodeArray() {
     return bytecodesField;
   }

--- a/tests/tools/nodestats/StaticNodeStructureTests.java
+++ b/tests/tools/nodestats/StaticNodeStructureTests.java
@@ -19,9 +19,10 @@ import trufflesom.primitives.arithmetic.SubtractionPrimFactory;
 import trufflesom.primitives.basics.AsStringPrimFactory;
 import trufflesom.primitives.basics.IntegerPrimsFactory.AbsPrimFactory;
 import trufflesom.primitives.basics.IntegerPrimsFactory.AsDoubleValueFactory;
+import trufflesom.tests.TruffleTestSetup;
 
 
-public class StaticNodeStructureTests {
+public class StaticNodeStructureTests extends TruffleTestSetup {
 
   @Test
   public void testSimpleAdd() {

--- a/tests/trufflesom/tests/BytecodeTestSetup.java
+++ b/tests/trufflesom/tests/BytecodeTestSetup.java
@@ -114,6 +114,9 @@ public class BytecodeTestSetup extends TruffleTestSetup {
           assertEquals(actual[i + 2], (byte) bc.arg2);
         }
       } else {
+        if ((byte) expectedBc != actualBc) {
+          dump();
+        }
         assertEquals(
             "Bytecode " + i + " expected " + Bytecodes.getBytecodeName((byte) expectedBc)
                 + " but got " + Bytecodes.getBytecodeName(actualBc),

--- a/tests/trufflesom/tests/OptimizeTrivialTests.java
+++ b/tests/trufflesom/tests/OptimizeTrivialTests.java
@@ -3,6 +3,7 @@ package trufflesom.tests;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static trufflesom.vm.SymbolTable.symSelf;
@@ -39,6 +40,7 @@ import trufflesom.interpreter.nodes.dispatch.CachedFieldWriteAndSelf;
 import trufflesom.interpreter.nodes.dispatch.CachedLiteralNode;
 import trufflesom.interpreter.nodes.dispatch.CachedNewObject;
 import trufflesom.interpreter.nodes.dispatch.UninitializedDispatchNode;
+import trufflesom.interpreter.nodes.literals.BlockNode;
 import trufflesom.interpreter.nodes.literals.DoubleLiteralNode;
 import trufflesom.interpreter.nodes.literals.GenericLiteralNode;
 import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
@@ -49,6 +51,7 @@ import trufflesom.vm.Universe;
 import trufflesom.vm.VmSettings;
 import trufflesom.vmobjects.SClass;
 import trufflesom.vmobjects.SInvokable;
+import trufflesom.vmobjects.SInvokable.SMethod;
 import trufflesom.vmobjects.SInvokable.SPrimitive;
 import trufflesom.vmobjects.SObject;
 import trufflesom.vmobjects.SSymbol;
@@ -340,6 +343,27 @@ public class OptimizeTrivialTests extends TruffleTestSetup {
     Method m = parseMethod("test = ( ^ [] )");
 
     assertFalse(m.isTrivial());
+  }
+
+  @Test
+  public void testFieldReadInBlock() {
+    addField("field");
+    Method m = parseBlock("[ field ]");
+
+    PreevaluatedExpression e = m.copyTrivialNode();
+    assertThat(e, instanceOf(FieldReadNode.class));
+  }
+
+  @Test
+  public void testFieldReadInBlockInsideAnotherBlock() {
+    addField("field");
+    Method m = parseBlock("[ [ field ] ]");
+
+    BlockNode block = (BlockNode) m.getChildren().iterator().next();
+    SMethod blockMethod = block.getMethod();
+    PreevaluatedExpression trivial = blockMethod.getInvokable().copyTrivialNode();
+
+    assertNull(trivial);
   }
 
   private void literalBlock(final String source, final String result, final Class<?> cls) {

--- a/tests/trufflesom/tests/OptimizeTrivialTests.java
+++ b/tests/trufflesom/tests/OptimizeTrivialTests.java
@@ -32,6 +32,7 @@ import trufflesom.interpreter.nodes.GlobalNode;
 import trufflesom.interpreter.nodes.GlobalNode.FalseGlobalNode;
 import trufflesom.interpreter.nodes.GlobalNode.NilGlobalNode;
 import trufflesom.interpreter.nodes.GlobalNode.TrueGlobalNode;
+import trufflesom.interpreter.nodes.bc.BytecodeLoopNode;
 import trufflesom.interpreter.nodes.dispatch.AbstractDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.CachedDispatchNode;
 import trufflesom.interpreter.nodes.dispatch.CachedExprNode;
@@ -359,10 +360,17 @@ public class OptimizeTrivialTests extends TruffleTestSetup {
     addField("field");
     Method m = parseBlock("[ [ field ] ]");
 
-    BlockNode block = (BlockNode) m.getChildren().iterator().next();
-    SMethod blockMethod = block.getMethod();
-    PreevaluatedExpression trivial = blockMethod.getInvokable().copyTrivialNode();
+    SMethod blockMethod;
+    if (VmSettings.UseAstInterp) {
+      BlockNode block = (BlockNode) m.getChildren().iterator().next();
+      blockMethod = block.getMethod();
 
+    } else {
+      BytecodeLoopNode bcNode = (BytecodeLoopNode) m.getChildren().iterator().next();
+      blockMethod = (SMethod) bcNode.getConstant(0);
+    }
+
+    PreevaluatedExpression trivial = blockMethod.getInvokable().copyTrivialNode();
     assertNull(trivial);
   }
 

--- a/tests/trufflesom/tests/OptimizeTrivialTests.java
+++ b/tests/trufflesom/tests/OptimizeTrivialTests.java
@@ -364,7 +364,6 @@ public class OptimizeTrivialTests extends TruffleTestSetup {
     if (VmSettings.UseAstInterp) {
       BlockNode block = (BlockNode) m.getChildren().iterator().next();
       blockMethod = block.getMethod();
-
     } else {
       BytecodeLoopNode bcNode = (BytecodeLoopNode) m.getChildren().iterator().next();
       blockMethod = (SMethod) bcNode.getConstant(0);


### PR DESCRIPTION
This PR makes sure that we do not accidentally try to create a trivial method for a block needed in another block.
For that to work, we would need to have a trivial field read node, which supports reading from a context.

While that would be easy to implement, we can do that another time.
This PR tries to make sure we avoid the issue, and test for it.
It also tries to make sure that we support trivial blocks with a field read in the bytecode interpreter, where we are currently missing this optimization.

@OctaveLarose, that's the other issue that came up on your branch.