### PR TITLE
Avoid copying the AST for non-splitting operations

### DIFF
--- a/som
+++ b/som
@@ -254,6 +254,7 @@ else:
     flags += ['-Dpolyglot.engine.MultiTier=false',
               '-Dpolyglot.engine.DynamicCompilationThresholds=false',
               '-Dpolyglot.engine.SingleTierCompilationThreshold=253',
+              '-Dpolyglot.engine.Mode=throughput',
               '-Dpolyglot.engine.CompilationFailureAction=ExitVM']
 
 if args.som_dnu:

--- a/src/bdt/inlining/NodeVisitorUtil.java
+++ b/src/bdt/inlining/NodeVisitorUtil.java
@@ -12,12 +12,17 @@ final class NodeVisitorUtil {
   @SuppressWarnings("unchecked")
   public static <ExprT extends Node> ExprT applyVisitor(final ExprT body,
       final NodeVisitor visitor, final TruffleLanguage<?> language) {
+    Node oldParent = body.getParent();
     DummyParent dummyParent = new DummyParent(language, body);
 
     body.accept(visitor);
 
     // need to return the child of the dummy parent,
     // since it could have been replaced
-    return (ExprT) dummyParent.child;
+    ExprT result = (ExprT) dummyParent.child;
+    if (oldParent != null) {
+      oldParent.insert(result);
+    }
+    return result;
   }
 }

--- a/src/bdt/inlining/ScopeAdaptationVisitor.java
+++ b/src/bdt/inlining/ScopeAdaptationVisitor.java
@@ -50,9 +50,15 @@ public final class ScopeAdaptationVisitor implements NodeVisitor {
       final int appliesTo, final boolean someOuterScopeIsMerged,
       final boolean isSplittingOperation,
       final TruffleLanguage<?> language) {
-    N inlinedBody = NodeUtil.cloneNode(body);
 
-    return NodeVisitorUtil.applyVisitor(inlinedBody,
+    N adaptedBody;
+    if (isSplittingOperation) {
+      adaptedBody = NodeUtil.cloneNode(body);
+    } else {
+      adaptedBody = body;
+    }
+
+    return NodeVisitorUtil.applyVisitor(adaptedBody,
         new ScopeAdaptationVisitor(newScope, oldScope, appliesTo, someOuterScopeIsMerged,
             isSplittingOperation),
         language);


### PR DESCRIPTION
Only the splitting operations require the old AST to be intact. For the bytecode inlining, we also really don’t need to copy the AST, we just need to traverse it.