### PR TITLE
Add Square supernodes

### DIFF
--- a/src/trufflesom/src/trufflesom/compiler/ParserAst.java
+++ b/src/trufflesom/src/trufflesom/compiler/ParserAst.java
@@ -35,7 +35,9 @@ import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.interpreter.nodes.FieldNode;
 import trufflesom.interpreter.nodes.FieldNode.FieldReadNode;
 import trufflesom.interpreter.nodes.GlobalNode;
+import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableReadNode;
 import trufflesom.interpreter.nodes.MessageSendNode;
+import trufflesom.interpreter.nodes.NonLocalVariableNode.NonLocalVariableReadNode;
 import trufflesom.interpreter.nodes.SequenceNode;
 import trufflesom.interpreter.nodes.literals.BlockNode;
 import trufflesom.interpreter.nodes.literals.BlockNode.BlockNodeWithContext;
@@ -45,7 +47,9 @@ import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
 import trufflesom.interpreter.nodes.literals.LiteralNode;
 import trufflesom.interpreter.supernodes.IntIncrementNodeGen;
 import trufflesom.interpreter.supernodes.LocalFieldStringEqualsNode;
+import trufflesom.interpreter.supernodes.LocalVariableSquareNodeGen;
 import trufflesom.interpreter.supernodes.NonLocalFieldStringEqualsNode;
+import trufflesom.interpreter.supernodes.NonLocalVariableSquareNodeGen;
 import trufflesom.interpreter.supernodes.StringEqualsNodeGen;
 import trufflesom.primitives.Primitives;
 import trufflesom.vm.Globals;
@@ -305,6 +309,20 @@ public class ParserAst extends Parser<MethodGenerationContext> {
           }
 
           return StringEqualsNodeGen.create(s, operand).initialize(coordWithL);
+        }
+      }
+    } else if (binSelector.equals("*")) {
+      if (receiver instanceof LocalVariableReadNode rcvr
+          && operand instanceof LocalVariableReadNode op) {
+        if (rcvr.isSameLocal(op)) {
+          return LocalVariableSquareNodeGen.create(rcvr.getLocal()).initialize(coordWithL);
+        }
+      } else if (receiver instanceof NonLocalVariableReadNode rcvr
+          && operand instanceof NonLocalVariableReadNode op) {
+        if (rcvr.isSameLocal(op)) {
+          assert rcvr.getContextLevel() == op.getContextLevel();
+          return NonLocalVariableSquareNodeGen.create(
+              rcvr.getContextLevel(), rcvr.getLocal()).initialize(coordWithL);
         }
       }
     }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/LocalVariableNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/LocalVariableNode.java
@@ -22,7 +22,7 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
   // TODO: We currently assume that there is a 1:1 mapping between lexical contexts
   // and frame descriptors, which is apparently not strictly true anymore in Truffle 1.0.0.
   // Generally, we also need to revise everything in this area and address issue SOMns#240.
-  private LocalVariableNode(final Local local) {
+  protected LocalVariableNode(final Local local) {
     this.local = local;
     this.slotIndex = local.getIndex();
   }
@@ -44,6 +44,10 @@ public abstract class LocalVariableNode extends NoPreEvalExprNode
 
     public LocalVariableReadNode(final LocalVariableReadNode node) {
       this(node.local);
+    }
+
+    public boolean isSameLocal(final LocalVariableNode node) {
+      return local.equals(node.local);
     }
 
     @Specialization(guards = "isUninitialized(frame)")

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/NonLocalVariableNode.java
@@ -24,10 +24,14 @@ public abstract class NonLocalVariableNode extends ContextualNode
   protected final int   slotIndex;
   protected final Local local;
 
-  private NonLocalVariableNode(final int contextLevel, final Local local) {
+  protected NonLocalVariableNode(final int contextLevel, final Local local) {
     super(contextLevel);
     this.local = local;
     this.slotIndex = local.getIndex();
+  }
+
+  public boolean isSameLocal(final NonLocalVariableNode node) {
+    return local.equals(node.local);
   }
 
   @Override

--- a/src/trufflesom/src/trufflesom/interpreter/supernodes/LocalVariableReadSquareWriteNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/supernodes/LocalVariableReadSquareWriteNode.java
@@ -1,0 +1,84 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor.ScopeElement;
+import trufflesom.compiler.Variable.Local;
+import trufflesom.interpreter.nodes.LocalVariableNode;
+
+
+public abstract class LocalVariableReadSquareWriteNode extends LocalVariableNode {
+
+  protected final Local readLocal;
+  protected final int   readIndex;
+
+  public LocalVariableReadSquareWriteNode(final Local writeLocal, final Local readLocal) {
+    super(writeLocal);
+    this.readLocal = readLocal;
+    this.readIndex = readLocal.getIndex();
+  }
+
+  @Specialization(guards = {"isLongKind(frame)", "frame.isLong(readIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final long writeLong(final VirtualFrame frame) throws FrameSlotTypeException {
+    long current = frame.getLong(readIndex);
+    long result = Math.multiplyExact(current, current);
+    frame.setLong(slotIndex, result);
+    return result;
+  }
+
+  @Specialization(guards = {"isDoubleKind(frame)", "frame.isDouble(readIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final double writeDouble(final VirtualFrame frame) throws FrameSlotTypeException {
+    double current = frame.getDouble(readIndex);
+    double result = current * current;
+    frame.setDouble(slotIndex, result);
+    return result;
+  }
+
+  // uses frame to make sure guard is not converted to assertion
+  protected final boolean isLongKind(final VirtualFrame frame) {
+    FrameDescriptor descriptor = local.getFrameDescriptor();
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Long) {
+      return true;
+    }
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Illegal) {
+      descriptor.setSlotKind(slotIndex, FrameSlotKind.Long);
+      return true;
+    }
+    return false;
+  }
+
+  // uses frame to make sure guard is not converted to assertion
+  protected final boolean isDoubleKind(final VirtualFrame frame) {
+    FrameDescriptor descriptor = local.getFrameDescriptor();
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Double) {
+      return true;
+    }
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Illegal) {
+      descriptor.setSlotKind(slotIndex, FrameSlotKind.Double);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+    ScopeElement seWrite = inliner.getAdaptedVar(local);
+    ScopeElement seRead = inliner.getAdaptedVar(readLocal);
+
+    assert seWrite.contextLevel == seRead.contextLevel;
+
+    if (seWrite.var != local || seWrite.contextLevel < 0) {
+      assert seRead.var != readLocal || seRead.contextLevel < 0;
+      replace(seWrite.var.getReadSquareWriteNode(seWrite.contextLevel, sourceCoord,
+          (Local) seRead.var, seRead.contextLevel));
+    } else {
+      assert 0 == seWrite.contextLevel;
+    }
+  }
+}

--- a/src/trufflesom/src/trufflesom/interpreter/supernodes/LocalVariableSquareNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/supernodes/LocalVariableSquareNode.java
@@ -1,0 +1,41 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor.ScopeElement;
+import trufflesom.compiler.Variable.Local;
+import trufflesom.interpreter.nodes.LocalVariableNode;
+
+
+public abstract class LocalVariableSquareNode extends LocalVariableNode {
+
+  public LocalVariableSquareNode(final Local variable) {
+    super(variable);
+  }
+
+  @Specialization(guards = {"frame.isLong(slotIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final long doLong(final VirtualFrame frame) throws FrameSlotTypeException {
+    long value = frame.getLong(slotIndex);
+    return Math.multiplyExact(value, value);
+  }
+
+  @Specialization(guards = {"frame.isDouble(slotIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final double doDouble(final VirtualFrame frame) throws FrameSlotTypeException {
+    double value = frame.getDouble(slotIndex);
+    return value * value;
+  }
+
+  @Override
+  public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+    ScopeElement se = inliner.getAdaptedVar(local);
+    if (se.var != local || se.contextLevel < 0) {
+      replace(se.var.getSquareNode(se.contextLevel, sourceCoord));
+    } else {
+      assert 0 == se.contextLevel;
+    }
+  }
+}

--- a/src/trufflesom/src/trufflesom/interpreter/supernodes/NonLocalVariableReadSquareWriteNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/supernodes/NonLocalVariableReadSquareWriteNode.java
@@ -1,0 +1,148 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameSlotKind;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor.ScopeElement;
+import trufflesom.compiler.Variable.Local;
+import trufflesom.interpreter.nodes.NonLocalVariableNode;
+import trufflesom.vmobjects.SBlock;
+
+
+public abstract class NonLocalVariableReadSquareWriteNode extends NonLocalVariableNode {
+
+  protected final Local readLocal;
+  protected final int   readIndex;
+  protected final int   readContextLevel;
+
+  public NonLocalVariableReadSquareWriteNode(final int writeContextLevel,
+      final Local writeLocal,
+      final Local readLocal, final int readContextLevel) {
+    super(writeContextLevel, writeLocal);
+    this.readLocal = readLocal;
+    this.readIndex = readLocal.getIndex();
+    this.readContextLevel = readContextLevel;
+  }
+
+  @ExplodeLoop
+  protected final Frame determineReadContext(final VirtualFrame frame) {
+    if (readContextLevel == 0) {
+      return frame;
+    }
+
+    SBlock self = (SBlock) frame.getArguments()[0];
+    int i = readContextLevel - 1;
+
+    while (i > 0) {
+      self = (SBlock) self.getOuterSelf();
+      i--;
+    }
+
+    // Graal needs help here to see that this is always a MaterializedFrame
+    // so, we record explicitly a class profile
+    return frameType.profile(self.getContext());
+  }
+
+  @Specialization(
+      guards = {"isLongKind(ctx)", "ctx.isLong(readIndex)",
+          "contextLevel == readContextLevel"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final long writeLongSameContext(final VirtualFrame frame,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    long current = ctx.getLong(readIndex);
+    long result = Math.multiplyExact(current, current);
+
+    ctx.setLong(slotIndex, result);
+
+    return result;
+  }
+
+  @Specialization(guards = {"isLongKind(writeCtx)", "readCtx.isLong(readIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final long writeLong(final VirtualFrame frame,
+      @Bind("determineContext(frame)") final MaterializedFrame writeCtx,
+      @Bind("determineReadContext(frame)") final Frame readCtx)
+      throws FrameSlotTypeException {
+    long current = readCtx.getLong(readIndex);
+    long result = Math.multiplyExact(current, current);
+
+    writeCtx.setLong(slotIndex, result);
+
+    return result;
+  }
+
+  @Specialization(
+      guards = {"isDoubleKind(ctx)", "ctx.isDouble(readIndex)",
+          "contextLevel == readContextLevel"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final double writeDoubleSameContext(final VirtualFrame frame,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    double current = ctx.getDouble(readIndex);
+    double result = current * current;
+
+    ctx.setDouble(slotIndex, result);
+    return result;
+  }
+
+  @Specialization(guards = {"isDoubleKind(writeCtx)", "readCtx.isDouble(readIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final double writeDouble(final VirtualFrame frame,
+      @Bind("determineContext(frame)") final MaterializedFrame writeCtx,
+      @Bind("determineReadContext(frame)") final Frame readCtx)
+      throws FrameSlotTypeException {
+    double current = readCtx.getDouble(readIndex);
+    double result = current * current;
+
+    writeCtx.setDouble(slotIndex, result);
+    return result;
+  }
+
+  protected final boolean isLongKind(final VirtualFrame frame) {
+    FrameDescriptor descriptor = local.getFrameDescriptor();
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Long) {
+      return true;
+    }
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Illegal) {
+      descriptor.setSlotKind(slotIndex, FrameSlotKind.Long);
+      return true;
+    }
+    return false;
+  }
+
+  protected final boolean isDoubleKind(final VirtualFrame frame) {
+    FrameDescriptor descriptor = local.getFrameDescriptor();
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Double) {
+      return true;
+    }
+    if (descriptor.getSlotKind(slotIndex) == FrameSlotKind.Illegal) {
+      descriptor.setSlotKind(slotIndex, FrameSlotKind.Double);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+    ScopeElement seWrite = inliner.getAdaptedVar(local);
+    ScopeElement seRead = inliner.getAdaptedVar(readLocal);
+
+    assert seWrite.contextLevel == seRead.contextLevel;
+
+    if (seWrite.var != local || seWrite.contextLevel < contextLevel) {
+      assert seRead.var != readLocal || seRead.contextLevel < contextLevel;
+      replace(seWrite.var.getReadSquareWriteNode(seWrite.contextLevel, sourceCoord,
+          (Local) seRead.var, seRead.contextLevel));
+    } else {
+      assert contextLevel == seWrite.contextLevel;
+    }
+  }
+}

--- a/src/trufflesom/src/trufflesom/interpreter/supernodes/NonLocalVariableSquareNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/supernodes/NonLocalVariableSquareNode.java
@@ -1,0 +1,47 @@
+package trufflesom.interpreter.supernodes;
+
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameSlotTypeException;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor;
+import trufflesom.bdt.inlining.ScopeAdaptationVisitor.ScopeElement;
+import trufflesom.compiler.Variable.Local;
+import trufflesom.interpreter.nodes.NonLocalVariableNode;
+
+
+public abstract class NonLocalVariableSquareNode extends NonLocalVariableNode {
+
+  public NonLocalVariableSquareNode(final int contextLevel, final Local local) {
+    super(contextLevel, local);
+  }
+
+  @Specialization(guards = {"ctx.isLong(slotIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final long doLong(final VirtualFrame frame,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    long current = ctx.getLong(slotIndex);
+    return Math.multiplyExact(current, current);
+  }
+
+  @Specialization(guards = {"ctx.isDouble(slotIndex)"},
+      rewriteOn = {FrameSlotTypeException.class})
+  public final double doDouble(final VirtualFrame frame,
+      @Bind("determineContext(frame)") final MaterializedFrame ctx)
+      throws FrameSlotTypeException {
+    double current = ctx.getDouble(slotIndex);
+    return current * current;
+  }
+
+  @Override
+  public void replaceAfterScopeChange(final ScopeAdaptationVisitor inliner) {
+    ScopeElement se = inliner.getAdaptedVar(local);
+    if (se.var != local || se.contextLevel < contextLevel) {
+      replace(se.var.getSquareNode(se.contextLevel, sourceCoord));
+    } else {
+      assert contextLevel == se.contextLevel;
+    }
+  }
+}

--- a/tests/trufflesom/supernodes/SquareTests.java
+++ b/tests/trufflesom/supernodes/SquareTests.java
@@ -1,0 +1,85 @@
+package trufflesom.supernodes;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.LocalVariableNode.LocalVariableWriteNode;
+import trufflesom.interpreter.nodes.NonLocalVariableNode.NonLocalVariableWriteNode;
+import trufflesom.interpreter.nodes.SequenceNode;
+import trufflesom.interpreter.nodes.literals.BlockNode;
+import trufflesom.interpreter.supernodes.LocalVariableReadSquareWriteNode;
+import trufflesom.interpreter.supernodes.LocalVariableSquareNode;
+import trufflesom.interpreter.supernodes.NonLocalVariableReadSquareWriteNode;
+import trufflesom.interpreter.supernodes.NonLocalVariableSquareNode;
+import trufflesom.primitives.arithmetic.MultiplicationPrim;
+import trufflesom.tests.AstTestSetup;
+
+
+public class SquareTests extends AstTestSetup {
+  @SuppressWarnings("unchecked")
+  private <T> T assertThatMainNodeIs(final String test, final Class<T> expectedNode) {
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test = ( | l1 l2 l3 l4 | \n" + test + " )");
+
+    ExpressionNode testExpr = read(seq, "expressions", 0);
+    assertThat(testExpr, instanceOf(expectedNode));
+    return (T) testExpr;
+  }
+
+  @Test
+  public void testJustSquareLocals() {
+    LocalVariableSquareNode s =
+        assertThatMainNodeIs("l2 * l2.", LocalVariableSquareNode.class);
+    assertEquals(s.getLocal().name, "l2");
+
+    s = assertThatMainNodeIs("l1 * l1.", LocalVariableSquareNode.class);
+    assertEquals(s.getLocal().name, "l1");
+
+    assertThatMainNodeIs("l1 * l3.", MultiplicationPrim.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T inBlock(final String test, final Class<T> expectedNode) {
+    addField("field");
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg = ( | l1 l2 l3 l4 | \n" + test + " )");
+
+    BlockNode block = (BlockNode) read(seq, "expressions", 0);
+    ExpressionNode testExpr =
+        read(block.getMethod().getInvokable(), "body", ExpressionNode.class);
+    assertThat(testExpr, instanceOf(expectedNode));
+    return (T) testExpr;
+  }
+
+  @Test
+  public void testJustSquareNonLocals() {
+    NonLocalVariableSquareNode s = inBlock("[ l2 * l2 ]", NonLocalVariableSquareNode.class);
+    assertEquals(s.getLocal().name, "l2");
+
+    s = inBlock("[ l1 * l1 ]", NonLocalVariableSquareNode.class);
+    assertEquals(s.getLocal().name, "l1");
+
+    inBlock("[ l1 * l3 ]", MultiplicationPrim.class);
+  }
+
+  @Test
+  public void testSquareAndAssignLocal() {
+    assertThatMainNodeIs("l1 := l2 * l2.", LocalVariableReadSquareWriteNode.class);
+    assertThatMainNodeIs("l2 := l2 * l2.", LocalVariableReadSquareWriteNode.class);
+
+    assertThatMainNodeIs("l3 := l1 * l2.", LocalVariableWriteNode.class);
+  }
+
+  @Test
+  public void testSquareAndAssignNonLocal() {
+    inBlock("[ l1 := l2 * l2 ]", NonLocalVariableReadSquareWriteNode.class);
+    inBlock("[ l2 := l2 * l2 ]", NonLocalVariableReadSquareWriteNode.class);
+    inBlock("[|bl1| l2 := bl1 * bl1 ]", NonLocalVariableReadSquareWriteNode.class);
+    inBlock("[|bl1| bl1 := l2 * l2 ]", NonLocalVariableReadSquareWriteNode.class);
+
+    inBlock("[ l3 := l1 * l2 ]", NonLocalVariableWriteNode.class);
+  }
+}


### PR DESCRIPTION
This PR adds support for the basic multiplication of a variable with itself for local and non-local variables, i.e.:
   - `local * local`
   - `| l | [ l * l ]`

It also supports multiplication and assigning result to local/non-local variables:
   - `b := l * l`

This is taking a bit of https://github.com/SOM-st/TruffleSOM/pull/185 to integrate directly.

This PR should benefit the following benchmarks:
 - Mandelbrot (mostly this one I believe)
 - NBody
 - PageRank
 - CD