### PR TITLE
Fix GRAAL_HOME/JVMCI_BIN handling in `som` and fix field access implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 build
 src_gen
 user-dict.txt
+/bin/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,7 +212,7 @@ benchmark-y4:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    # - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling m:yuria4
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling m:yuria4 || true
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf m:yuria4
   after_script:

--- a/som
+++ b/som
@@ -12,6 +12,8 @@ JVMCI_BIN   = os.getenv('JVMCI_BIN',  None)
 GRAAL_HOME  = os.getenv('GRAAL_HOME',  None)
 GRAAL_FLAGS = os.getenv('GRAAL_FLAGS', None)
 
+EXPLICITLY_SET_GRAALVM = JVMCI_BIN is not None or GRAAL_HOME is not None
+
 ##
 ## Defining Argument Parsing
 ##
@@ -84,9 +86,8 @@ parser.add_argument('-C', '--no-compilation', help='disable Truffle compilation'
                     dest='no_compilation', action='store_true', default=False)
 parser.add_argument('-G', '--interpreter', help='run without Graal',
                     dest='interpreter', action='store_true', default=False)
-parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal. When set, USE_EMBEDDED_GRAAL, JVMCI_BIN, or GRAAL_HOME are used.',
-                    dest='use_embedded_graal', action='store', nargs='?',
-                    const=False, default=True)
+parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal and use JVMCI_BIN or GRAAL_HOME.',
+                    dest='use_embedded_graal', action='store_false', default=True)
 parser.add_argument('-LG', '--no-libgraal', help='run without using the embedded libgraal, which is a precompiled Graal',
                     dest='use_libgraal', action='store_false', default=True)
 parser.add_argument('-X', '--java-interpreter', help='run without Graal, and only the Java interpreter',
@@ -215,9 +216,6 @@ if args.java_interpreter:
 if args.flight_recorder:
     args.interpreter = True
 
-if args.interpreter:
-    args.use_embedded_graal = False
-
 # Handle executable names
 if sys.argv[0].endswith('fast'):
     args.assert_ = False
@@ -230,23 +228,14 @@ if sys.argv[0].endswith('debug'):
 # Determine JVM to be used
 java_bin = None
 
-# try local JVMCI, which ant already needed
-local_jvmci_bin = BASE_DIR + '/libs/jvmci'
-local_jvmci_bin += '/bin/java'
-if os.path.isfile(local_jvmci_bin):
-  java_bin = local_jvmci_bin
-
-if not java_bin and JAVA_HOME:
-  java_bin = JAVA_HOME + '/bin/java'
-
-if not java_bin:
-  java_bin = "java"
-
-
-if args.use_embedded_graal is True:
+if args.use_embedded_graal and not EXPLICITLY_SET_GRAALVM:
   from subprocess import check_output, STDOUT, CalledProcessError
   try:
-    java_bin = get_compiled_graalvm_java_bin(args.use_libgraal)
+    if args.interpreter:
+      java_bin = BASE_DIR + "/libs/jvmci/bin/java"
+    else:
+      java_bin = get_compiled_graalvm_java_bin(args.use_libgraal)
+
     if not java_bin or not os.path.isfile(java_bin):
       if args.use_libgraal:
         print("The use of LibGraal was requested, but it does not seem to be available.")
@@ -260,21 +249,28 @@ if args.use_embedded_graal is True:
     print(e.output.decode())
     sys.exit(1)
 else:
-    if args.use_embedded_graal is not False:
-      if not os.path.isdir(args.use_embedded_graal):
-        print("USE_EMBEDDED_GRAAL does not seem to exist: " + args.use_embedded_graal)
-        sys.exit(1)
-
-      if not os.path.isfile(args.use_embedded_graal + '/bin/java'):
-        print("USE_EMBEDDED_GRAAL did not seem to have a bin/java: " + args.use_embedded_graal)
-        sys.exit(1)
-
-      java_bin = args.use_embedded_graal + '/bin/java'
-    if not java_bin and JVMCI_BIN:
+    args.use_embedded_graal = False
+    used_var = None
+    if JVMCI_BIN:
       java_bin = JVMCI_BIN
-    if not java_bin and GRAAL_HOME and os.path.isfile(GRAAL_HOME + '/bin/java'):
-      java_bin = GRAAL_HOME + '/bin/java'
+      used_var = 'JVMCI_BIN'
 
+    if GRAAL_HOME:
+      java_bin = GRAAL_HOME + '/bin/java'
+      used_var = 'GRAAL_HOME'
+
+    if not java_bin and JAVA_HOME:
+        java_bin = JAVA_HOME + '/bin/java'
+
+    if not java_bin and os.path.isfile(BASE_DIR + "/libs/jvmci/bin/java"):
+        java_bin = BASE_DIR + "/libs/jvmci/bin/java"
+
+    if java_bin and not os.path.isfile(java_bin):
+      print("Used " + used_var + " to find Java binary (" + java_bin + "), but it does not exist.")
+      sys.exit(1)
+
+    if not java_bin:
+        java_bin = "java"
 
 ##
 ## Defining Necessary Parameter Bits

--- a/src/trufflesom/src/trufflesom/compiler/Lexer.java
+++ b/src/trufflesom/src/trufflesom/compiler/Lexer.java
@@ -114,11 +114,15 @@ public class Lexer {
   }
 
   public String getCurrentLine() {
+    int next = state.lastLineEnd + 1;
     int endLine = content.indexOf("\n", state.lastLineEnd + 1);
     if (endLine == -1) {
       endLine = content.length() - 1;
     }
-    return content.substring(state.lastLineEnd + 1, endLine);
+    if (next > endLine) {
+      return "";
+    }
+    return content.substring(next, endLine);
   }
 
   private Symbol doSym() {

--- a/src/trufflesom/src/trufflesom/vm/Classes.java
+++ b/src/trufflesom/src/trufflesom/vm/Classes.java
@@ -80,7 +80,9 @@ public class Classes {
 
   public static SClass getBlockClass(final int numberOfArguments) {
     SClass result = blockClasses[numberOfArguments];
-    assert result != null || numberOfArguments == 0;
+    assert result != null || numberOfArguments == 0 : "Failed to getBlockClass. result: "
+        + result
+        + " numberOfArguments: " + numberOfArguments;
     return result;
   }
 

--- a/src/trufflesom/src/trufflesom/vmobjects/SObject.java
+++ b/src/trufflesom/src/trufflesom/vmobjects/SObject.java
@@ -168,6 +168,10 @@ public class SObject extends SAbstractObject {
     }
   }
 
+  public final boolean hasOutdatedLayout() {
+    return !objectLayout.isValid();
+  }
+
   public final boolean updateLayoutToMatchClass() {
     ObjectLayout layoutAtClass = clazz.getLayoutForInstances();
     assert layoutAtClass.getNumberOfFields() == objectLayout.getNumberOfFields();
@@ -242,7 +246,7 @@ public class SObject extends SAbstractObject {
     primitiveUsedMap |= mask;
   }
 
-  private StorageLocation getLocation(final long index) {
+  public StorageLocation getLocation(final long index) {
     StorageLocation location = objectLayout.getStorageLocation(index);
     assert location != null;
     return location;


### PR DESCRIPTION
The launcher wasn't properly using the environment variables.
Think the changed version is more what I would expect.

Field access in FieldAccessorNode had a few issues:
 - most importantly, they never went to a megamorphic case, so, would have endless chains
 - there was unnecessary re-specialization when encountering objects with an outdated object layout

This change should be performance neutral, but may not be: https://rebench.dev/TruffleSOM/compare/1bc7250d08356fe9ea7cb8525064231cd39c4e4e..58b446652be9a6281b462f9b8cea1c8c2b5bc5ec