### PR TITLE
Add more interpreter microbenchmarks

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -132,6 +132,29 @@ benchmark_suites:
             - SomParse: {extra_args: 1, machines: [yuria2]}
             - SomInit:  {extra_args: 10000, machines: [yuria2]}
 
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        invocations: 5
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead:                           {machines: [yuria ]}
+            - ArrayReadConst:                    {machines: [yuria ]}
+            - ArrayWriteConstConst:              {machines: [yuria ]}
+            - BlockSend0ConstReturn:             {machines: [yuria ]}
+            - Const:                             {machines: [yuria ]}
+            - FieldConstWrite:                   {machines: [yuria ]}
+            - FieldRead:                         {machines: [yuria ]}
+            - FieldReadIncWrite:                 {machines: [yuria ]}
+            - FieldReadWrite:                    {machines: [yuria ]}
+            - GlobalRead:                        {machines: [yuria ]}
+            - LocalConstWrite:                   {machines: [yuria ]}
+            - LocalRead:                         {machines: [yuria ]}
+            - LocalReadIncWrite:                 {machines: [yuria ]}
+            - LocalReadWrite:                    {machines: [yuria ]}
+            - SelfSend0:                         {machines: [yuria ]}
+            - SelfSend0BlockConstNonLocalReturn: {machines: [yuria ]}
+
 executors:
     TruffleSOM-interp:
         path: .
@@ -162,7 +185,7 @@ executors:
         executable: som-native-interp-ast
         profiler:
           perf: {}
-          
+
     TruffleSOM-native-interp-bc:
         path: .
         executable: som-native-interp-bc
@@ -181,7 +204,7 @@ executors:
         executable: som-native-interp-ast-ee
         profiler:
           perf: {}
-          
+
     TruffleSOM-native-interp-bc-ee:
         path: .
         executable: som-native-interp-bc-ee
@@ -249,12 +272,14 @@ experiments:
                     - macro-startup
                     - awfy-startup
                     - som-parse
+                    - interpreter
             - TruffleSOM-native-interp-bc:
                 suites:
                     - micro-startup
                     - macro-startup
                     - awfy-startup
                     - som-parse
+                    - interpreter
             - SomSom-native-interp-ast:
                 suites:
                   - micro-somsom
@@ -268,19 +293,21 @@ experiments:
                   - macro-startup
                   - awfy-startup
                   - som-parse
+                  - interpreter
             - TruffleSOM-native-interp-bc-ee:
                 suites:
                   - micro-startup
                   - macro-startup
                   - awfy-startup
                   - som-parse
+                  - interpreter
             - SomSom-native-interp-ast-ee:
                 suites:
                   - micro-somsom
             - SomSom-native-interp-bc-ee:
                 suites:
                   - micro-somsom
-    
+
     profiling:
       description: Profile Native Image Interpreters
       action: profile


### PR DESCRIPTION
This updates the core-lib to https://github.com/SOM-st/SOM/pull/121
and adds the benchmarks to the rebench.conf file.