### PR TITLE
Added zullie1 to GitLab benchmarking setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,10 @@ build:aarch64-test-and-rebench:
     GRAALEE_HOME: /Users/gitlab-runner/.asdf/installs/awfy/oracle-graalvm-ea-jdk-23.0.0-ea.08/Contents/Home
     JAVA_HOME: /Users/gitlab-runner/.asdf/installs/java/temurin-21.0.2+13.0.LTS
 
-  script: 
+  script:
+    - pmset -g live
+    - pmset -g systemstate
+
     - ./som --setup labsjdk
     - mx sforceimport
     - rm libs/jvmci || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,48 @@ build:native-interp-bc:
         put som-native-interp-bc-ee.lz4 incoming/${CI_PIPELINE_ID}/
       EOF
 
+build:aarch64-test-and-rebench:
+  stage: build-and-test
+  tags: [zullie1]
+  variables:
+    ECLIPSE_EXE: /Users/gitlab-runner/.local/eclipse/eclipse
+    GRAALEE_HOME: /Users/gitlab-runner/.asdf/installs/awfy/oracle-graalvm-ea-jdk-23.0.0-ea.08/Contents/Home
+    JAVA_HOME: /Users/gitlab-runner/.asdf/installs/java/temurin-21.0.2+13.0.LTS
+
+  script: 
+    - ./som --setup labsjdk
+    - mx sforceimport
+    - rm libs/jvmci || true
+    - ./som --setup labsjdk
+
+    - mx build
+    - mx --env libgraal build
+    - mx tests-junit
+    - mx tests-som
+    - mx tests-somsom
+    - mx build-native-image-tool
+
+    - mx build-native-obj-test
+    - ./som-obj-storage-tester
+
+    - mx build-native --no-jit -t BC
+    - ./som-native-interp-bc -cp Smalltalk TestSuite/TestHarness.som
+
+    - mx build-native --no-jit -t AST
+    - ./som-native-interp-ast -cp Smalltalk TestSuite/TestHarness.som
+    
+    - mx build-native --no-jit -t BC -g ${GRAALEE_HOME}
+    - ./som-native-interp-bc-ee -cp Smalltalk TestSuite/TestHarness.som
+
+    - mx build-native --no-jit -t AST -g ${GRAALEE_HOME}
+    - ./som-native-interp-ast-ee -cp Smalltalk TestSuite/TestHarness.som
+    
+    - mx tests-nodestats || true
+    - mx tests-coverage || true
+
+    - export PATH=$PATH:/Users/gitlab-runner/Library/Python/3.12/bin
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf
+
 benchmark-y1:
   stage: benchmark
   needs: ["build:native-interp-ast", "build:native-interp-bc"]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "888e43559fc6975c00d3aa7278093d941cb52479",
+                "version": "4186b49c88690386fce71af0c7ad8a5a341d6d8e",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -1,6 +1,6 @@
 suite = {
     "name": "trufflesom",
-    "mxversion": "6.18.0",
+    "mxversion": "7.27.2",
     "versionConflictResolution": "latest",
     "version": "0.0.1",
     "release": False,

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -26,7 +26,7 @@ suite = {
             "urls": [
                 "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.9.3/checkstyle-10.9.3-all.jar"
             ],
-            "sha1": "5bd65d2d7e0eefe73782c072db2066f6832d5b43",
+            "digest": "sha512:57443ea697a02630cea080e78296545586ce2fa40c72d4d5e3d24c511287fc5d460e274ef49a6c0fc386682df248c4306a232b5f13d844c2ef4d1613d5b37e92",
             "licence": "LGPLv21",
         },
         "LABS_JDK": {

--- a/som
+++ b/som
@@ -152,11 +152,17 @@ def get_compiled_graalvm_java_bin(use_libgraal):
   graal_bin = None
 
   mx = find_mx()
-  libgraal_jdk_home = check_output(
+  output = check_output(
     [mx, '--env', 'libgraal' if use_libgraal else 'graal', 'graalvm-home'],
     stderr=STDOUT, cwd=BASE_DIR
   ).decode()
-  return libgraal_jdk_home.strip() + '/bin/java'
+
+  lines = output.strip().split('\n')
+  if not lines:
+    return None
+
+  libgraal_jdk_home = lines[-1].strip()
+  return libgraal_jdk_home + '/bin/java'
 
 
 if args.setup == 'mx':
@@ -241,7 +247,7 @@ if args.use_embedded_graal is True:
   from subprocess import check_output, STDOUT, CalledProcessError
   try:
     java_bin = get_compiled_graalvm_java_bin(args.use_libgraal)
-    if not os.path.isfile(java_bin):
+    if not java_bin or not os.path.isfile(java_bin):
       if args.use_libgraal:
         print("The use of LibGraal was requested, but it does not seem to be available.")
         print("To build it, please run `mx --env libgraal build`")

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/GenericMessageSendNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/GenericMessageSendNode.java
@@ -2,10 +2,8 @@ package trufflesom.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.ProbeNode;
-import com.oracle.truffle.api.nodes.NodeCost;
 
 import trufflesom.interpreter.nodes.dispatch.AbstractDispatchNode;
-import trufflesom.interpreter.nodes.dispatch.DispatchChain.Cost;
 import trufflesom.vm.VmSettings;
 import trufflesom.vmobjects.SSymbol;
 
@@ -40,11 +38,6 @@ public class GenericMessageSendNode extends AbstractMessageSendNode {
   @Override
   public String toString() {
     return "GMsgSend(" + selector.getString() + ")";
-  }
-
-  @Override
-  public NodeCost getCost() {
-    return Cost.getCost(dispatchNode);
   }
 
   @Override

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/GenericMessageSendNodeWrapper.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/GenericMessageSendNodeWrapper.java
@@ -3,7 +3,6 @@ package trufflesom.interpreter.nodes;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableNode.WrapperNode;
 import com.oracle.truffle.api.instrumentation.ProbeNode;
-import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 
 
@@ -27,11 +26,6 @@ final class GenericMessageSendNodeWrapper extends GenericMessageSendNode
   @Override
   public ProbeNode getProbeNode() {
     return probeNode;
-  }
-
-  @Override
-  public NodeCost getCost() {
-    return NodeCost.NONE;
   }
 
   @Override

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/SequenceNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/SequenceNode.java
@@ -26,8 +26,6 @@ import com.oracle.truffle.api.instrumentation.StandardTags.ExpressionTag;
 import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.NodeCost;
-import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.source.Source;
 
 import trufflesom.bdt.primitives.nodes.PreevaluatedExpression;
@@ -35,7 +33,6 @@ import trufflesom.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
 import trufflesom.interpreter.nodes.dispatch.AbstractDispatchNode;
 
 
-@NodeInfo(cost = NodeCost.NONE)
 public final class SequenceNode extends NoPreEvalExprNode {
   @Children private final ExpressionNode[] expressions;
 

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/dispatch/DispatchChain.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/dispatch/DispatchChain.java
@@ -1,23 +1,5 @@
 package trufflesom.interpreter.nodes.dispatch;
 
-import com.oracle.truffle.api.nodes.NodeCost;
-
-
 public interface DispatchChain {
   int lengthOfDispatchChain();
-
-  class Cost {
-    public static NodeCost getCost(final DispatchChain chain) {
-      int dispatchChain = chain.lengthOfDispatchChain();
-      if (dispatchChain == 0) {
-        return NodeCost.UNINITIALIZED;
-      } else if (dispatchChain == 1) {
-        return NodeCost.MONOMORPHIC;
-      } else if (dispatchChain <= AbstractDispatchNode.INLINE_CACHE_SIZE) {
-        return NodeCost.POLYMORPHIC;
-      } else {
-        return NodeCost.MEGAMORPHIC;
-      }
-    }
-  }
 }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/literals/LiteralNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/literals/LiteralNode.java
@@ -22,8 +22,6 @@
 package trufflesom.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.nodes.NodeCost;
-import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.source.Source;
 
 import trufflesom.bdt.inlining.nodes.Inlinable;
@@ -40,7 +38,6 @@ import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SBlock;
 
 
-@NodeInfo(cost = NodeCost.NONE)
 public abstract class LiteralNode extends ExpressionNode
     implements PreevaluatedExpression, Inlinable<MethodGenerationContext> {
   public static ExpressionNode create(final Object literal) {

--- a/src/trufflesom/src/trufflesom/primitives/reflection/PerformWithArgumentsPrim.java
+++ b/src/trufflesom/src/trufflesom/primitives/reflection/PerformWithArgumentsPrim.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.nodes.NodeCost;
 
 import trufflesom.bdt.primitives.Primitive;
 import trufflesom.interpreter.nodes.nary.TernaryExpressionNode;
@@ -30,10 +29,5 @@ public abstract class PerformWithArgumentsPrim extends TernaryExpressionNode {
   public final Object doObject(final VirtualFrame frame,
       final Object receiver, final SSymbol selector, final SArray argsArr) {
     return dispatch.executeDispatch(frame, receiver, selector, argsArr);
-  }
-
-  @Override
-  public NodeCost getCost() {
-    return dispatch.getCost();
   }
 }

--- a/tests/trufflesom/supernodes/StringEqualsTests.java
+++ b/tests/trufflesom/supernodes/StringEqualsTests.java
@@ -1,7 +1,7 @@
 package trufflesom.supernodes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -1,8 +1,8 @@
 package trufflesom.tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;

--- a/tests/trufflesom/tests/OptimizeTrivialTests.java
+++ b/tests/trufflesom/tests/OptimizeTrivialTests.java
@@ -1,10 +1,10 @@
 package trufflesom.tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static trufflesom.vm.SymbolTable.symSelf;
 import static trufflesom.vm.SymbolTable.symbolFor;
@@ -541,7 +541,7 @@ public class OptimizeTrivialTests extends TruffleTestSetup {
     return objClazz;
   }
 
-  private SPrimitive constructDummyNewPrim(final Source s) {
+  private static SPrimitive constructDummyNewPrim(final Source s) {
     ExpressionNode newPrim = NewObjectPrimFactory.create(null);
     SSymbol symNew = symbolFor("new");
     Primitive primMethodNode = new Primitive("new", s, 1, newPrim, newPrim);


### PR DESCRIPTION
This adds the M2 machine for benchmarking.

Other changes:
 - update Truffle
 - removes use of `NodeCost` since that was/is going to be deprecated in Truffle 24.1
 - use `MatcherAssert.assertThat()` to handle deprecation
 - request use of mx version 7.27.2
 - use sha512 checksum for Checkstyle dependency