### PR TITLE
Truffle Update, and ReBench compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,9 +167,9 @@ benchmark-y1:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling m:yuria
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria
     # Run Benchmarks
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf m:yuria
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria
   after_script:
     - sudo reown-project.sh
 
@@ -182,9 +182,9 @@ benchmark-y2:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling m:yuria2
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria2
     # Run Benchmarks
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf m:yuria2
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria2
   after_script:
     - sudo reown-project.sh
 
@@ -197,9 +197,9 @@ benchmark-y3:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling m:yuria3
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria3
     # Run Benchmarks
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf m:yuria3
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria3
   after_script:
     - sudo reown-project.sh
 
@@ -212,9 +212,9 @@ benchmark-y4:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling m:yuria4 || true
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria4 || true
     # Run Benchmarks
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf m:yuria4
+    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria4
   after_script:
     - sudo reown-project.sh
 

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "7227e7620849054055835c6719acba43d48e36c4",
+                "version": "6339bcd8f1ca06eee25877838d92ca1256cbbf02",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]

--- a/rebench.conf
+++ b/rebench.conf
@@ -23,23 +23,23 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - Richards:     {extra_args:    1, machines: [yuria4]}
-            - DeltaBlue:    {extra_args:  100, machines: [yuria4]}
-            - NBody:        {extra_args: 1000, machines: [yuria3]}
-            - Json:         {extra_args:    1, machines: [yuria4]}
-            - GraphSearch:  {extra_args:    7, machines: [yuria2]}
-            - PageRank:     {extra_args:   75, machines: [yuria3]}
+            - Richards:     {extra_args:    1, tags: [yuria4]}
+            - DeltaBlue:    {extra_args:  100, tags: [yuria4]}
+            - NBody:        {extra_args: 1000, tags: [yuria3]}
+            - Json:         {extra_args:    1, tags: [yuria4]}
+            - GraphSearch:  {extra_args:    7, tags: [yuria2]}
+            - PageRank:     {extra_args:   75, tags: [yuria3]}
 
     macro-steady:
         gauge_adapter: RebenchLog
         command: *MACRO_CMD
         benchmarks:
-            - Richards:     {extra_args: 40,     warmup:  30,   iterations: 130, machines: [yuria4]}
-            - DeltaBlue:    {extra_args: 10000,  warmup:  20,   iterations: 120, machines: [yuria4]}
-            - NBody:        {extra_args: 200000, warmup:  20,   iterations: 120, machines: [yuria3]}
-            - Json:         {extra_args: 80,     warmup:  20,   iterations: 120, machines: [yuria4]}
-            - GraphSearch:  {extra_args: 25,     warmup: 100,   iterations: 250, machines: [yuria4]}
-            - PageRank:     {extra_args: 1000,   warmup:  20,   iterations: 120, machines: [yuria3]}
+            - Richards:     {extra_args: 40,     warmup:  30,   iterations: 130, tags: [yuria4]}
+            - DeltaBlue:    {extra_args: 10000,  warmup:  20,   iterations: 120, tags: [yuria4]}
+            - NBody:        {extra_args: 200000, warmup:  20,   iterations: 120, tags: [yuria3]}
+            - Json:         {extra_args: 80,     warmup:  20,   iterations: 120, tags: [yuria4]}
+            - GraphSearch:  {extra_args: 25,     warmup: 100,   iterations: 250, tags: [yuria4]}
+            - PageRank:     {extra_args: 1000,   warmup:  20,   iterations: 120, tags: [yuria3]}
 
     awfy-startup:
         gauge_adapter: RebenchLog
@@ -47,15 +47,15 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - CD:     {extra_args: 10, machines: [yuria4]}
-            - Havlak: {extra_args: 15, machines: [yuria4]}
+            - CD:     {extra_args: 10, tags: [yuria4]}
+            - Havlak: {extra_args: 15, tags: [yuria4]}
 
     awfy-steady:
         gauge_adapter: RebenchLog
         command: *AWFY_CMD
         benchmarks:
-            - CD:     {extra_args: 100, warmup: 30, iterations: 130, machines: [yuria4]}
-            - Havlak: {extra_args: 150, warmup: 30, iterations: 130, machines: [yuria3]}
+            - CD:     {extra_args: 100, warmup: 30, iterations: 130, tags: [yuria4]}
+            - Havlak: {extra_args: 150, warmup: 30, iterations: 130, tags: [yuria3]}
 
     micro-startup:
         gauge_adapter: RebenchLog
@@ -63,65 +63,65 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - Fannkuch:     {extra_args:   7, machines: [yuria4]}
-            - Fibonacci:    {extra_args:  10, machines: [yuria2]}
-            - Dispatch:     {extra_args:  10, machines: [yuria3]}
-            - Bounce:       {extra_args:  10, machines: [yuria4]}
-            - Loop:         {extra_args: 100, machines: [yuria2]}
-            - Permute:      {extra_args:  10, machines: [yuria3]}
-            - Queens:       {extra_args:  10, machines: [yuria4]}
-            - List:         {extra_args:   2, machines: [yuria2]}
-            - Recurse:      {extra_args:  12, machines: [yuria3]}
-            - Storage:      {extra_args:   8, machines: [yuria4]}
-            - Sieve:        {extra_args:  20, machines: [yuria2]}
-            - BubbleSort:   {extra_args:  15, machines: [yuria3]}
-            - QuickSort:    {extra_args:  15, machines: [yuria ]}
-            - Sum:          {extra_args:  40, machines: [yuria2]}
-            - Towers:       {extra_args:   2, machines: [yuria3]}
-            - TreeSort:     {extra_args:   7, machines: [yuria ]}
-            - IntegerLoop:  {extra_args:   7, machines: [yuria2]}
-            - FieldLoop:    {extra_args:   1, machines: [yuria3]}
-            - WhileLoop:    {extra_args:  30, machines: [yuria ]}
-            - Mandelbrot:   {extra_args:  50, machines: [yuria2]}
+            - Fannkuch:     {extra_args:   7, tags: [yuria4]}
+            - Fibonacci:    {extra_args:  10, tags: [yuria2]}
+            - Dispatch:     {extra_args:  10, tags: [yuria3]}
+            - Bounce:       {extra_args:  10, tags: [yuria4]}
+            - Loop:         {extra_args: 100, tags: [yuria2]}
+            - Permute:      {extra_args:  10, tags: [yuria3]}
+            - Queens:       {extra_args:  10, tags: [yuria4]}
+            - List:         {extra_args:   2, tags: [yuria2]}
+            - Recurse:      {extra_args:  12, tags: [yuria3]}
+            - Storage:      {extra_args:   8, tags: [yuria4]}
+            - Sieve:        {extra_args:  20, tags: [yuria2]}
+            - BubbleSort:   {extra_args:  15, tags: [yuria3]}
+            - QuickSort:    {extra_args:  15, tags: [yuria ]}
+            - Sum:          {extra_args:  40, tags: [yuria2]}
+            - Towers:       {extra_args:   2, tags: [yuria3]}
+            - TreeSort:     {extra_args:   7, tags: [yuria ]}
+            - IntegerLoop:  {extra_args:   7, tags: [yuria2]}
+            - FieldLoop:    {extra_args:   1, tags: [yuria3]}
+            - WhileLoop:    {extra_args:  30, tags: [yuria ]}
+            - Mandelbrot:   {extra_args:  50, tags: [yuria2]}
 
-            - Test:     {invocations: 10, machines: [yuria ]}
-            - TestGC:   {invocations: 10, extra_args: 10, machines: [yuria ]}
+            - Test:     {invocations: 10, tags: [yuria ]}
+            - TestGC:   {invocations: 10, extra_args: 10, tags: [yuria ]}
 
     micro-steady:
         gauge_adapter: RebenchLog
         command: *MICRO_CMD
         benchmarks:
-            - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55, machines: [yuria4]}
-            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria4]}
-            - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria4]}
-            - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60, machines: [yuria4]}
-            - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
-            - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55, machines: [yuria4]}
-            - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria4]}
-            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, machines: [yuria4]}
-            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, machines: [yuria4]}
-            - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria4]}
-            - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60, machines: [yuria2]}
-            - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55, machines: [yuria4]}
-            - QuickSort:    {extra_args: 2000,   warmup:   5,   iterations:  55, machines: [yuria4]}
-            - Sum:          {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
-            - Towers:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria4]}
-            - TreeSort:     {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria4]}
-            - IntegerLoop:  {extra_args: 8000,   warmup:   5,   iterations:  55, machines: [yuria2]}
-            - FieldLoop:    {extra_args: 900,    warmup:   5,   iterations:  55, machines: [yuria4]}
-            - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55, machines: [yuria2]}
-            - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110, machines: [yuria4]}
+            - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55, tags: [yuria4]}
+            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60, tags: [yuria4]}
+            - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55, tags: [yuria4]}
+            - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60, tags: [yuria4]}
+            - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55, tags: [yuria2]}
+            - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55, tags: [yuria4]}
+            - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55, tags: [yuria4]}
+            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, tags: [yuria4]}
+            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, tags: [yuria4]}
+            - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60, tags: [yuria4]}
+            - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60, tags: [yuria2]}
+            - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55, tags: [yuria4]}
+            - QuickSort:    {extra_args: 2000,   warmup:   5,   iterations:  55, tags: [yuria4]}
+            - Sum:          {extra_args: 10000,  warmup:   5,   iterations:  55, tags: [yuria2]}
+            - Towers:       {extra_args: 1000,   warmup:   5,   iterations:  55, tags: [yuria4]}
+            - TreeSort:     {extra_args: 1000,   warmup:  10,   iterations:  60, tags: [yuria4]}
+            - IntegerLoop:  {extra_args: 8000,   warmup:   5,   iterations:  55, tags: [yuria2]}
+            - FieldLoop:    {extra_args: 900,    warmup:   5,   iterations:  55, tags: [yuria4]}
+            - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55, tags: [yuria2]}
+            - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110, tags: [yuria4]}
 
     micro-somsom:
         gauge_adapter: RebenchLog
         command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
         iterations: 1
         benchmarks:
-            - Loop:         {extra_args: 1, machines: [yuria4]}
-            - Queens:       {extra_args: 1, machines: [yuria4]}
-            - List:         {extra_args: 1, machines: [yuria2]}
-            - Recurse:      {extra_args: 1, machines: [yuria4]}
-            - Mandelbrot:   {extra_args: 3, machines: [yuria4]}
+            - Loop:         {extra_args: 1, tags: [yuria4]}
+            - Queens:       {extra_args: 1, tags: [yuria4]}
+            - List:         {extra_args: 1, tags: [yuria2]}
+            - Recurse:      {extra_args: 1, tags: [yuria4]}
+            - Mandelbrot:   {extra_args: 3, tags: [yuria4]}
 
     som-parse:
         gauge_adapter: RebenchLog
@@ -129,8 +129,8 @@ benchmark_suites:
         iterations: 1!
         invocations: 10
         benchmarks:
-            - SomParse: {extra_args: 1, machines: [yuria2]}
-            - SomInit:  {extra_args: 10000, machines: [yuria2]}
+            - SomParse: {extra_args: 1, tags: [yuria2]}
+            - SomInit:  {extra_args: 10000, tags: [yuria2]}
 
     interpreter:
         description: Basic interpreter benchmarks for comparing performance of most basic concepts.
@@ -138,22 +138,22 @@ benchmark_suites:
         invocations: 5
         command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
         benchmarks:
-            - ArgRead:                           {machines: [yuria ]}
-            - ArrayReadConst:                    {machines: [yuria ]}
-            - ArrayWriteConstConst:              {machines: [yuria ]}
-            - BlockSend0ConstReturn:             {machines: [yuria ]}
-            - Const:                             {machines: [yuria ]}
-            - FieldConstWrite:                   {machines: [yuria ]}
-            - FieldRead:                         {machines: [yuria ]}
-            - FieldReadIncWrite:                 {machines: [yuria ]}
-            - FieldReadWrite:                    {machines: [yuria ]}
-            - GlobalRead:                        {machines: [yuria ]}
-            - LocalConstWrite:                   {machines: [yuria ]}
-            - LocalRead:                         {machines: [yuria ]}
-            - LocalReadIncWrite:                 {machines: [yuria ]}
-            - LocalReadWrite:                    {machines: [yuria ]}
-            - SelfSend0:                         {machines: [yuria ]}
-            - SelfSend0BlockConstNonLocalReturn: {machines: [yuria ]}
+            - ArgRead:                           {tags: [yuria ]}
+            - ArrayReadConst:                    {tags: [yuria ]}
+            - ArrayWriteConstConst:              {tags: [yuria ]}
+            - BlockSend0ConstReturn:             {tags: [yuria ]}
+            - Const:                             {tags: [yuria ]}
+            - FieldConstWrite:                   {tags: [yuria ]}
+            - FieldRead:                         {tags: [yuria ]}
+            - FieldReadIncWrite:                 {tags: [yuria ]}
+            - FieldReadWrite:                    {tags: [yuria ]}
+            - GlobalRead:                        {tags: [yuria ]}
+            - LocalConstWrite:                   {tags: [yuria ]}
+            - LocalRead:                         {tags: [yuria ]}
+            - LocalReadIncWrite:                 {tags: [yuria ]}
+            - LocalReadWrite:                    {tags: [yuria ]}
+            - SelfSend0:                         {tags: [yuria ]}
+            - SelfSend0BlockConstNonLocalReturn: {tags: [yuria ]}
 
 executors:
     TruffleSOM-interp:


### PR DESCRIPTION
Update Graal/Truffle to version of 2024-11-16 and update the rebench and GitLab CI configuration to the renaming of `machines` to `tags`.