### PR TITLE
Fix style gate on GitHub Actions and use only single frameType profile object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Download Eclipse
         run: |
           export ECLIPSE_TAR=eclipse.tar.gz
-          export ECLIPSE_URL=https://ftp.fau.de/eclipse/eclipse/downloads/drops4/R-4.30-202312010110/eclipse-SDK-4.30-linux-gtk-x86_64.tar.gz
+          export ECLIPSE_URL=https://archive.eclipse.org/eclipse/downloads/drops4/R-4.30-202312010110/eclipse-SDK-4.30-linux-gtk-x86_64.tar.gz
           curl -L ${ECLIPSE_URL} -o ${ECLIPSE_TAR}
           tar --warning=no-unknown-keyword -C ${GITHUB_WORKSPACE}/.. -xzf ${ECLIPSE_TAR}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           curl -L ${ECLIPSE_URL} -o ${ECLIPSE_TAR}
           tar --warning=no-unknown-keyword -C ${GITHUB_WORKSPACE}/.. -xzf ${ECLIPSE_TAR}
 
+      - name: Install Black and PyLint
+        run: |
+          pip install black pylint==2.4
+
       - name: Run Style Gate
         run: |
           export ECLIPSE_EXE=${GITHUB_WORKSPACE}/../eclipse/eclipse

--- a/mx.trufflesom/mx_trufflesom.py
+++ b/mx.trufflesom/mx_trufflesom.py
@@ -124,19 +124,21 @@ def build_native_image_tool(args, **kwargs):
     svm_path = get_svm_path()
     mx.run_mx(["build"], svm_path)
 
+
 BASE_DIR = suite.dir
-TRUFFLE_DIR = BASE_DIR + '/../graal'
+TRUFFLE_DIR = BASE_DIR + "/../graal"
 
 MODULE_PATH_ENTRIES = [
-  BASE_DIR + '/mxbuild/dists/trufflesom.jar',
-  TRUFFLE_DIR + '/sdk/mxbuild/dists/graal-sdk.jar',
-  TRUFFLE_DIR + '/sdk/mxbuild/dists/collections.jar',
-  TRUFFLE_DIR + '/sdk/mxbuild/dists/polyglot.jar',
-  TRUFFLE_DIR + '/sdk/mxbuild/dists/word.jar',
-  TRUFFLE_DIR + '/sdk/mxbuild/dists/jniutils.jar',
-  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-runtime.jar',
-  TRUFFLE_DIR + '/substratevm/mxbuild/dists/truffle-runtime-svm.jar',
-  TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-api.jar']
+    BASE_DIR + "/mxbuild/dists/trufflesom.jar",
+    TRUFFLE_DIR + "/sdk/mxbuild/dists/graal-sdk.jar",
+    TRUFFLE_DIR + "/sdk/mxbuild/dists/collections.jar",
+    TRUFFLE_DIR + "/sdk/mxbuild/dists/polyglot.jar",
+    TRUFFLE_DIR + "/sdk/mxbuild/dists/word.jar",
+    TRUFFLE_DIR + "/sdk/mxbuild/dists/jniutils.jar",
+    TRUFFLE_DIR + "/truffle/mxbuild/dists/truffle-runtime.jar",
+    TRUFFLE_DIR + "/substratevm/mxbuild/dists/truffle-runtime-svm.jar",
+    TRUFFLE_DIR + "/truffle/mxbuild/dists/truffle-api.jar",
+]
 
 
 @mx.command(
@@ -173,7 +175,8 @@ def build_native(args, **kwargs):
         "--no-fallback",
         "--link-at-build-time",
         "-H:+ReportExceptionStackTraces",
-        "-H:+UnlockExperimentalVMOptions", "-H:-DeleteLocalSymbols",
+        "-H:+UnlockExperimentalVMOptions",
+        "-H:-DeleteLocalSymbols",
         "-Dsom.interp=" + opt.type,
     ]
 
@@ -197,12 +200,13 @@ def build_native(args, **kwargs):
     # -H:+EnforceMaxRuntimeCompileMethods
 
     cmd += [
-        '--module-path', ':'.join(MODULE_PATH_ENTRIES),
+        "--module-path",
+        ":".join(MODULE_PATH_ENTRIES),
         "-o",
         suite.dir + output_name,
     ]
 
-    if opt.use_g1 and opt.graalvm and os.uname().sysname != 'Darwin':
+    if opt.use_g1 and opt.graalvm and os.uname().sysname != "Darwin":
         cmd += ["--gc=G1"]
 
     cmd += ["trufflesom.Launcher"]

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -88,7 +88,9 @@ suite = {
                 },
             },
             "dependencies": ["trufflesom"],
-            "distDependencies": ["truffle:TRUFFLE_API"], # , "tools:TRUFFLE_COVERAGE", "tools:TRUFFLE_PROFILER"
+            "distDependencies": [
+                "truffle:TRUFFLE_API"
+            ],  # , "tools:TRUFFLE_COVERAGE", "tools:TRUFFLE_PROFILER"
         },
         "TRUFFLESOM_TEST": {
             "description": "TruffleSOM JUnit Tests",

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/ContextualNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/ContextualNode.java
@@ -31,7 +31,7 @@ import trufflesom.vmobjects.SBlock;
 
 public abstract class ContextualNode extends NoPreEvalExprNode {
 
-  private static final ValueProfile frameType = ValueProfile.createClassProfile();
+  public static final ValueProfile frameType = ValueProfile.createClassProfile();
 
   protected final int contextLevel;
 

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1,5 +1,6 @@
 package trufflesom.interpreter.nodes.bc;
 
+import static trufflesom.interpreter.nodes.ContextualNode.frameType;
 import static trufflesom.compiler.bc.BytecodeGenerator.emit1;
 import static trufflesom.compiler.bc.BytecodeGenerator.emit3;
 import static trufflesom.compiler.bc.BytecodeGenerator.emit3WithDummy;
@@ -147,8 +148,7 @@ import trufflesom.vmobjects.SSymbol;
 
 
 public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReference {
-  private static final ValueProfile frameType = ValueProfile.createClassProfile();
-  private static final LiteralNode  dummyNode = new IntegerLiteralNode(0);
+  private static final LiteralNode dummyNode = new IntegerLiteralNode(0);
 
   @CompilationFinal(dimensions = 1) private final byte[]   bytecodesField;
   @CompilationFinal(dimensions = 1) private final Object[] literalsAndConstantsField;


### PR DESCRIPTION
This PR is mostly GHA maintenance, but also has a code change:

 - have only a single frameType profile object

Maintenance:

 - change Eclipse download URL since mirrors don't have the version any more (newer versions do get stuck on Github Actions for unknown reason)
 - apply black formatting to mx suite
 - setup black and pylint on GitHub actions