### PR TITLE
Update LabsJDK and add the various libraries needed by Truffle these days

### DIFF
--- a/mx.trufflesom/mx_trufflesom.py
+++ b/mx.trufflesom/mx_trufflesom.py
@@ -219,7 +219,6 @@ def build_native_obj_test(args, **kwargs):
     svm_path = get_svm_path()
     cmd = [
         "native-image",
-        "--macro:truffle",
         "--no-fallback",
         "--initialize-at-build-time",
         "-H:+ReportExceptionStackTraces",

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -30,7 +30,7 @@ suite = {
             "licence": "LGPLv21",
         },
         "LABS_JDK": {
-            "id": "labsjdk-ce-21",
+            "id": "labsjdk-ce-latest",
             # I am just using the suite.py to store the info
             # so but manage it in mx_trufflesom.py
             "path": ".",

--- a/som
+++ b/som
@@ -295,7 +295,11 @@ MODULE_PATH_ENTRIES = [
   TRUFFLE_DIR + '/sdk/mxbuild/dists/polyglot.jar',
   TRUFFLE_DIR + '/sdk/mxbuild/dists/word.jar',
   TRUFFLE_DIR + '/sdk/mxbuild/dists/nativeimage.jar',
-  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-api.jar']
+  TRUFFLE_DIR + '/sdk/mxbuild/dists/jniutils.jar',
+  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-json.jar',
+  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-compiler.jar',
+  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-api.jar',
+  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-runtime.jar']
 
 SOM_ARGS = ['--module', 'trufflesom/trufflesom.Launcher']
 


### PR DESCRIPTION
As I understand it, the extra libraries are used for the Truffle Unchained mode.