### PR TITLE
Update Graal to August 12th

### DIFF
--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "4da9baa0f8f0676d0d77fd361cb5adf44104c0cb",
+                "version": "86f363ce80a7dcf2ff80faa184eaff81f5c2a9df",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "86f363ce80a7dcf2ff80faa184eaff81f5c2a9df",
+                "version": "b38902d359f3af2c7cdec65afc562dd9e54fb974",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "ce745f6ff6f910db04324364b1daa1de7b093702",
+                "version": "e4f561e098cdea69aa13e2953b2a421932972a5c",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "e4f561e098cdea69aa13e2953b2a421932972a5c",
+                "version": "4da9baa0f8f0676d0d77fd361cb5adf44104c0cb",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/som
+++ b/som
@@ -251,8 +251,6 @@ else:
 ##
 ## Defining Necessary Parameter Bits
 ##
-TRUFFLE_API_JAR = TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-api.jar'
-GRAAL_SDK_JAR   = TRUFFLE_DIR + '/sdk/mxbuild/dists/graal-sdk.jar'
 LIBGRAAL_JAR    = TRUFFLE_DIR + '/compiler/mxbuild/dists/graal-truffle-compiler-libgraal.jar'
 COVERAGE_JAR    = TRUFFLE_DIR + '/tools/mxbuild/dists/truffle-coverage.jar'
 PROFILER_JAR    = TRUFFLE_DIR + '/tools/mxbuild/dists/truffle-profiler.jar'
@@ -262,7 +260,14 @@ if args.use_libgraal:
 else:
   GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:+UseJVMCICompiler', '-XX:-UseJVMCINativeLibrary']
 
-MODULE_PATH_ENTRIES = [BASE_DIR + '/mxbuild/dists/trufflesom.jar', GRAAL_SDK_JAR, TRUFFLE_API_JAR]
+MODULE_PATH_ENTRIES = [
+  BASE_DIR + '/mxbuild/dists/trufflesom.jar',
+  TRUFFLE_DIR + '/sdk/mxbuild/dists/graal-sdk.jar',
+  TRUFFLE_DIR + '/sdk/mxbuild/dists/collections.jar',
+  TRUFFLE_DIR + '/sdk/mxbuild/dists/polyglot.jar',
+  TRUFFLE_DIR + '/sdk/mxbuild/dists/word.jar',
+  TRUFFLE_DIR + '/sdk/mxbuild/dists/nativeimage.jar',
+  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-api.jar']
 
 SOM_ARGS = ['--module', 'trufflesom/trufflesom.Launcher']
 


### PR DESCRIPTION
This required changes in the module path of the `som` launcher script since the SDK is now split into multiple jars.