### PR TITLE
Process linter issues and remove unused virtual frame arguments

### DIFF
--- a/src/trufflesom/src/trufflesom/bdt/inlining/InlinableNodes.java
+++ b/src/trufflesom/src/trufflesom/bdt/inlining/InlinableNodes.java
@@ -50,12 +50,12 @@ public final class InlinableNodes<Id> {
     initializeFactories(inlinableFactories);
   }
 
-  private void initializeNodes(final List<Class<? extends Node>> inlinableNodes) {
-    if (inlinableNodes == null) {
+  private void initializeNodes(final List<Class<? extends Node>> nodes) {
+    if (nodes == null) {
       return;
     }
 
-    for (Class<? extends Node> nodeClass : inlinableNodes) {
+    for (Class<? extends Node> nodeClass : nodes) {
       Inline[] ann = getInlineAnnotation(nodeClass);
       assert ann != null;
 

--- a/src/trufflesom/src/trufflesom/bdt/primitives/Specializer.java
+++ b/src/trufflesom/src/trufflesom/bdt/primitives/Specializer.java
@@ -62,7 +62,8 @@ public class Specializer<ExprT, Id> {
     return fact.getClass().getSimpleName();
   }
 
-  public boolean matches(final Object[] args, final ExprT[] argNodes) {
+  public boolean matches(final Object[] args,
+      @SuppressWarnings("unused") final ExprT[] argNodes) {
     // TODO: figure out whether we really want it like this with a VmSetting, or whether
     // there should be something on the context
     // TODO: with the dynamic metrics setting gone, this assertion isn't useful anymore

--- a/src/trufflesom/src/trufflesom/compiler/ClassGenerationContext.java
+++ b/src/trufflesom/src/trufflesom/compiler/ClassGenerationContext.java
@@ -147,11 +147,11 @@ public final class ClassGenerationContext {
     }
   }
 
-  public Field addInstanceField(final SSymbol name, final long coord) {
+  public Field addInstanceField(final SSymbol fieldName, final long coord) {
     int length = SourceCoordinate.getLength(coord);
-    assert name.getString().length() == length;
+    assert fieldName.getString().length() == length;
 
-    Field f = new Field(instanceFields.size(), name, coord);
+    Field f = new Field(instanceFields.size(), fieldName, coord);
     instanceFields.add(f);
     if (structuralProbe != null) {
       structuralProbe.recordNewSlot(f);
@@ -159,11 +159,11 @@ public final class ClassGenerationContext {
     return f;
   }
 
-  public Field addClassField(final SSymbol name, final long coord) {
+  public Field addClassField(final SSymbol fieldName, final long coord) {
     int length = SourceCoordinate.getLength(coord);
-    assert name.getString().length() == length;
+    assert fieldName.getString().length() == length;
 
-    Field f = new Field(classFields.size(), name, coord);
+    Field f = new Field(classFields.size(), fieldName, coord);
     classFields.add(f);
     if (structuralProbe != null) {
       structuralProbe.recordNewSlot(f);

--- a/src/trufflesom/src/trufflesom/compiler/MethodGenerationContext.java
+++ b/src/trufflesom/src/trufflesom/compiler/MethodGenerationContext.java
@@ -224,7 +224,8 @@ public class MethodGenerationContext
     return assembleMethod(body, coord);
   }
 
-  protected SMethod assembleMethod(ExpressionNode body, final long coord) {
+  protected SMethod assembleMethod(final ExpressionNode methodBody, final long coord) {
+    ExpressionNode body = methodBody;
     if (needsToCatchNonLocalReturn()) {
       body = new CatchNonLocalReturnNode(
           body, getFrameOnStackMarker(coord)).initialize(body.getSourceCoordinate());
@@ -538,7 +539,8 @@ public class MethodGenerationContext
     return signature;
   }
 
-  private static String stripColonsAndSourceLocation(String str) {
+  private static String stripColonsAndSourceLocation(final String s) {
+    String str = s;
     int startOfSource = str.indexOf('@');
     if (startOfSource > -1) {
       str = str.substring(0, startOfSource);

--- a/src/trufflesom/src/trufflesom/compiler/Parser.java
+++ b/src/trufflesom/src/trufflesom/compiler/Parser.java
@@ -242,7 +242,7 @@ public abstract class Parser<MGenC extends MethodGenerationContext> {
   }
 
   protected abstract MGenC createMGenC(ClassGenerationContext cgenc,
-      StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe);
+      StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structProbe);
 
   public void classdef(final ClassGenerationContext cgenc) throws ProgramDefinitionError {
     int coord = getStartIndex();

--- a/src/trufflesom/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/src/trufflesom/compiler/ParserAst.java
@@ -60,8 +60,8 @@ public class ParserAst extends Parser<MethodGenerationContext> {
 
   @Override
   protected MethodGenerationContext createMGenC(final ClassGenerationContext cgenc,
-      final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe) {
-    return new MethodGenerationContext(cgenc, structuralProbe);
+      final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structProbe) {
+    return new MethodGenerationContext(cgenc, structProbe);
   }
 
   @Override

--- a/src/trufflesom/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/src/trufflesom/compiler/ParserBc.java
@@ -60,8 +60,8 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
 
   @Override
   protected BytecodeMethodGenContext createMGenC(final ClassGenerationContext cgenc,
-      final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structuralProbe) {
-    return new BytecodeMethodGenContext(cgenc, structuralProbe);
+      final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> structProbe) {
+    return new BytecodeMethodGenContext(cgenc, structProbe);
   }
 
   @Override

--- a/src/trufflesom/src/trufflesom/compiler/Variable.java
+++ b/src/trufflesom/src/trufflesom/compiler/Variable.java
@@ -54,7 +54,7 @@ public abstract class Variable implements trufflesom.bdt.inlining.Variable<Expre
   }
 
   @Override
-  public abstract ExpressionNode getReadNode(int contextLevel, long coord);
+  public abstract ExpressionNode getReadNode(int contextLevel, long coordinate);
 
   protected abstract void emitPop(BytecodeMethodGenContext mgenc);
 
@@ -115,25 +115,26 @@ public abstract class Variable implements trufflesom.bdt.inlining.Variable<Expre
     }
 
     @Override
-    public ExpressionNode getReadNode(final int contextLevel, final long coord) {
+    public ExpressionNode getReadNode(final int contextLevel, final long coordinate) {
       transferToInterpreterAndInvalidate();
 
       if (contextLevel == 0) {
-        return new LocalArgumentReadNode(this).initialize(coord);
+        return new LocalArgumentReadNode(this).initialize(coordinate);
       } else {
-        return new NonLocalArgumentReadNode(this, contextLevel).initialize(coord);
+        return new NonLocalArgumentReadNode(this, contextLevel).initialize(coordinate);
       }
     }
 
     @Override
     public ExpressionNode getWriteNode(final int contextLevel,
-        final ExpressionNode valueExpr, final long coord) {
+        final ExpressionNode valueExpr, final long coordinate) {
       transferToInterpreterAndInvalidate();
 
       if (contextLevel == 0) {
-        return new LocalArgumentWriteNode(this, valueExpr).initialize(coord);
+        return new LocalArgumentWriteNode(this, valueExpr).initialize(coordinate);
       } else {
-        return new NonLocalArgumentWriteNode(this, contextLevel, valueExpr).initialize(coord);
+        return new NonLocalArgumentWriteNode(this, contextLevel, valueExpr).initialize(
+            coordinate);
       }
     }
 
@@ -165,17 +166,17 @@ public abstract class Variable implements trufflesom.bdt.inlining.Variable<Expre
       this.descriptor = descriptor;
     }
 
-    public void init(final FrameDescriptor descriptor) {
-      this.descriptor = descriptor;
+    public void init(final FrameDescriptor desc) {
+      this.descriptor = desc;
     }
 
     @Override
-    public ExpressionNode getReadNode(final int contextLevel, final long coord) {
+    public ExpressionNode getReadNode(final int contextLevel, final long coordinate) {
       transferToInterpreterAndInvalidate();
       if (contextLevel > 0) {
-        return NonLocalVariableReadNodeGen.create(contextLevel, this).initialize(coord);
+        return NonLocalVariableReadNodeGen.create(contextLevel, this).initialize(coordinate);
       }
-      return LocalVariableReadNodeGen.create(this).initialize(coord);
+      return LocalVariableReadNodeGen.create(this).initialize(coordinate);
     }
 
     public final int getIndex() {
@@ -194,13 +195,13 @@ public abstract class Variable implements trufflesom.bdt.inlining.Variable<Expre
 
     @Override
     public ExpressionNode getWriteNode(final int contextLevel,
-        final ExpressionNode valueExpr, final long coord) {
+        final ExpressionNode valueExpr, final long coordinate) {
       transferToInterpreterAndInvalidate();
       if (contextLevel > 0) {
         return NonLocalVariableWriteNodeGen.create(contextLevel, this, valueExpr)
-                                           .initialize(coord);
+                                           .initialize(coordinate);
       }
-      return LocalVariableWriteNodeGen.create(this, valueExpr).initialize(coord);
+      return LocalVariableWriteNodeGen.create(this, valueExpr).initialize(coordinate);
     }
 
     public final FrameDescriptor getFrameDescriptor() {
@@ -232,7 +233,7 @@ public abstract class Variable implements trufflesom.bdt.inlining.Variable<Expre
     }
 
     @Override
-    public ExpressionNode getReadNode(final int contextLevel, final long coord) {
+    public ExpressionNode getReadNode(final int contextLevel, final long coordinate) {
       throw new UnsupportedOperationException(
           "There shouldn't be any language-level read nodes for internal slots. "
               + "They are used directly by other nodes.");

--- a/src/trufflesom/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/src/trufflesom/interpreter/Invokable.java
@@ -98,6 +98,7 @@ public abstract class Invokable extends RootNode implements WithSource {
     return null;
   }
 
+  @SuppressWarnings("unused")
   public AbstractDispatchNode asDispatchNode(final Object rcvr,
       final AbstractDispatchNode next) {
     return null;

--- a/src/trufflesom/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/src/trufflesom/interpreter/Invokable.java
@@ -1,6 +1,7 @@
 package trufflesom.interpreter;
 
 import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
@@ -32,7 +33,7 @@ public abstract class Invokable extends RootNode implements WithSource {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Invokable initialize(final long coord) {
+  public <T extends Node> T initialize(final long coord) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/trufflesom/src/trufflesom/interpreter/Invokable.java
+++ b/src/trufflesom/src/trufflesom/interpreter/Invokable.java
@@ -32,7 +32,7 @@ public abstract class Invokable extends RootNode implements WithSource {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Invokable initialize(final long sourceCoord) {
+  public Invokable initialize(final long coord) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/trufflesom/src/trufflesom/interpreter/LexicalScope.java
+++ b/src/trufflesom/src/trufflesom/interpreter/LexicalScope.java
@@ -209,8 +209,8 @@ public final class LexicalScope implements Scope<LexicalScope, Method> {
   }
 
   @Override
-  public LexicalScope getScope(final Method method) {
-    if (method.equals(this.method)) {
+  public LexicalScope getScope(final Method m) {
+    if (m.equals(this.method)) {
       return this;
     }
 
@@ -218,8 +218,8 @@ public final class LexicalScope implements Scope<LexicalScope, Method> {
       return null;
     }
 
-    for (LexicalScope m : embeddedScopes) {
-      LexicalScope result = m.getScope(method);
+    for (LexicalScope scope : embeddedScopes) {
+      LexicalScope result = scope.getScope(m);
       if (result != null) {
         return result;
       }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/ExpressionNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/ExpressionNode.java
@@ -85,6 +85,7 @@ public abstract class ExpressionNode extends SOMNode
     return null;
   }
 
+  @SuppressWarnings("unused")
   public AbstractDispatchNode asDispatchNode(final Object rcvr, final Source source,
       final AbstractDispatchNode next) {
     // Some of the subclasses may be trivial and implement this

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/FieldNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/FieldNode.java
@@ -209,7 +209,7 @@ public abstract class FieldNode extends ExpressionNode {
       return new CachedFieldWriteAndSelf(rcvr.getClass(), layout, source, storage, next);
     }
 
-    public final Object executeEvaluated(final VirtualFrame frame,
+    public final Object executeEvaluated(@SuppressWarnings("unused") final VirtualFrame frame,
         final SObject self, final Object value) {
       return write.write(self, value);
     }
@@ -221,14 +221,12 @@ public abstract class FieldNode extends ExpressionNode {
     }
 
     @Specialization
-    public long doLong(final VirtualFrame frame, final SObject self,
-        final long value) {
+    public long doLong(final SObject self, final long value) {
       return write.write(self, value);
     }
 
     @Specialization
-    public double doDouble(final VirtualFrame frame, final SObject self,
-        final double value) {
+    public double doDouble(final SObject self, final double value) {
       return write.write(self, value);
     }
 

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/LocalVariableNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/LocalVariableNode.java
@@ -47,7 +47,7 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
     }
 
     @Specialization(guards = "isUninitialized(frame)")
-    public static final SObject doNil(final VirtualFrame frame) {
+    public static final SObject doNil(@SuppressWarnings("unused") final VirtualFrame frame) {
       return Nil.nilObject;
     }
 
@@ -76,7 +76,8 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
       return frame.getObject(slotIndex);
     }
 
-    protected final boolean isUninitialized(final VirtualFrame frame) {
+    protected final boolean isUninitialized(
+        @SuppressWarnings("unused") final VirtualFrame frame) {
       return local.getFrameDescriptor().getSlotKind(slotIndex) == FrameSlotKind.Illegal;
     }
 
@@ -125,7 +126,7 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
     }
 
     // uses expValue to make sure guard is not converted to assertion
-    protected final boolean isBoolKind(final boolean expValue) {
+    protected final boolean isBoolKind(@SuppressWarnings("unused") final boolean expValue) {
       if (local.getFrameDescriptor().getSlotKind(slotIndex) == FrameSlotKind.Boolean) {
         return true;
       }
@@ -137,7 +138,7 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
     }
 
     // uses expValue to make sure guard is not converted to assertion
-    protected final boolean isLongKind(final long expValue) {
+    protected final boolean isLongKind(@SuppressWarnings("unused") final long expValue) {
       if (local.getFrameDescriptor().getSlotKind(slotIndex) == FrameSlotKind.Long) {
         return true;
       }
@@ -149,7 +150,7 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
     }
 
     // uses expValue to make sure guard is not converted to assertion
-    protected final boolean isDoubleKind(final double expValue) {
+    protected final boolean isDoubleKind(@SuppressWarnings("unused") final double expValue) {
       if (local.getFrameDescriptor().getSlotKind(slotIndex) == FrameSlotKind.Double) {
         return true;
       }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/NonLocalVariableNode.java
@@ -46,13 +46,13 @@ public abstract class NonLocalVariableNode extends ContextualNode
     }
 
     @Specialization(guards = "isUninitialized(frame)")
-    public static final SObject doNil(final VirtualFrame frame) {
+    public static final SObject doNil(@SuppressWarnings("unused") final VirtualFrame frame) {
       return Nil.nilObject;
     }
 
     @Specialization(guards = {"ctx.isBoolean(slotIndex)"},
         rewriteOn = {FrameSlotTypeException.class})
-    public final boolean doBoolean(final VirtualFrame frame,
+    public final boolean doBoolean(@SuppressWarnings("unused") final VirtualFrame frame,
         @Shared("all") @Bind("determineContext(frame)") final MaterializedFrame ctx)
         throws FrameSlotTypeException {
       return ctx.getBoolean(slotIndex);
@@ -60,7 +60,7 @@ public abstract class NonLocalVariableNode extends ContextualNode
 
     @Specialization(guards = {"ctx.isLong(slotIndex)"},
         rewriteOn = {FrameSlotTypeException.class})
-    public final long doLong(final VirtualFrame frame,
+    public final long doLong(@SuppressWarnings("unused") final VirtualFrame frame,
         @Shared("all") @Bind("determineContext(frame)") final MaterializedFrame ctx)
         throws FrameSlotTypeException {
       return ctx.getLong(slotIndex);
@@ -68,7 +68,7 @@ public abstract class NonLocalVariableNode extends ContextualNode
 
     @Specialization(guards = {"ctx.isDouble(slotIndex)"},
         rewriteOn = {FrameSlotTypeException.class})
-    public final double doDouble(final VirtualFrame frame,
+    public final double doDouble(@SuppressWarnings("unused") final VirtualFrame frame,
         @Shared("all") @Bind("determineContext(frame)") final MaterializedFrame ctx)
         throws FrameSlotTypeException {
       return ctx.getDouble(slotIndex);
@@ -77,13 +77,14 @@ public abstract class NonLocalVariableNode extends ContextualNode
     @Specialization(guards = {"ctx.isObject(slotIndex)"},
         replaces = {"doBoolean", "doLong", "doDouble"},
         rewriteOn = {FrameSlotTypeException.class})
-    public final Object doObject(final VirtualFrame frame,
+    public final Object doObject(@SuppressWarnings("unused") final VirtualFrame frame,
         @Shared("all") @Bind("determineContext(frame)") final MaterializedFrame ctx)
         throws FrameSlotTypeException {
       return ctx.getObject(slotIndex);
     }
 
-    protected final boolean isUninitialized(final VirtualFrame frame) {
+    protected final boolean isUninitialized(
+        @SuppressWarnings("unused") final VirtualFrame frame) {
       return local.getFrameDescriptor().getSlotKind(slotIndex) == FrameSlotKind.Illegal;
     }
 
@@ -127,7 +128,7 @@ public abstract class NonLocalVariableNode extends ContextualNode
       return expValue;
     }
 
-    protected final boolean isBoolKind(final VirtualFrame frame) {
+    protected final boolean isBoolKind(@SuppressWarnings("unused") final VirtualFrame frame) {
       FrameDescriptor descriptor = local.getFrameDescriptor();
       FrameSlotKind kind = descriptor.getSlotKind(slotIndex);
       if (kind == FrameSlotKind.Boolean) {
@@ -140,7 +141,7 @@ public abstract class NonLocalVariableNode extends ContextualNode
       return false;
     }
 
-    protected final boolean isLongKind(final VirtualFrame frame) {
+    protected final boolean isLongKind(@SuppressWarnings("unused") final VirtualFrame frame) {
       FrameDescriptor descriptor = local.getFrameDescriptor();
       FrameSlotKind kind = descriptor.getSlotKind(slotIndex);
       if (kind == FrameSlotKind.Long) {
@@ -153,7 +154,8 @@ public abstract class NonLocalVariableNode extends ContextualNode
       return false;
     }
 
-    protected final boolean isDoubleKind(final VirtualFrame frame) {
+    protected final boolean isDoubleKind(
+        @SuppressWarnings("unused") final VirtualFrame frame) {
       FrameDescriptor descriptor = local.getFrameDescriptor();
       FrameSlotKind kind = descriptor.getSlotKind(slotIndex);
       if (kind == FrameSlotKind.Double) {

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/dispatch/AbstractDispatchNode.java
@@ -30,7 +30,7 @@ public abstract class AbstractDispatchNode extends Node
 
   @Override
   @SuppressWarnings("unchecked")
-  public AbstractDispatchNode initialize(final long sourceCoord) {
+  public <T extends Node> T initialize(final long sourceCoord) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/dispatch/AbstractDispatchWithSource.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/dispatch/AbstractDispatchWithSource.java
@@ -1,5 +1,6 @@
 package trufflesom.interpreter.nodes.dispatch;
 
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
 
 import trufflesom.bdt.inlining.nodes.WithSource;
@@ -28,7 +29,7 @@ public abstract class AbstractDispatchWithSource extends AbstractDispatchNode
 
   @SuppressWarnings("unchecked")
   @Override
-  public final AbstractDispatchNode initialize(final long sourceCoord) {
+  public final <T extends Node> T initialize(final long sourceCoord) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/AndBoolMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/AndBoolMessageNode.java
@@ -2,7 +2,6 @@ package trufflesom.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 
 import trufflesom.interpreter.nodes.nary.BinaryMsgExprNode;
 import trufflesom.vm.SymbolTable;
@@ -12,8 +11,7 @@ import trufflesom.vmobjects.SSymbol;
 @GenerateNodeFactory
 public abstract class AndBoolMessageNode extends BinaryMsgExprNode {
   @Specialization
-  public static final boolean doAnd(final VirtualFrame frame, final boolean receiver,
-      final boolean argument) {
+  public static final boolean doAnd(final boolean receiver, final boolean argument) {
     return receiver && argument;
   }
 

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfMessageNode.java
@@ -63,7 +63,7 @@ public abstract class IfMessageNode extends BinaryMsgExprNode {
   @SuppressWarnings("truffle-static-method")
   @Specialization(guards = {"arg.getMethod() == method"}, limit = "LIMIT")
   public final Object cachedBlock(final boolean rcvr, final SBlock arg,
-      @Cached("arg.getMethod()") final SInvokable method,
+      @SuppressWarnings("unused") @Cached("arg.getMethod()") final SInvokable method,
       @Cached("create(method.getCallTarget())") final DirectCallNode callTarget,
       @Shared("all") @Cached final InlinedCountingConditionProfile condProf,
       @Bind("this") final Node node) {

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfTrueIfFalseMessageNode.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
@@ -149,7 +148,7 @@ public abstract class IfTrueIfFalseMessageNode extends TernaryMsgExprNode {
   }
 
   @Specialization
-  public static final Object doIfTrueIfFalseTwoValues(final VirtualFrame frame,
+  public static final Object doIfTrueIfFalseTwoValues(
       final boolean receiver, final Object trueValue, final Object falseValue,
       @Shared("all") @Cached final InlinedCountingConditionProfile condProf,
       @Bind("this") final Node node) {

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IntDownToDoMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IntDownToDoMessageNode.java
@@ -33,7 +33,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
 
   @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doIntCached(final long receiver, final long limit, final SBlock block,
-      @Cached("block.getMethod()") final SInvokable cachedMethod,
+      @SuppressWarnings("unused") @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
     try {
       if (receiver >= limit) {
@@ -71,7 +71,7 @@ public abstract class IntDownToDoMessageNode extends TernaryMsgExprNode {
 
   @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doDoubleCached(final long receiver, final double limit, final SBlock block,
-      @Cached("block.getMethod()") final SInvokable cachedMethod,
+      @SuppressWarnings("unused") @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
     try {
       if (receiver >= limit) {

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IntToDoMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IntToDoMessageNode.java
@@ -33,7 +33,7 @@ public abstract class IntToDoMessageNode extends TernaryMsgExprNode {
 
   @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final long doIntCached(final long receiver, final long limit, final SBlock block,
-      @Cached("block.getMethod()") final SInvokable cachedMethod,
+      @SuppressWarnings("unused") @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
     try {
       doLooping(receiver, limit, block, callNode);
@@ -98,7 +98,7 @@ public abstract class IntToDoMessageNode extends TernaryMsgExprNode {
   @Specialization(guards = {"block.getMethod() == cachedMethod"}, limit = "LIMIT")
   public final double doDoubleDoubleCached(final double receiver, final double limit,
       final SBlock block,
-      @Cached("block.getMethod()") final SInvokable cachedMethod,
+      @SuppressWarnings("unused") @Cached("block.getMethod()") final SInvokable cachedMethod,
       @Cached("create(cachedMethod.getCallTarget())") final DirectCallNode callNode) {
     try {
       if (receiver <= limit) {

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/NotMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/NotMessageNode.java
@@ -2,7 +2,6 @@ package trufflesom.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 
 import trufflesom.bdt.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
@@ -14,7 +13,7 @@ import trufflesom.interpreter.nodes.nary.UnaryExpressionNode;
 @Primitive(selector = "not", receiverType = Boolean.class)
 public abstract class NotMessageNode extends UnaryExpressionNode {
   @Specialization
-  public static final boolean doNot(final VirtualFrame frame, final boolean receiver) {
+  public static final boolean doNot(final boolean receiver) {
     return !receiver;
   }
 }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/OrBoolMessageNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/OrBoolMessageNode.java
@@ -2,7 +2,6 @@ package trufflesom.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 
 import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 
@@ -10,8 +9,7 @@ import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
 @GenerateNodeFactory
 public abstract class OrBoolMessageNode extends BinaryExpressionNode {
   @Specialization
-  public static final boolean doOr(final VirtualFrame frame, final boolean receiver,
-      final boolean argument) {
+  public static final boolean doOr(final boolean receiver, final boolean argument) {
     return receiver || argument;
   }
 }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileFalsePrimitiveNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileFalsePrimitiveNode.java
@@ -23,6 +23,7 @@ public abstract class WhileFalsePrimitiveNode extends WhilePrimitiveNode {
   @Specialization(limit = "INLINE_CACHE_SIZE",
       guards = {"loopCondition.getMethod() == cachedLoopCondition",
           "loopBody.getMethod() == cachedLoopBody"})
+  @SuppressWarnings("unused")
   public final SObject doCached(final SBlock loopCondition, final SBlock loopBody,
       @Cached("loopCondition.getMethod()") final SInvokable cachedLoopCondition,
       @Cached("loopBody.getMethod()") final SInvokable cachedLoopBody,

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileTruePrimitiveNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/whileloops/WhileTruePrimitiveNode.java
@@ -23,6 +23,7 @@ public abstract class WhileTruePrimitiveNode extends WhilePrimitiveNode {
   @Specialization(limit = "INLINE_CACHE_SIZE",
       guards = {"loopCondition.getMethod() == cachedLoopCondition",
           "loopBody.getMethod() == cachedLoopBody"})
+  @SuppressWarnings("unused")
   public final SObject doCached(final SBlock loopCondition, final SBlock loopBody,
       @Cached("loopCondition.getMethod()") final SInvokable cachedLoopCondition,
       @Cached("loopBody.getMethod()") final SInvokable cachedLoopBody,

--- a/src/trufflesom/src/trufflesom/interpreter/objectstorage/StorageLocation.java
+++ b/src/trufflesom/src/trufflesom/interpreter/objectstorage/StorageLocation.java
@@ -120,7 +120,7 @@ public abstract class StorageLocation {
     }
 
     @Override
-    public AbstractWriteFieldNode getWriteNode(final int fieldIndex,
+    public AbstractWriteFieldNode getWriteNode(final int fieldIdx,
         final ObjectLayout layout, final AbstractWriteFieldNode next) {
       CompilerAsserts.neverPartOfCompilation("StorageLocation");
       throw new RuntimeException("we should not get here, should we?");

--- a/src/trufflesom/src/trufflesom/primitives/EmptyPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/EmptyPrim.java
@@ -29,7 +29,7 @@ public final class EmptyPrim extends UnaryExpressionNode {
   }
 
   @Override
-  public Object executeEvaluated(final VirtualFrame frame, final Object receiver) {
+  public Object executeEvaluated(final VirtualFrame frame, final Object rcvr) {
     CompilerDirectives.transferToInterpreter();
     Universe.errorExit(
         "Warning: undefined primitive called: " + signature + " at: " + getSourceSection());

--- a/src/trufflesom/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/src/trufflesom/primitives/Primitives.java
@@ -196,9 +196,9 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
 
   @Override
   protected void registerPrimitive(
-      final Specializer<ExpressionNode, SSymbol> specializer) {
-    String className = specializer.getPrimitive().className();
-    String primName = specializer.getPrimitive().primitive();
+      final Specializer<ExpressionNode, SSymbol> splzr) {
+    String className = splzr.getPrimitive().className();
+    String primName = splzr.getPrimitive().primitive();
 
     if (!("".equals(primName)) && !("".equals(className))) {
       SSymbol clazz = ids.getId(className);
@@ -207,7 +207,7 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
           primitives.computeIfAbsent(clazz, s -> new HashMap<>());
       assert !primsForClass.containsKey(signature) : className
           + " already has a primitive " + primName + " registered.";
-      primsForClass.put(signature, specializer);
+      primsForClass.put(signature, splzr);
     } else {
       assert "".equals(primName) && "".equals(
           className) : "If either primitive() or className() is set on @Primitive, both should be set";
@@ -216,7 +216,7 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
 
   private static SInvokable constructPrimitive(final SSymbol signature,
       final Source source, final long coord,
-      final Specializer<ExpressionNode, SSymbol> specializer,
+      final Specializer<ExpressionNode, SSymbol> splzr,
       final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe) {
     CompilerAsserts.neverPartOfCompilation("This is only executed during bootstrapping.");
 
@@ -225,7 +225,7 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
     // args is needed to communicate the number of arguments to the constructor
     ExpressionNode[] args = new ExpressionNode[numArgs];
 
-    ExpressionNode primNode = specializer.create(null, args, coord);
+    ExpressionNode primNode = splzr.create(null, args, coord);
 
     Primitive primMethodNode = new Primitive(signature.getString(), source, coord, primNode,
         (ExpressionNode) primNode.deepCopy());

--- a/src/trufflesom/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/src/trufflesom/primitives/Primitives.java
@@ -217,7 +217,7 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
   private static SInvokable constructPrimitive(final SSymbol signature,
       final Source source, final long coord,
       final Specializer<ExpressionNode, SSymbol> splzr,
-      final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe) {
+      @SuppressWarnings("unused") final StructuralProbe<SSymbol, SClass, SInvokable, Field, Variable> probe) {
     CompilerAsserts.neverPartOfCompilation("This is only executed during bootstrapping.");
 
     final int numArgs = signature.getNumberOfSignatureArguments();

--- a/src/trufflesom/src/trufflesom/primitives/arithmetic/DoubleDivPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/arithmetic/DoubleDivPrim.java
@@ -46,6 +46,7 @@ public abstract class DoubleDivPrim extends ArithmeticPrim {
 
   @Specialization
   @TruffleBoundary
+  @SuppressWarnings("unused")
   public static final SAbstractObject doLong(final long left, final BigInteger right) {
     CompilerAsserts.neverPartOfCompilation("DoubleDiv100");
     // TODO: need to implement the "/" case here directly... :

--- a/src/trufflesom/src/trufflesom/primitives/arrays/DoIndexesPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/arrays/DoIndexesPrim.java
@@ -35,11 +35,11 @@ public abstract class DoIndexesPrim extends BinaryMsgExprNode {
 
   @Override
   @SuppressWarnings("unchecked")
-  public DoIndexesPrim initialize(final long coord) {
+  public <T extends Node> T initialize(final long coord) {
     super.initialize(coord);
     block = ValueOnePrimFactory.create(null, null);
     length = LengthPrimFactory.create(null);
-    return this;
+    return (T) this;
   }
 
   @Specialization

--- a/src/trufflesom/src/trufflesom/primitives/arrays/NewPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/arrays/NewPrim.java
@@ -35,7 +35,8 @@ public abstract class NewPrim extends BinaryMsgExprNode {
   }
 
   @Specialization(guards = "receiver == arrayClass")
-  public static final SArray doSClass(final SClass receiver, final long length) {
+  public static final SArray doSClass(@SuppressWarnings("unused") final SClass receiver,
+      final long length) {
     return new SArray(length);
   }
 

--- a/src/trufflesom/src/trufflesom/primitives/arrays/PutAllNode.java
+++ b/src/trufflesom/src/trufflesom/primitives/arrays/PutAllNode.java
@@ -43,14 +43,16 @@ public abstract class PutAllNode extends BinaryExpressionNode {
   }
 
   @Specialization(guards = {"rcvr.isEmptyType()", "valueIsNil(nil)"})
-  public SArray doPutNilInEmptyArray(final SArray rcvr, final SObject nil,
-      final long length) {
+  public SArray doPutNilInEmptyArray(final SArray rcvr,
+      @SuppressWarnings("unused") final SObject nil,
+      @SuppressWarnings("unused") final long length) {
     // NO OP
     return rcvr;
   }
 
   @Specialization(guards = {"valueIsNil(nil)"}, replaces = {"doPutNilInEmptyArray"})
-  public SArray doPutNilInOtherArray(final SArray rcvr, final SObject nil,
+  public SArray doPutNilInOtherArray(final SArray rcvr,
+      @SuppressWarnings("unused") final SObject nil,
       final long length) {
     rcvr.transitionToEmpty(length);
     return rcvr;

--- a/src/trufflesom/src/trufflesom/primitives/arrays/ToArgumentsArrayNode.java
+++ b/src/trufflesom/src/trufflesom/primitives/arrays/ToArgumentsArrayNode.java
@@ -30,7 +30,8 @@ public abstract class ToArgumentsArrayNode extends NoPreEvalExprNode {
   }
 
   @Specialization(guards = "somArray == null")
-  public static final Object[] doNoArray(final Object somArray, final Object rcvr) {
+  public static final Object[] doNoArray(@SuppressWarnings("unused") final Object somArray,
+      final Object rcvr) {
     return new Object[] {rcvr};
   }
 

--- a/src/trufflesom/src/trufflesom/primitives/basics/BlockPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/BlockPrims.java
@@ -181,7 +181,7 @@ public abstract class BlockPrims {
   @Primitive(className = "Block4", primitive = "value:with:with:")
   public abstract static class ValueMorePrim extends QuaternaryExpressionNode {
     @Specialization
-    public static final Object doSBlock(final VirtualFrame frame,
+    public static final Object doSBlock(
         final SBlock receiver, final Object firstArg, final Object secondArg,
         final Object thirdArg) {
       CompilerDirectives.transferToInterpreter();

--- a/src/trufflesom/src/trufflesom/primitives/basics/BlockPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/BlockPrims.java
@@ -39,7 +39,7 @@ public abstract class BlockPrims {
   @Primitive(className = "Block", primitive = "restart")
   public abstract static class RestartPrim extends UnaryExpressionNode {
     @Specialization
-    public SAbstractObject doSBlock(final SBlock receiver) {
+    public SAbstractObject doSBlock(@SuppressWarnings("unused") final SBlock receiver) {
       assert VmSettings.UseBcInterp : "This primitive is not supported in the AST interpreter "
           + "Perhaps something went wrong with the intrinsification of "
           + "#whileTrue:/#whileFalse:?";
@@ -63,7 +63,7 @@ public abstract class BlockPrims {
         guards = {"receiver.getMethod() == method", "!method.isTrivial()"},
         limit = "InlineCacheSize")
     public static final Object doSBlock(final SBlock receiver,
-        @Cached("receiver.getMethod()") final SInvokable method,
+        @SuppressWarnings("unused") @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("createCallNode(method)") final DirectCallNode call) {
       return call.call(receiver);
     }
@@ -72,7 +72,7 @@ public abstract class BlockPrims {
         guards = {"receiver.getMethod() == method", "method.isTrivial()"},
         limit = "InlineCacheSize")
     public static final Object doTrivial(final SBlock receiver,
-        @Cached("receiver.getMethod()") final SInvokable method,
+        @SuppressWarnings("unused") @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("method.copyTrivialNode()") final PreevaluatedExpression expr) {
       return expr.doPreEvaluated(null, new Object[] {receiver});
     }
@@ -108,7 +108,7 @@ public abstract class BlockPrims {
         guards = {"receiver.getMethod() == method", "!method.isTrivial()"},
         limit = "InlineCacheSize")
     public static final Object doSBlock(final SBlock receiver, final Object arg,
-        @Cached("receiver.getMethod()") final SInvokable method,
+        @SuppressWarnings("unused") @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("createCallNode(method)") final DirectCallNode call) {
       return call.call(receiver, arg);
     }
@@ -117,7 +117,7 @@ public abstract class BlockPrims {
         guards = {"receiver.getMethod() == method", "method.isTrivial()"},
         limit = "InlineCacheSize")
     public static final Object doTrivial(final SBlock receiver, final Object arg,
-        @Cached("receiver.getMethod()") final SInvokable method,
+        @SuppressWarnings("unused") @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("method.copyTrivialNode()") final PreevaluatedExpression expr) {
       return expr.doPreEvaluated(null, new Object[] {receiver, arg});
     }
@@ -154,7 +154,7 @@ public abstract class BlockPrims {
         limit = "InlineCacheSize")
     public static final Object doSBlock(final SBlock receiver, final Object arg1,
         final Object arg2,
-        @Cached("receiver.getMethod()") final SInvokable method,
+        @SuppressWarnings("unused") @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("createCallNode(method)") final DirectCallNode call) {
       return call.call(receiver, arg1, arg2);
     }
@@ -164,7 +164,7 @@ public abstract class BlockPrims {
         limit = "InlineCacheSize")
     public static final Object doTrivial(final SBlock receiver, final Object arg1,
         final Object arg2,
-        @Cached("receiver.getMethod()") final SInvokable method,
+        @SuppressWarnings("unused") @Cached("receiver.getMethod()") final SInvokable method,
         @Cached("method.copyTrivialNode()") final PreevaluatedExpression expr) {
       return expr.doPreEvaluated(null, new Object[] {receiver, arg1, arg2});
     }
@@ -181,6 +181,7 @@ public abstract class BlockPrims {
   @Primitive(className = "Block4", primitive = "value:with:with:")
   public abstract static class ValueMorePrim extends QuaternaryExpressionNode {
     @Specialization
+    @SuppressWarnings("unused")
     public static final Object doSBlock(
         final SBlock receiver, final Object firstArg, final Object secondArg,
         final Object thirdArg) {

--- a/src/trufflesom/src/trufflesom/primitives/basics/DoublePrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/DoublePrims.java
@@ -37,7 +37,7 @@ public abstract class DoublePrims {
   @Primitive(className = "Double", primitive = "PositiveInfinity", classSide = true)
   public abstract static class PositiveInfinityPrim extends UnaryExpressionNode {
     @Specialization(guards = "receiver == doubleClass")
-    public static final double doSClass(final SClass receiver) {
+    public static final double doSClass(@SuppressWarnings("unused") final SClass receiver) {
       return Double.POSITIVE_INFINITY;
     }
   }
@@ -49,7 +49,8 @@ public abstract class DoublePrims {
 
     @TruffleBoundary
     @Specialization(guards = "receiver == doubleClass")
-    public static final double doSClass(final SClass receiver, final String str) {
+    public static final double doSClass(@SuppressWarnings("unused") final SClass receiver,
+        final String str) {
       try {
         return Double.parseDouble(str);
       } catch (NumberFormatException e) {

--- a/src/trufflesom/src/trufflesom/primitives/basics/EqualsPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/EqualsPrim.java
@@ -30,6 +30,7 @@ public abstract class EqualsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doBoolean(final boolean left, final SObject right) {
     return false;
   }
@@ -51,16 +52,19 @@ public abstract class EqualsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doLong(final long left, final String right) {
     return false;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doLong(final long left, final SObject right) {
     return false;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doLong(final long left, final SSymbol right) {
     return false;
   }
@@ -104,11 +108,13 @@ public abstract class EqualsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doString(final String receiver, final long argument) {
     return false;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doString(final String receiver, final SObject argument) {
     return false;
   }
@@ -124,11 +130,13 @@ public abstract class EqualsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doSSymbol(final SSymbol receiver, final long argument) {
     return false;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doSSymbol(final SSymbol receiver, final SObject argument) {
     return false;
   }

--- a/src/trufflesom/src/trufflesom/primitives/basics/IntegerPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/IntegerPrims.java
@@ -112,7 +112,8 @@ public abstract class IntegerPrims {
 
     @TruffleBoundary
     @Specialization(guards = "receiver == integerClass")
-    public static final Object doString(final SClass receiver, final String argument) {
+    public static final Object doString(@SuppressWarnings("unused") final SClass receiver,
+        final String argument) {
       try {
         return Long.parseLong(argument);
       } catch (NumberFormatException e) {
@@ -276,7 +277,8 @@ public abstract class IntegerPrims {
 
     @Specialization(guards = "minLong(receiver)")
     @TruffleBoundary
-    public static final BigInteger doLongMinValue(final long receiver) {
+    public static final BigInteger doLongMinValue(
+        @SuppressWarnings("unused") final long receiver) {
       return BigInteger.valueOf(Long.MIN_VALUE).abs();
     }
 

--- a/src/trufflesom/src/trufflesom/primitives/basics/SystemPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/SystemPrims.java
@@ -45,7 +45,8 @@ public final class SystemPrims {
   @GenerateNodeFactory
   public abstract static class LoadPrim extends BinaryExpressionNode {
     @Specialization
-    public static final Object doSObject(final SObject receiver, final SSymbol argument) {
+    public static final Object doSObject(@SuppressWarnings("unused") final SObject receiver,
+        final SSymbol argument) {
       SClass result = Universe.loadClass(argument);
       return result != null ? result : Nil.nilObject;
     }
@@ -65,7 +66,8 @@ public final class SystemPrims {
   @Primitive(className = "System", primitive = "global:put:")
   public abstract static class GlobalPutPrim extends TernaryExpressionNode {
     @Specialization
-    public static final Object doSObject(final SObject receiver, final SSymbol global,
+    public static final Object doSObject(@SuppressWarnings("unused") final SObject receiver,
+        final SSymbol global,
         final Object value) {
       Globals.setGlobal(global, value);
       return value;
@@ -133,7 +135,7 @@ public final class SystemPrims {
 
     @TruffleBoundary
     @Specialization
-    public static final Object doSObject(final SObject receiver) {
+    public static final Object doSObject(@SuppressWarnings("unused") final SObject receiver) {
       System.gc();
       return true;
     }
@@ -144,7 +146,8 @@ public final class SystemPrims {
   public abstract static class LoadFilePrim extends BinaryExpressionNode {
     @TruffleBoundary
     @Specialization
-    public static final Object doSObject(final SObject receiver, final String fileName) {
+    public static final Object doSObject(@SuppressWarnings("unused") final SObject receiver,
+        final String fileName) {
       Path p = Paths.get(fileName);
       try {
         return new String(Files.readAllBytes(p));
@@ -163,7 +166,7 @@ public final class SystemPrims {
   @Primitive(className = "System", primitive = "printStackTrace")
   public abstract static class PrintStackTracePrim extends UnaryExpressionNode {
     @Specialization
-    public static final boolean doSObject(final SObject receiver) {
+    public static final boolean doSObject(@SuppressWarnings("unused") final SObject receiver) {
       printStackTrace(2, null);
       return true;
     }
@@ -230,7 +233,7 @@ public final class SystemPrims {
   @Primitive(className = "System", primitive = "time")
   public abstract static class TimePrim extends UnaryExpressionNode {
     @Specialization
-    public static final long doSObject(final SObject receiver) {
+    public static final long doSObject(@SuppressWarnings("unused") final SObject receiver) {
       return System.currentTimeMillis() - startTime;
     }
   }
@@ -239,7 +242,7 @@ public final class SystemPrims {
   @Primitive(className = "System", primitive = "ticks")
   public abstract static class TicksPrim extends UnaryExpressionNode {
     @Specialization
-    public static final long doSObject(final SObject receiver) {
+    public static final long doSObject(@SuppressWarnings("unused") final SObject receiver) {
       return System.nanoTime() / 1000L - startMicroTime;
     }
   }
@@ -251,7 +254,7 @@ public final class SystemPrims {
     @CompilationFinal private static ThreadMXBean                 threadBean;
 
     @Specialization
-    public static final SArray doSObject(final Object receiver) {
+    public static final SArray doSObject(@SuppressWarnings("unused") final Object receiver) {
       if (gcBeans == null) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
@@ -291,7 +294,7 @@ public final class SystemPrims {
     @CompilationFinal private static CompilationMXBean bean;
 
     @Specialization
-    public static final long doSObject(final Object receiver) {
+    public static final long doSObject(@SuppressWarnings("unused") final Object receiver) {
       if (bean == null) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         bean = ManagementFactory.getCompilationMXBean();

--- a/src/trufflesom/src/trufflesom/primitives/basics/UnequalsPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/UnequalsPrim.java
@@ -29,6 +29,7 @@ public abstract class UnequalsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doBoolean(final boolean left, final SObject right) {
     return true;
   }
@@ -82,36 +83,43 @@ public abstract class UnequalsPrim extends BinaryMsgExprNode {
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doLong(final long left, final String right) {
     return true;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doLong(final long left, final SObject right) {
     return true;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doLong(final long left, final SSymbol right) {
     return true;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doString(final String receiver, final long argument) {
     return true;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doString(final String receiver, final SObject argument) {
     return true;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doSSymbol(final SSymbol receiver, final long argument) {
     return true;
   }
 
   @Specialization
+  @SuppressWarnings("unused")
   public static final boolean doSSymbol(final SSymbol receiver, final SObject argument) {
     return true;
   }

--- a/src/trufflesom/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
@@ -45,9 +45,9 @@ public abstract class AbstractSymbolDispatch extends Node
     this.sourceCoord = wrapped.sourceCoord;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public AbstractSymbolDispatch initialize(final long coord) {
+  @SuppressWarnings("unchecked")
+  public <T extends Node> T initialize(final long coord) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/trufflesom/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
@@ -47,7 +47,7 @@ public abstract class AbstractSymbolDispatch extends Node
 
   @SuppressWarnings("unchecked")
   @Override
-  public AbstractSymbolDispatch initialize(final long sourceCoord) {
+  public AbstractSymbolDispatch initialize(final long coord) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/trufflesom/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/AbstractSymbolDispatch.java
@@ -104,6 +104,7 @@ public abstract class AbstractSymbolDispatch extends Node
 
   @Specialization(limit = "INLINE_CACHE_SIZE",
       guards = {"selector == cachedSelector", "argsArr == null"})
+  @SuppressWarnings("unused")
   public Object doCachedWithoutArgArr(final VirtualFrame frame,
       final Object receiver, final SSymbol selector, final Object argsArr,
       @Cached("selector") final SSymbol cachedSelector,
@@ -115,6 +116,7 @@ public abstract class AbstractSymbolDispatch extends Node
   }
 
   @Specialization(limit = "INLINE_CACHE_SIZE", guards = "selector == cachedSelector")
+  @SuppressWarnings("unused")
   public Object doCached(final VirtualFrame frame,
       final Object receiver, final SSymbol selector, final SArray argsArr,
       @Cached("selector") final SSymbol cachedSelector,
@@ -128,7 +130,8 @@ public abstract class AbstractSymbolDispatch extends Node
 
   @TruffleBoundary
   @Specialization(replaces = "doCachedWithoutArgArr", guards = "argsArr == null")
-  public Object doUncached(final Object receiver, final SSymbol selector, final Object argsArr,
+  public Object doUncached(final Object receiver, final SSymbol selector,
+      @SuppressWarnings("unused") final Object argsArr,
       @Shared("indirect") @Cached final IndirectCallNode call) {
     SInvokable invokable = Types.getClassOf(receiver).lookupInvokable(selector);
 

--- a/src/trufflesom/src/trufflesom/primitives/reflection/GlobalPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/GlobalPrim.java
@@ -22,7 +22,8 @@ public abstract class GlobalPrim extends BinaryExpressionNode {
   @Child private GetGlobalNode getGlobal = new UninitializedGetGlobal(0);
 
   @Specialization
-  public final Object doSObject(final VirtualFrame frame, final SObject receiver,
+  public final Object doSObject(final VirtualFrame frame,
+      @SuppressWarnings("unused") final SObject receiver,
       final SSymbol argument) {
     return getGlobal.getGlobal(frame, argument);
   }

--- a/src/trufflesom/src/trufflesom/primitives/reflection/HasGlobalPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/HasGlobalPrim.java
@@ -19,7 +19,8 @@ public abstract class HasGlobalPrim extends BinaryExpressionNode {
   @Child private HasGlobalNode hasGlobal = new UninitializedHasGlobal(0);
 
   @Specialization
-  public final boolean doSObject(final SObject receiver, final SSymbol argument) {
+  public final boolean doSObject(@SuppressWarnings("unused") final SObject receiver,
+      final SSymbol argument) {
     return hasGlobal.hasGlobal(argument);
   }
 

--- a/src/trufflesom/src/trufflesom/primitives/reflection/MethodPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/MethodPrims.java
@@ -66,6 +66,7 @@ public final class MethodPrims {
 
     @Specialization(guards = "receiver == cachedReceiver",
         limit = "" + AbstractDispatchNode.INLINE_CACHE_SIZE)
+    @SuppressWarnings("unused")
     public static final Object doCached(
         final SInvokable receiver, final Object target, final SArray somArr,
         final Object[] argArr,
@@ -75,6 +76,7 @@ public final class MethodPrims {
     }
 
     @Specialization(replaces = "doCached")
+    @SuppressWarnings("unused")
     public static final Object doUncached(
         final SInvokable receiver, final Object target, final SArray somArr,
         final Object[] argArr,

--- a/src/trufflesom/src/trufflesom/primitives/reflection/ObjectPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/ObjectPrims.java
@@ -115,6 +115,7 @@ public final class ObjectPrims {
 
   @GenerateNodeFactory
   @Primitive(className = "Object", primitive = "class")
+  @SuppressWarnings("unused")
   public abstract static class ClassPrim extends UnaryExpressionNode {
 
     public abstract SClass executeEvaluated(Object rcvr);

--- a/src/trufflesom/src/trufflesom/primitives/reflection/ObjectSizePrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/ObjectSizePrim.java
@@ -26,7 +26,8 @@ public abstract class ObjectSizePrim extends UnaryExpressionNode {
   }
 
   @Specialization
-  public static final long doSAbstractObject(final Object receiver) {
+  public static final long doSAbstractObject(
+      @SuppressWarnings("unused") final Object receiver) {
     return 0; // TODO: allow polymorphism?
   }
 }

--- a/src/trufflesom/src/trufflesom/primitives/reflection/PerformPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/PerformPrim.java
@@ -3,6 +3,7 @@ package trufflesom.primitives.reflection;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
 
 import trufflesom.bdt.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.BinaryExpressionNode;
@@ -16,10 +17,10 @@ public abstract class PerformPrim extends BinaryExpressionNode {
 
   @SuppressWarnings("unchecked")
   @Override
-  public PerformPrim initialize(final long coord) {
+  public <T extends Node> T initialize(final long coord) {
     super.initialize(coord);
     dispatch = AbstractSymbolDispatchNodeGen.create(coord);
-    return this;
+    return (T) this;
   }
 
   @Specialization

--- a/src/trufflesom/src/trufflesom/primitives/reflection/PerformWithArgumentsPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/PerformWithArgumentsPrim.java
@@ -3,6 +3,7 @@ package trufflesom.primitives.reflection;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
 
 import trufflesom.bdt.primitives.Primitive;
@@ -19,10 +20,10 @@ public abstract class PerformWithArgumentsPrim extends TernaryExpressionNode {
 
   @SuppressWarnings("unchecked")
   @Override
-  public PerformWithArgumentsPrim initialize(final long coord) {
+  public <T extends Node> T initialize(final long coord) {
     super.initialize(coord);
     dispatch = AbstractSymbolDispatchNodeGen.create(coord);
-    return this;
+    return (T) this;
   }
 
   @Specialization

--- a/src/trufflesom/src/trufflesom/vm/Universe.java
+++ b/src/trufflesom/src/trufflesom/vm/Universe.java
@@ -380,26 +380,26 @@ public final class Universe {
     objectSystemInitialized = true;
   }
 
-  private static void initializeSystemClass(final SClass systemClass, final SClass superClass,
+  private static void initializeSystemClass(final SClass sysClass, final SClass superClass,
       final String name) {
     // Initialize the superclass hierarchy
     if (superClass != null) {
-      systemClass.setSuperClass(superClass);
-      systemClass.getSOMClass().setSuperClass(superClass.getSOMClass());
+      sysClass.setSuperClass(superClass);
+      sysClass.getSOMClass().setSuperClass(superClass.getSOMClass());
     } else {
-      systemClass.getSOMClass().setSuperClass(classClass);
+      sysClass.getSOMClass().setSuperClass(classClass);
     }
 
     // Initialize the array of instance fields
-    systemClass.setInstanceFields(Arrays.asList());
-    systemClass.getSOMClass().setInstanceFields(Arrays.asList());
+    sysClass.setInstanceFields(Arrays.asList());
+    sysClass.getSOMClass().setInstanceFields(Arrays.asList());
 
     // Initialize the name of the system class
-    systemClass.setName(symbolFor(name));
-    systemClass.getSOMClass().setName(symbolFor(name + " class"));
+    sysClass.setName(symbolFor(name));
+    sysClass.getSOMClass().setName(symbolFor(name + " class"));
 
     // Insert the system class into the dictionary of globals
-    setGlobal(systemClass.getName(), systemClass);
+    setGlobal(sysClass.getName(), sysClass);
   }
 
   private static void loadBlockClass(final int numberOfArguments) {
@@ -462,12 +462,12 @@ public final class Universe {
   }
 
   @TruffleBoundary
-  public static void loadSystemClass(final SClass systemClass) {
+  public static void loadSystemClass(final SClass sysClass) {
     // Load the system class
-    SClass result = loadClass(systemClass.getName(), systemClass);
+    SClass result = loadClass(sysClass.getName(), sysClass);
 
     if (result == null) {
-      throw new IllegalStateException(systemClass.getName().getString()
+      throw new IllegalStateException(sysClass.getName().getString()
           + " class could not be loaded. "
           + "It is likely that the class path has not been initialized properly. "
           + "Please set system property 'system.class.path' or "
@@ -478,7 +478,7 @@ public final class Universe {
   }
 
   @TruffleBoundary
-  private static SClass loadClass(final SSymbol name, final SClass systemClass) {
+  private static SClass loadClass(final SSymbol name, final SClass sysClass) {
     // Skip if classPath is not set
     if (classPath == null) {
       return null;
@@ -489,7 +489,7 @@ public final class Universe {
       try {
         // Load the class from a file and return the loaded class
         SClass result = sourceCompiler.compileClass(
-            cpEntry, name.getString(), systemClass, structuralProbe);
+            cpEntry, name.getString(), sysClass, structuralProbe);
         if (printIR > 0) {
           Disassembler.dump(result.getSOMClass());
           Disassembler.dump(result);

--- a/tests/trufflesom/bdt/inlining/TScope.java
+++ b/tests/trufflesom/bdt/inlining/TScope.java
@@ -1,10 +1,13 @@
 package trufflesom.bdt.inlining;
 
+import com.oracle.truffle.api.nodes.Node;
+
+
 public class TScope implements Scope<TScope, Void> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Variable<?>[] getVariables() {
+  public <T extends Variable<? extends Node>> T[] getVariables() {
     return null;
   }
 

--- a/tests/trufflesom/bdt/testsetup/ExprNode.java
+++ b/tests/trufflesom/bdt/testsetup/ExprNode.java
@@ -16,9 +16,9 @@ public abstract class ExprNode extends Node implements WithSource {
 
   @Override
   @SuppressWarnings("unchecked")
-  public ExprNode initialize(final long coord) {
+  public <T extends Node> T initialize(final long coord) {
     this.sourceCoord = coord;
-    return this;
+    return (T) this;
   }
 
   @Override


### PR DESCRIPTION
- avoids hiding fields, mostly because those are now the linter settings
- remove unused virtual frames, avoids the need for them to be passed into methods that don't use them
- work around javac complains around unchecked generic types
- mark unused arguments as such, to document that I considered them as correctly unused