### PR TITLE
Update Truffle to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,7 @@ jobs:
       
       - name: Compile TruffleSOM
         run: |
-          mx build
-          # --no-native restore after updating after the fix
-          # https://github.com/oracle/graal/commit/3bfca94351befabd80aa7b9c2bfb5ca67aa29561
+          mx build --no-native
       
       - name: Tests
         run: |

--- a/mx.trufflesom/mx_trufflesom.py
+++ b/mx.trufflesom/mx_trufflesom.py
@@ -212,7 +212,7 @@ def build_native(args, **kwargs):
     if opt.graalvm:
         cmd += ["--gc=G1"]
 
-    cmd += ["trufflesom.vm.Universe"]
+    cmd += ["trufflesom.Launcher"]
 
     mx.run_mx(cmd, svm_path)
 

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "a77ffd52138043196d42b6ebd9f2130cadf722c3",
+                "version": "88a6d872db34c4d8544f635a0b382922a68134a7",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "adb3a0a0cef3360454c0835468ba1db0f2080723",
+                "version": "a77ffd52138043196d42b6ebd9f2130cadf722c3",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "88a6d872db34c4d8544f635a0b382922a68134a7",
+                "version": "a8cf1af2963e092dc447710028578f7d3bc18b0b",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/som
+++ b/som
@@ -206,7 +206,7 @@ else:
 
 MODULE_PATH_ENTRIES = [BASE_DIR + '/mxbuild/dists/trufflesom.jar', GRAAL_SDK_JAR, TRUFFLE_API_JAR]
 
-SOM_ARGS = ['trufflesom.vm.Universe']
+SOM_ARGS = ['--module', 'trufflesom/trufflesom.Launcher']
 
 # == Compiler Settings
 TWEAK_INLINING = ['-Dpolyglot.engine.CompilationThreshold=191',

--- a/som
+++ b/som
@@ -199,28 +199,12 @@ LIBGRAAL_JAR    = TRUFFLE_DIR + '/compiler/mxbuild/dists/graal-truffle-compiler-
 COVERAGE_JAR    = TRUFFLE_DIR + '/tools/mxbuild/dists/truffle-coverage.jar'
 PROFILER_JAR    = TRUFFLE_DIR + '/tools/mxbuild/dists/truffle-profiler.jar'
 
-classpath = (BASE_DIR + '/mxbuild/jdk20/trufflesom/bin:'
-           + GRAAL_SDK_JAR + ':'
-           + TRUFFLE_API_JAR)
-
-TRUFFLE_API_CLASSPATH = (TRUFFLE_API_JAR)
-
 if args.use_libgraal:
   GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:+UseJVMCICompiler', '-XX:+UseJVMCINativeLibrary']
 else:
   GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:+UseJVMCICompiler', '-XX:-UseJVMCINativeLibrary']
 
-
-GRAAL_TRUFFLE_FLAGS = [
-  '--module-path=' + GRAAL_SDK_JAR + ':' + TRUFFLE_API_JAR,
-  '--upgrade-module-path=' + LIBGRAAL_JAR
-]
-
-ADD_OPEN_FLAGS = [
-  '--add-opens=org.graalvm.truffle/com.oracle.truffle.api=ALL-UNNAMED',
-  '--add-opens=org.graalvm.truffle/com.oracle.truffle.api.interop=ALL-UNNAMED',
-  '--add-opens=org.graalvm.truffle/com.oracle.truffle.api.nodes=ALL-UNNAMED'
-]
+MODULE_PATH_ENTRIES = [BASE_DIR + '/mxbuild/dists/trufflesom.jar', GRAAL_SDK_JAR, TRUFFLE_API_JAR]
 
 SOM_ARGS = ['trufflesom.vm.Universe']
 
@@ -240,8 +224,6 @@ if not args.interpreter and GRAAL_FLAGS:
 else:
     flags = []
 
-flags += GRAAL_TRUFFLE_FLAGS
-
 if args.dump_ir:
     SOM_ARGS += ['-di']
 
@@ -249,7 +231,7 @@ if args.interpreter:
     flags += ['-Dtruffle.TruffleRuntime=com.oracle.truffle.api.impl.DefaultTruffleRuntime',
               '-Dpolyglot.engine.WarnInterpreterOnly=false']
 else:
-    flags += GRAAL_JVMCI_FLAGS + ADD_OPEN_FLAGS
+    flags += GRAAL_JVMCI_FLAGS
     flags += ['-Dpolyglot.engine.MultiTier=false',
               '-Dpolyglot.engine.DynamicCompilationThresholds=false',
               '-Dpolyglot.engine.SingleTierCompilationThreshold=253',
@@ -312,7 +294,7 @@ if args.nodestats:
     flags += ['-Dpolyglot.nodestats.OutputFile=' + args.nodestats, '-Dpolyglot.nodestats=true']
 
 if args.coverage != False:
-    classpath += ':' + COVERAGE_JAR
+    MODULE_PATH_ENTRIES.append(COVERAGE_JAR)
     flags += ['-Dpolyglot.coverage=true',
               '-Dpolyglot.coverage.Count=true',
               '-Dpolyglot.coverage.StrictLines=false',
@@ -321,7 +303,7 @@ if args.coverage != False:
       flags += ['-Dpolyglot.coverage.OutputFile=' + args.coverage]
 
 if args.cpusampler != False:
-    classpath += ':' + PROFILER_JAR
+    MODULE_PATH_ENTRIES.append(PROFILER_JAR)
     flags += ['-Dpolyglot.cpusampler=true', '-Dpolyglot.cpusampler.Output=' + args.cpusampler]
     
 
@@ -334,7 +316,7 @@ if not args.interpreter and not args.background_compilation:
 if not args.interpreter and args.no_compilation:
     flags.append('-Dpolyglot.engine.CompileOnly=__FAKE_METHOD_NON_EXISTING__')
 if not args.interpreter and args.no_trace and not args.perf_warnings:
-    flags += ['-Dpolyglot.engine.TraceInlining=false', '-Dpolyglot.engine.TraceCompilation=false']
+    flags += ['-Dpolyglot.compiler.TraceInlining=false', '-Dpolyglot.engine.TraceCompilation=false']
 if not args.interpreter and not args.graph_pe:
     flags += ['-Dpolyglot.engine.GraphPE=false']
 if args.threads:
@@ -356,7 +338,12 @@ if 'Havlak' in args.args:
   # we don't do it always, because...
   JAVA_ARGS += ['-Xss3072k']
 
-all_args = JAVA_ARGS + ['-classpath', classpath] + ['-Dtruffle.class.path.append=' + classpath] + flags + SOM_ARGS + unknown_args + args.args
+flags += [
+  '--module-path=' + ':'.join(MODULE_PATH_ENTRIES),
+  '--upgrade-module-path=' + LIBGRAAL_JAR
+]
+
+all_args = JAVA_ARGS + flags + SOM_ARGS + unknown_args + args.args
 
 if args.verbose:
     print("CMD: " + java_bin + ' ' + ' '.join(all_args))

--- a/som
+++ b/som
@@ -315,8 +315,6 @@ if not args.interpreter and not args.background_compilation:
     flags += ['-Dpolyglot.engine.BackgroundCompilation=false']
 if not args.interpreter and args.no_compilation:
     flags.append('-Dpolyglot.engine.CompileOnly=__FAKE_METHOD_NON_EXISTING__')
-if not args.interpreter and args.no_trace and not args.perf_warnings:
-    flags += ['-Dpolyglot.compiler.TraceInlining=false', '-Dpolyglot.engine.TraceCompilation=false']
 if not args.interpreter and not args.graph_pe:
     flags += ['-Dpolyglot.engine.GraphPE=false']
 if args.threads:

--- a/src/trufflesom/src/trufflesom/Launcher.java
+++ b/src/trufflesom/src/trufflesom/Launcher.java
@@ -1,0 +1,43 @@
+package trufflesom;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Context.Builder;
+import org.graalvm.polyglot.Value;
+
+import trufflesom.interpreter.SomLanguage;
+import trufflesom.vm.VmSettings;
+
+
+public class Launcher {
+  public static void main(final String[] arguments) {
+    Value returnCode = eval(arguments);
+    if (returnCode.isNumber()) {
+      System.exit(returnCode.asInt());
+    } else {
+      System.exit(0);
+    }
+  }
+
+  public static Value eval(final String[] arguments) {
+    Builder builder = createContextBuilder();
+    builder.arguments(SomLanguage.LANG_ID, arguments);
+    builder.logHandler(System.err);
+
+    if (!VmSettings.UseJitCompiler) {
+      builder.option("engine.Compilation", "false");
+    }
+
+    Context context = builder.build();
+
+    Value returnCode = context.eval(SomLanguage.START);
+    return returnCode;
+  }
+
+  public static Builder createContextBuilder() {
+    Builder builder = Context.newBuilder(SomLanguage.LANG_ID)
+                             .in(System.in)
+                             .out(System.out)
+                             .allowAllAccess(true);
+    return builder;
+  }
+}

--- a/src/trufflesom/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/src/trufflesom/vm/Universe.java
@@ -51,10 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.StringTokenizer;
 
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Context.Builder;
-import org.graalvm.polyglot.Value;
-
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -67,7 +63,6 @@ import trufflesom.compiler.Disassembler;
 import trufflesom.compiler.Field;
 import trufflesom.compiler.SourcecodeCompiler;
 import trufflesom.compiler.Variable;
-import trufflesom.interpreter.SomLanguage;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SArray;
@@ -125,38 +120,6 @@ public final class Universe {
     if (FailOnMissingOptimizations) {
       CompilerAsserts.neverPartOfCompilation(msg);
     }
-  }
-
-  public static void main(final String[] arguments) {
-    Value returnCode = eval(arguments);
-    if (returnCode.isNumber()) {
-      System.exit(returnCode.asInt());
-    } else {
-      System.exit(0);
-    }
-  }
-
-  public static Builder createContextBuilder() {
-    Builder builder = Context.newBuilder(SomLanguage.LANG_ID)
-                             .in(System.in)
-                             .out(System.out)
-                             .allowAllAccess(true);
-    return builder;
-  }
-
-  public static Value eval(final String[] arguments) {
-    Builder builder = createContextBuilder();
-    builder.arguments(SomLanguage.LANG_ID, arguments);
-    builder.logHandler(System.err);
-
-    if (!VmSettings.UseJitCompiler) {
-      builder.option("engine.Compilation", "false");
-    }
-
-    Context context = builder.build();
-
-    Value returnCode = context.eval(SomLanguage.START);
-    return returnCode;
   }
 
   public static Object interpret(final String[] arguments) {

--- a/tests/trufflesom/tests/BasicInterpreterTests.java
+++ b/tests/trufflesom/tests/BasicInterpreterTests.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import trufflesom.Launcher;
 import trufflesom.compiler.SourcecodeCompiler.AstCompiler;
 import trufflesom.compiler.SourcecodeCompiler.BcCompiler;
 import trufflesom.interpreter.SomLanguage;
@@ -206,7 +207,7 @@ public class BasicInterpreterTests {
       Universe.setSourceCompiler(new BcCompiler(), true);
     }
 
-    Builder builder = Universe.createContextBuilder();
+    Builder builder = Launcher.createContextBuilder();
     builder.option("som.CLASS_PATH", "Smalltalk:TestSuite/BasicInterpreterTests");
     builder.option("som.TEST_CLASS", testClass);
     builder.option("som.TEST_SELECTOR", testSelector);

--- a/tests/trufflesom/tests/SomTests.java
+++ b/tests/trufflesom/tests/SomTests.java
@@ -32,8 +32,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import trufflesom.Launcher;
 import trufflesom.vm.Classes;
-import trufflesom.vm.Universe;
 import trufflesom.vmobjects.SObject;
 
 
@@ -98,7 +98,7 @@ public class SomTests {
   public void testSomeTest() {
     Classes.reset();
 
-    Value returnCode = Universe.eval(
+    Value returnCode = Launcher.eval(
         new String[] {"-cp", "Smalltalk", "TestSuite/TestHarness.som", testName});
     if (returnCode.isNumber()) {
       assertEquals(0, returnCode.asInt());

--- a/tests/trufflesom/tests/TruffleTestSetup.java
+++ b/tests/trufflesom/tests/TruffleTestSetup.java
@@ -11,6 +11,7 @@ import org.junit.Ignore;
 
 import com.oracle.truffle.api.nodes.Node;
 
+import trufflesom.Launcher;
 import trufflesom.bdt.source.SourceCoordinate;
 import trufflesom.bdt.tools.structure.StructuralProbe;
 import trufflesom.compiler.ClassGenerationContext;
@@ -55,7 +56,7 @@ public class TruffleTestSetup {
       Universe.setSourceCompiler(new BcCompiler(), true);
     }
 
-    Builder builder = Universe.createContextBuilder();
+    Builder builder = Launcher.createContextBuilder();
     builder.logHandler(System.err);
 
     Context context = builder.build();


### PR DESCRIPTION
This moves the main method out of Universe into a Launcher class to avoid class dependencies in the main context, i.e., non-Truffle code.

This also reverts the `--no-native` work-around from the last PR.

And, finally, perhaps most importantly, the som launcher is now adapted to use the module path.