### PR TITLE
Fix issues with PE: move context level for non-local returns to bytecode node

### DIFF
--- a/src/trufflesom/src/trufflesom/compiler/bc/BytecodeGenerator.java
+++ b/src/trufflesom/src/trufflesom/compiler/bc/BytecodeGenerator.java
@@ -146,7 +146,7 @@ public final class BytecodeGenerator {
   }
 
   public static void emitRETURNNONLOCAL(final BytecodeMethodGenContext mgenc) {
-    emit2(mgenc, RETURN_NON_LOCAL, mgenc.getMaxContextLevel(), 0);
+    emit1(mgenc, RETURN_NON_LOCAL, 0);
   }
 
   public static void emitRETURNFIELD(final BytecodeMethodGenContext mgenc, final byte idx) {

--- a/src/trufflesom/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
+++ b/src/trufflesom/src/trufflesom/compiler/bc/BytecodeMethodGenContext.java
@@ -329,7 +329,7 @@ public class BytecodeMethodGenContext extends MethodGenerationContext {
     BackJump[] loops = inlinedLoops.toArray(new BackJump[0]);
 
     return new BytecodeLoopNode(bytecodes, locals.size(), literalsArr, maxStackDepth,
-        frameOnStackMarkerIndex, loops);
+        frameOnStackMarkerIndex, loops, getMaxContextLevel());
   }
 
   public byte[] getBytecodeArray() {

--- a/src/trufflesom/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/src/trufflesom/compiler/bc/Disassembler.java
@@ -320,7 +320,9 @@ public class Disassembler {
         }
 
         case RETURN_NON_LOCAL: {
-          Universe.errorPrintln("context: " + bytecodes.get(b + 1));
+          if (m != null) {
+            Universe.errorPrintln("context: " + m.getContextLevel());
+          }
           break;
         }
 

--- a/src/trufflesom/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -297,7 +297,7 @@ public class Bytecodes {
         2, // SEND
         2, // SUPER_SEND
         1, // RETURN_LOCAL
-        2, // RETURN_NON_LOCAL
+        1, // RETURN_NON_LOCAL
         1, // RETURN_SELF
 
         1, // RETURN_FIELD_0

--- a/src/trufflesom/src/trufflesom/primitives/basics/BlockPrims.java
+++ b/src/trufflesom/src/trufflesom/primitives/basics/BlockPrims.java
@@ -49,7 +49,6 @@ public abstract class BlockPrims {
     }
   }
 
-  @ReportPolymorphism
   @GenerateNodeFactory
   @GenerateWrapper
   @Primitive(className = "Block", primitive = "value")
@@ -100,7 +99,6 @@ public abstract class BlockPrims {
     }
   }
 
-  @ReportPolymorphism
   @GenerateWrapper
   @GenerateNodeFactory
   @Primitive(className = "Block2", primitive = "value:", selector = "value:", inParser = false,
@@ -146,7 +144,6 @@ public abstract class BlockPrims {
     }
   }
 
-  @ReportPolymorphism
   @GenerateNodeFactory
   @Primitive(className = "Block3", primitive = "value:with:", selector = "value:with:",
       inParser = false, receiverType = SBlock.class)

--- a/tests/trufflesom/tests/BytecodeBlockTests.java
+++ b/tests/trufflesom/tests/BytecodeBlockTests.java
@@ -192,12 +192,12 @@ public class BytecodeBlockTests extends BytecodeTestSetup {
         + " #end\n"
         + "]");
 
-    assertEquals(17, bytecodes.length);
+    assertEquals(16, bytecodes.length);
     check(bytecodes,
         t(5, Bytecodes.SEND),
-        new BC(jumpBytecode, 6),
+        new BC(jumpBytecode, 5),
         Bytecodes.PUSH_ARG1,
-        new BC(Bytecodes.RETURN_NON_LOCAL, 1),
+        Bytecodes.RETURN_NON_LOCAL,
         Bytecodes.POP);
   }
 


### PR DESCRIPTION
PE fails with multiple values for the Queens benchmark.
This is a work around, but works for the moment.

Not sure what the underlying issue is. It's surprising and indicates something else is wrong.

Also fix some DSL issues around polymorphism.