### PR TITLE
Update Truffle and fix issues with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       
       - name: Compile TruffleSOM
         run: |
-          mx build --no-native
+          mx build
       
       - name: Tests
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ test:
     - (cd ../graal/compiler/mxbuild && sudo reown-project.sh) || true
     - ./som --setup labsjdk
     - mx sforceimport
-    - mx build --no-native
+    - mx build
     - mx tests-junit
     - mx tests-som
     - mx tests-somsom
@@ -41,7 +41,7 @@ build:native-interp-ast:
     - (cd ../graal/compiler/mxbuild && sudo reown-project.sh) || true
     - ./som --setup labsjdk
     - mx sforceimport
-    - mx build --no-native
+    - mx build
     - mx build-native -J -t AST -bn
     - ./som-native-interp-ast -cp Smalltalk TestSuite/TestHarness.som
 
@@ -66,7 +66,7 @@ build:native-interp-bc:
     - (cd ../graal/compiler/mxbuild && sudo reown-project.sh) || true
     - ./som --setup labsjdk
     - mx sforceimport
-    - mx build --no-native
+    - mx build
     - mx build-native -J -t BC -bn
     - ./som-native-interp-bc -cp Smalltalk TestSuite/TestHarness.som
 

--- a/mx.trufflesom/mx_trufflesom.py
+++ b/mx.trufflesom/mx_trufflesom.py
@@ -218,7 +218,7 @@ def tests_junit(args, **kwargs):
     """run Java unit tests"""
     for t in INTERP_TYPES:
         print(f"Run JUnit for {t} interpreter:")
-        mx.run_mx(["unittest", "--suite", "trufflesom", "-Dsom.interp=AST"])
+        mx.run_mx(["unittest", "--suite", "trufflesom", "-Dsom.interp=" + t])
 
 
 @mx.command(suite.name, "tests-som")
@@ -231,7 +231,7 @@ def tests_som(args, **kwargs):
                 suite.dir + "/som",
                 "-G",
                 "--no-embedded-graal",
-                "-Dsom.interp" + t,
+                "-Dsom.interp=" + t,
                 "-cp",
                 suite.dir + "/Smalltalk",
                 suite.dir + "/TestSuite/TestHarness.som",
@@ -261,7 +261,7 @@ def tests_somsom(args, **kwargs):
             [
                 suite.dir + "/som",
                 "-G",
-                "-Dsom.interp" + t,
+                "-Dsom.interp=" + t,
                 "-cp",
                 somsom_cp,
                 suite.dir + "/core-lib/SomSom/tests/SomSomTests.som",

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -95,7 +95,7 @@ suite = {
             "javaCompliance": "17+",
             "dependencies": ["tests"],
             "exclude": ["mx:JUNIT", "mx:HAMCREST"],
-            "distDependencies": ["TRUFFLESOM"],
+            "distDependencies": ["TRUFFLESOM", "truffle:TRUFFLE_TEST"],
             "testDistribution": True,
         },
     },

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "6c9c467700bb4ae67cace2191e5d9c90058a40fb",
+                "version": "fd9f76232f904ad5ac5d80e5cf53f375f0ff6ac2",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "fd9f76232f904ad5ac5d80e5cf53f375f0ff6ac2",
+                "version": "ee8e9a01557122593cebcb43ca27641442b12cd9",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]


### PR DESCRIPTION
The update required to add an explicit dependency to `TRUFFLE_TEST`.
I also noted that the tests were broken and didn't properly set the right property for the interpreter...

The PR also removes the use of `--no-native` which is brittle and breaks things, because it forcibly removes stuff, but doesn't really seem to make much of a difference when it comes to compile time savings.

As part of identifying the now needed `TRUFFLE_TEST` dependency, [Tomas](https://graalvm.slack.com/archives/CNQSB2DHD/p1701172925817229?thread_ts=1701022365.626539&cid=CNQSB2DHD) also suggested an alternative option:

```patch
diff --git a/mx.trufflesom/mx_trufflesom.py b/mx.trufflesom/mx_trufflesom.py
index c0bd455a..97e393f3 100644
--- a/mx.trufflesom/mx_trufflesom.py
+++ b/mx.trufflesom/mx_trufflesom.py
@@ -4,6 +4,7 @@ import sys
 from argparse import ArgumentParser
 
 import mx
+import mx_unittest
 
 INTERP_TYPES = ["AST", "BC"]
 
@@ -11,6 +12,28 @@ suite = mx.suite("trufflesom")
 LABS_JDK_ID = suite.suiteDict["libraries"]["LABS_JDK"]["id"]
 
 
+class TruffleSOMUnittestConfig(mx_unittest.MxUnittestConfig):
+
+    def __init__(self):
+        super(TruffleSOMUnittestConfig, self).__init__('trufflesom')
+
+    def apply(self, config):
+        vmArgs, mainClass, mainClassArgs = config
+
+        # This is required to access jdk.internal.module.Modules which
+        # in turn allows us to dynamically open fields/methods to reflection.
+        vmArgs = vmArgs + ['--add-exports=java.base/jdk.internal.module=ALL-UNNAMED']
+
+        mainClassArgs.extend(['-JUnitOpenPackages', 'org.graalvm.truffle/*=ALL-UNNAMED'])
+        mainClassArgs.extend(['-JUnitOpenPackages', 'org.graalvm.truffle.compiler/*=ALL-UNNAMED'])
+        mainClassArgs.extend(['-JUnitOpenPackages', 'org.graalvm.truffle.runtime/*=ALL-UNNAMED'])
+        mainClassArgs.extend(['-JUnitOpenPackages', 'org.graalvm.polyglot/*=ALL-UNNAMED'])
+        return (vmArgs, mainClass, mainClassArgs)
+
+
+mx_unittest.register_unittest_config(TruffleSOMUnittestConfig())
+
+
 def ensure_core_lib_is_available():
     if not os.path.exists(suite.dir + "/core-lib/.git"):
         git = mx.GitConfig()
diff --git a/mx.trufflesom/suite.py b/mx.trufflesom/suite.py
index 104c69f0..f9c2fa50 100644
--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -97,6 +97,7 @@ suite = {
             "exclude": ["mx:JUNIT", "mx:HAMCREST"],
             "distDependencies": ["TRUFFLESOM"],
             "testDistribution": True,
+            "unittestConfig": "trufflesom",
         },
     },
 }
```

Though, for the moment, I went with the minimal possible change.