### PR TITLE
Implement inlining for various `#ifNil:*` variants

### DIFF
--- a/src/trufflesom/src/trufflesom/compiler/ParserBc.java
+++ b/src/trufflesom/src/trufflesom/compiler/ParserBc.java
@@ -43,6 +43,7 @@ import com.oracle.truffle.api.source.Source;
 import trufflesom.bdt.basic.ProgramDefinitionError;
 import trufflesom.bdt.tools.structure.StructuralProbe;
 import trufflesom.compiler.bc.BytecodeMethodGenContext;
+import trufflesom.compiler.bc.BytecodeMethodGenContext.JumpCondition;
 import trufflesom.interpreter.nodes.ExpressionNode;
 import trufflesom.vm.constants.Nil;
 import trufflesom.vmobjects.SClass;
@@ -286,10 +287,22 @@ public class ParserBc extends Parser<BytecodeMethodGenContext> {
     String kwStr = kw.toString();
 
     if (!isSuperSend) {
-      if (("ifTrue:".equals(kwStr) && mgenc.inlineIfTrueOrIfFalse(this, true)) ||
-          ("ifFalse:".equals(kwStr) && mgenc.inlineIfTrueOrIfFalse(this, false)) ||
-          ("ifTrue:ifFalse:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this, true)) ||
-          ("ifFalse:ifTrue:".equals(kwStr) && mgenc.inlineIfTrueIfFalse(this, false)) ||
+      if (("ifTrue:".equals(kwStr) && mgenc.inlineThenBranch(this, JumpCondition.ON_FALSE)) ||
+          ("ifFalse:".equals(kwStr) && mgenc.inlineThenBranch(this, JumpCondition.ON_TRUE)) ||
+          ("ifTrue:ifFalse:".equals(kwStr)
+              && mgenc.inlineThenElseBranches(this, JumpCondition.ON_FALSE))
+          ||
+          ("ifFalse:ifTrue:".equals(kwStr)
+              && mgenc.inlineThenElseBranches(this, JumpCondition.ON_TRUE))
+          ||
+          ("ifNil:".equals(kwStr) && mgenc.inlineThenBranch(this, JumpCondition.ON_NOT_NIL)) ||
+          ("ifNotNil:".equals(kwStr) && mgenc.inlineThenBranch(this, JumpCondition.ON_NIL)) ||
+          ("ifNil:ifNotNil:".equals(kwStr)
+              && mgenc.inlineThenElseBranches(this, JumpCondition.ON_NOT_NIL))
+          ||
+          ("ifNotNil:ifNil:".equals(kwStr)
+              && mgenc.inlineThenElseBranches(this, JumpCondition.ON_NIL))
+          ||
           ("whileTrue:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, true)) ||
           ("whileFalse:".equals(kwStr) && mgenc.inlineWhileTrueOrFalse(this, false)) ||
           ("or:".equals(kwStr) && mgenc.inlineAndOr(this, true)) ||

--- a/src/trufflesom/src/trufflesom/compiler/bc/Disassembler.java
+++ b/src/trufflesom/src/trufflesom/compiler/bc/Disassembler.java
@@ -34,11 +34,19 @@ import static trufflesom.interpreter.bc.Bytecodes.JUMP2;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP2_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_FALSE_TOP_NIL;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NIL_TOP_TOP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NOT_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NOT_NIL_TOP_TOP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_TRUE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_TRUE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_BACKWARDS;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_FALSE_TOP_NIL;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NIL_TOP_TOP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NOT_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NOT_NIL_TOP_TOP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_POP;
 import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_TRUE_TOP_NIL;
 import static trufflesom.interpreter.bc.Bytecodes.POP_ARGUMENT;
@@ -270,11 +278,19 @@ public class Disassembler {
         case JUMP_ON_FALSE_TOP_NIL:
         case JUMP_ON_TRUE_POP:
         case JUMP_ON_FALSE_POP:
+        case JUMP_ON_NOT_NIL_TOP_TOP:
+        case JUMP_ON_NIL_TOP_TOP:
+        case JUMP_ON_NOT_NIL_POP:
+        case JUMP_ON_NIL_POP:
         case JUMP2:
         case JUMP2_ON_TRUE_TOP_NIL:
         case JUMP2_ON_FALSE_TOP_NIL:
         case JUMP2_ON_TRUE_POP:
-        case JUMP2_ON_FALSE_POP: {
+        case JUMP2_ON_FALSE_POP:
+        case JUMP2_ON_NOT_NIL_TOP_TOP:
+        case JUMP2_ON_NIL_TOP_TOP:
+        case JUMP2_ON_NOT_NIL_POP:
+        case JUMP2_ON_NIL_POP: {
           int offset = getJumpOffset(bytecodes.get(b + 1), bytecodes.get(b + 2));
 
           Universe.errorPrintln(

--- a/src/trufflesom/src/trufflesom/interpreter/bc/Bytecodes.java
+++ b/src/trufflesom/src/trufflesom/interpreter/bc/Bytecodes.java
@@ -93,29 +93,37 @@ public class Bytecodes {
   public static final byte INC_FIELD      = 42;
   public static final byte INC_FIELD_PUSH = 43;
 
-  public static final byte JUMP                  = 44;
-  public static final byte JUMP_ON_TRUE_TOP_NIL  = 45;
-  public static final byte JUMP_ON_FALSE_TOP_NIL = 46;
-  public static final byte JUMP_ON_TRUE_POP      = 47;
-  public static final byte JUMP_ON_FALSE_POP     = 48;
-  public static final byte JUMP_BACKWARDS        = 49;
+  public static final byte JUMP                    = 44;
+  public static final byte JUMP_ON_TRUE_TOP_NIL    = 45;
+  public static final byte JUMP_ON_FALSE_TOP_NIL   = 46;
+  public static final byte JUMP_ON_TRUE_POP        = 47;
+  public static final byte JUMP_ON_FALSE_POP       = 48;
+  public static final byte JUMP_ON_NOT_NIL_TOP_TOP = 49;
+  public static final byte JUMP_ON_NIL_TOP_TOP     = 50;
+  public static final byte JUMP_ON_NOT_NIL_POP     = 51;
+  public static final byte JUMP_ON_NIL_POP         = 52;
+  public static final byte JUMP_BACKWARDS          = 53;
 
-  public static final byte JUMP2                  = 50;
-  public static final byte JUMP2_ON_TRUE_TOP_NIL  = 51;
-  public static final byte JUMP2_ON_FALSE_TOP_NIL = 52;
-  public static final byte JUMP2_ON_TRUE_POP      = 53;
-  public static final byte JUMP2_ON_FALSE_POP     = 54;
-  public static final byte JUMP2_BACKWARDS        = 55;
+  public static final byte JUMP2                    = 54;
+  public static final byte JUMP2_ON_TRUE_TOP_NIL    = 55;
+  public static final byte JUMP2_ON_FALSE_TOP_NIL   = 56;
+  public static final byte JUMP2_ON_TRUE_POP        = 57;
+  public static final byte JUMP2_ON_FALSE_POP       = 58;
+  public static final byte JUMP2_ON_NOT_NIL_TOP_TOP = 59;
+  public static final byte JUMP2_ON_NIL_TOP_TOP     = 60;
+  public static final byte JUMP2_ON_NOT_NIL_POP     = 61;
+  public static final byte JUMP2_ON_NIL_POP         = 62;
+  public static final byte JUMP2_BACKWARDS          = 63;
 
-  public static final byte Q_PUSH_GLOBAL = 56;
-  public static final byte Q_SEND        = 57;
-  public static final byte Q_SEND_1      = 58;
-  public static final byte Q_SEND_2      = 59;
-  public static final byte Q_SEND_3      = 60;
+  public static final byte Q_PUSH_GLOBAL = 64;
+  public static final byte Q_SEND        = 65;
+  public static final byte Q_SEND_1      = 66;
+  public static final byte Q_SEND_2      = 67;
+  public static final byte Q_SEND_3      = 68;
 
   public static final byte INVALID = -1;
 
-  public static final byte NUM_1_BYTE_JUMP_BYTECODES = 6;
+  public static final byte NUM_1_BYTE_JUMP_BYTECODES = 10;
 
   private static final String[] PADDED_BYTECODE_NAMES;
   private static final String[] BYTECODE_NAMES;
@@ -150,10 +158,26 @@ public class Bytecodes {
   @CompilationFinal(dimensions = 1) private static final int[] BYTECODE_LENGTH;
 
   public static final byte[] JUMP_BYTECODES = new byte[] {
-      JUMP, JUMP_ON_TRUE_TOP_NIL, JUMP_ON_TRUE_POP,
-      JUMP_ON_FALSE_TOP_NIL, JUMP_ON_FALSE_POP, JUMP_BACKWARDS,
-      JUMP2, JUMP2_ON_TRUE_TOP_NIL, JUMP2_ON_TRUE_POP,
-      JUMP2_ON_FALSE_TOP_NIL, JUMP2_ON_FALSE_POP, JUMP_BACKWARDS
+      JUMP,
+      JUMP_ON_TRUE_TOP_NIL,
+      JUMP_ON_TRUE_POP,
+      JUMP_ON_FALSE_TOP_NIL,
+      JUMP_ON_FALSE_POP,
+      JUMP_ON_NOT_NIL_TOP_TOP,
+      JUMP_ON_NIL_TOP_TOP,
+      JUMP_ON_NOT_NIL_POP,
+      JUMP_ON_NIL_POP,
+      JUMP_BACKWARDS,
+      JUMP2,
+      JUMP2_ON_TRUE_TOP_NIL,
+      JUMP2_ON_TRUE_POP,
+      JUMP2_ON_FALSE_TOP_NIL,
+      JUMP2_ON_FALSE_POP,
+      JUMP2_ON_NOT_NIL_TOP_TOP,
+      JUMP2_ON_NIL_TOP_TOP,
+      JUMP2_ON_NOT_NIL_POP,
+      JUMP2_ON_NIL_POP,
+      JUMP_BACKWARDS
   };
 
   public static final boolean isOneOf(final byte bytecode, final byte[] arr) {
@@ -233,6 +257,10 @@ public class Bytecodes {
         "JUMP_ON_FALSE_TOP_NIL",
         "JUMP_ON_TRUE_POP",
         "JUMP_ON_FALSE_POP",
+        "JUMP_ON_NOT_NIL_TOP_TOP",
+        "JUMP_ON_NIL_TOP_TOP",
+        "JUMP_ON_NOT_NIL_POP",
+        "JUMP_ON_NIL_POP",
         "JUMP_BACKWARDS  ",
 
         "JUMP2           ",
@@ -240,6 +268,10 @@ public class Bytecodes {
         "JUMP2_ON_FALSE_TOP_NIL",
         "JUMP2_ON_TRUE_POP",
         "JUMP2_ON_FALSE_POP",
+        "JUMP2_ON_NOT_NIL_TOP_TOP",
+        "JUMP2_ON_NIL_TOP_TOP",
+        "JUMP2_ON_NOT_NIL_POP",
+        "JUMP2_ON_NIL_POP",
         "JUMP2_BACKWARDS ",
 
         "Q_PUSH_GLOBAL   ",
@@ -315,6 +347,10 @@ public class Bytecodes {
         3, // JUMP_ON_FALSE_TOP_NIL
         3, // JUMP_ON_TRUE_POP
         3, // JUMP_ON_FALSE_POP
+        3, // JUMP_ON_NOT_NIL_TOP_TOP
+        3, // JUMP_ON_NIL_TOP_TOP
+        3, // JUMP_ON_NOT_NIL_POP
+        3, // JUMP_ON_NIL_POP
         3, // JUMP_BACKWARDS
 
         3, // JUMP2
@@ -322,6 +358,10 @@ public class Bytecodes {
         3, // JUMP2_ON_FALSE_TOP_NIL
         3, // JUMP2_ON_TRUE_POP
         3, // JUMP2_ON_FALSE_POP
+        3, // JUMP2_ON_NOT_NIL_TOP_TOP,
+        3, // JUMP2_ON_NIL_TOP_TOP,
+        3, // JUMP2_ON_NOT_NIL_POP,
+        3, // JUMP2_ON_NIL_POP,
         3, // JUMP2_BACKWARDS
 
         2, // Q_PUSH_GLOBAL

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/bc/BytecodeLoopNode.java
@@ -1,6 +1,13 @@
 package trufflesom.interpreter.nodes.bc;
 
-import static trufflesom.interpreter.nodes.ContextualNode.frameType;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NIL_TOP_TOP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NOT_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP2_ON_NOT_NIL_TOP_TOP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NIL_TOP_TOP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NOT_NIL_POP;
+import static trufflesom.interpreter.bc.Bytecodes.JUMP_ON_NOT_NIL_TOP_TOP;
 import static trufflesom.compiler.bc.BytecodeGenerator.emit1;
 import static trufflesom.compiler.bc.BytecodeGenerator.emit3;
 import static trufflesom.compiler.bc.BytecodeGenerator.emit3WithDummy;
@@ -936,6 +943,56 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
           break;
         }
 
+        case JUMP_ON_NOT_NIL_TOP_TOP: {
+          Object val = stack[stackPointer];
+          if (val != Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
+            bytecodeIndex += offset;
+            // stack[stackPointer] = stack[stackPointer];
+          } else {
+            stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          break;
+        }
+
+        case JUMP_ON_NIL_TOP_TOP: {
+          Object val = stack[stackPointer];
+          if (val == Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
+            bytecodeIndex += offset;
+            // stack[stackPointer] = stack[stackPointer];
+          } else {
+            stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          break;
+        }
+
+        case JUMP_ON_NOT_NIL_POP: {
+          Object val = stack[stackPointer];
+          if (val != Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          stackPointer -= 1;
+          break;
+        }
+
+        case JUMP_ON_NIL_POP: {
+          Object val = stack[stackPointer];
+          if (val == Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          stackPointer -= 1;
+          break;
+        }
+
         case JUMP_BACKWARDS: {
           int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1]);
           bytecodeIndex -= offset;
@@ -997,6 +1054,60 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         case JUMP2_ON_FALSE_POP: {
           Object val = stack[stackPointer];
           if (val == Boolean.FALSE) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
+                + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          stackPointer -= 1;
+          break;
+        }
+
+        case JUMP2_ON_NOT_NIL_TOP_TOP: {
+          Object val = stack[stackPointer];
+          if (val != Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
+                + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
+            bytecodeIndex += offset;
+            // stack[stackPointer] = stack[stackPointer];
+          } else {
+            stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          break;
+        }
+
+        case JUMP2_ON_NIL_TOP_TOP: {
+          Object val = stack[stackPointer];
+          if (val == Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
+                + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
+            bytecodeIndex += offset;
+            // stack[stackPointer] = stack[stackPointer];
+          } else {
+            stackPointer -= 1;
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          break;
+        }
+
+        case JUMP2_ON_NOT_NIL_POP: {
+          Object val = stack[stackPointer];
+          if (val != Nil.nilObject) {
+            int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
+                + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
+            bytecodeIndex += offset;
+          } else {
+            bytecodeIndex += Bytecodes.LEN_TWO_ARGS;
+          }
+          stackPointer -= 1;
+          break;
+        }
+
+        case JUMP2_ON_NIL_POP: {
+          Object val = stack[stackPointer];
+          if (val == Nil.nilObject) {
             int offset = Byte.toUnsignedInt(bytecodes[bytecodeIndex + 1])
                 + (Byte.toUnsignedInt(bytecodes[bytecodeIndex + 2]) << 8);
             bytecodeIndex += offset;
@@ -1567,7 +1678,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         case JUMP_ON_TRUE_TOP_NIL:
         case JUMP2_ON_TRUE_TOP_NIL:
         case JUMP_ON_FALSE_TOP_NIL:
-        case JUMP2_ON_FALSE_TOP_NIL: {
+        case JUMP2_ON_FALSE_TOP_NIL:
+        case JUMP_ON_NOT_NIL_TOP_TOP:
+        case JUMP2_ON_NOT_NIL_TOP_TOP:
+        case JUMP_ON_NIL_TOP_TOP:
+        case JUMP2_ON_NIL_TOP_TOP: {
           int offset = getJumpOffset(bytecodes[i + 1], bytecodes[i + 2]);
 
           int idxOffset = emit3WithDummy(mgenc, bytecode, 0);
@@ -1578,7 +1693,11 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         case JUMP_ON_TRUE_POP:
         case JUMP2_ON_TRUE_POP:
         case JUMP_ON_FALSE_POP:
-        case JUMP2_ON_FALSE_POP: {
+        case JUMP2_ON_FALSE_POP:
+        case JUMP_ON_NOT_NIL_POP:
+        case JUMP2_ON_NOT_NIL_POP:
+        case JUMP_ON_NIL_POP:
+        case JUMP2_ON_NIL_POP: {
           int offset = getJumpOffset(bytecodes[i + 1], bytecodes[i + 2]);
 
           int idxOffset = emit3WithDummy(mgenc, bytecode, -1);
@@ -1751,12 +1870,20 @@ public class BytecodeLoopNode extends NoPreEvalExprNode implements ScopeReferenc
         case JUMP_ON_FALSE_TOP_NIL:
         case JUMP_ON_TRUE_POP:
         case JUMP_ON_FALSE_POP:
+        case JUMP_ON_NOT_NIL_TOP_TOP:
+        case JUMP_ON_NIL_TOP_TOP:
+        case JUMP_ON_NOT_NIL_POP:
+        case JUMP_ON_NIL_POP:
         case JUMP_BACKWARDS:
         case JUMP2:
         case JUMP2_ON_TRUE_TOP_NIL:
         case JUMP2_ON_FALSE_TOP_NIL:
         case JUMP2_ON_TRUE_POP:
         case JUMP2_ON_FALSE_POP:
+        case JUMP2_ON_NOT_NIL_TOP_TOP:
+        case JUMP2_ON_NIL_TOP_TOP:
+        case JUMP2_ON_NOT_NIL_POP:
+        case JUMP2_ON_NIL_POP:
         case JUMP2_BACKWARDS: {
           break;
         }

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfNilNotNilInlinedLiteralNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfNilNotNilInlinedLiteralNode.java
@@ -1,0 +1,45 @@
+package trufflesom.interpreter.nodes.specialized;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.profiles.CountingConditionProfile;
+import trufflesom.bdt.inlining.Inline;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.NoPreEvalExprNode;
+import trufflesom.vm.constants.Nil;
+
+
+@Inline(selector = "ifNil:ifNotNil:", inlineableArgIdx = {1, 2})
+public final class IfNilNotNilInlinedLiteralNode extends NoPreEvalExprNode {
+  private final CountingConditionProfile condProf = CountingConditionProfile.create();
+
+  @Child private ExpressionNode rcvr;
+  @Child private ExpressionNode arg1;
+  @Child private ExpressionNode arg2;
+
+  // In case we need to revert from this optimistic optimization, keep the
+  // original nodes around
+  @SuppressWarnings("unused") private final ExpressionNode originalArg1;
+  @SuppressWarnings("unused") private final ExpressionNode originalArg2;
+
+  public IfNilNotNilInlinedLiteralNode(final ExpressionNode rcvr,
+      final ExpressionNode originalArg1,
+      final ExpressionNode originalArg2,
+      final ExpressionNode inlinedArg1,
+      final ExpressionNode inlinedArg2) {
+    this.rcvr = rcvr;
+    this.originalArg1 = originalArg1;
+    this.originalArg2 = originalArg2;
+    this.arg1 = inlinedArg1;
+    this.arg2 = inlinedArg2;
+  }
+
+  @Override
+  public Object executeGeneric(final VirtualFrame frame) {
+    Object r = rcvr.executeGeneric(frame);
+
+    if (condProf.profile(r == Nil.nilObject)) {
+      return arg1.executeGeneric(frame);
+    }
+    return arg2.executeGeneric(frame);
+  }
+}

--- a/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfNotNilNilInlinedLiteralNode.java
+++ b/src/trufflesom/src/trufflesom/interpreter/nodes/specialized/IfNotNilNilInlinedLiteralNode.java
@@ -1,0 +1,45 @@
+package trufflesom.interpreter.nodes.specialized;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.profiles.CountingConditionProfile;
+import trufflesom.bdt.inlining.Inline;
+import trufflesom.interpreter.nodes.ExpressionNode;
+import trufflesom.interpreter.nodes.NoPreEvalExprNode;
+import trufflesom.vm.constants.Nil;
+
+
+@Inline(selector = "ifNotNil:ifNil:", inlineableArgIdx = {1, 2})
+public final class IfNotNilNilInlinedLiteralNode extends NoPreEvalExprNode {
+  private final CountingConditionProfile condProf = CountingConditionProfile.create();
+
+  @Child private ExpressionNode rcvr;
+  @Child private ExpressionNode arg1;
+  @Child private ExpressionNode arg2;
+
+  // In case we need to revert from this optimistic optimization, keep the
+  // original nodes around
+  @SuppressWarnings("unused") private final ExpressionNode originalArg1;
+  @SuppressWarnings("unused") private final ExpressionNode originalArg2;
+
+  public IfNotNilNilInlinedLiteralNode(final ExpressionNode rcvr,
+      final ExpressionNode originalArg1,
+      final ExpressionNode originalArg2,
+      final ExpressionNode inlinedArg1,
+      final ExpressionNode inlinedArg2) {
+    this.rcvr = rcvr;
+    this.originalArg1 = originalArg1;
+    this.originalArg2 = originalArg2;
+    this.arg1 = inlinedArg1;
+    this.arg2 = inlinedArg2;
+  }
+
+  @Override
+  public Object executeGeneric(final VirtualFrame frame) {
+    Object r = rcvr.executeGeneric(frame);
+
+    if (condProf.profile(r != Nil.nilObject)) {
+      return arg1.executeGeneric(frame);
+    }
+    return arg2.executeGeneric(frame);
+  }
+}

--- a/src/trufflesom/src/trufflesom/primitives/Primitives.java
+++ b/src/trufflesom/src/trufflesom/primitives/Primitives.java
@@ -54,7 +54,9 @@ import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfMessageNodeGen.IfFalseMessageNodeFactory;
 import trufflesom.interpreter.nodes.specialized.IfMessageNodeGen.IfTrueMessageNodeFactory;
 import trufflesom.interpreter.nodes.specialized.IfNilInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfNilNotNilInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfNotNilInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfNotNilNilInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.FalseIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.TrueIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseMessageNodeFactory;
@@ -315,6 +317,8 @@ public final class Primitives extends PrimitiveLoader<ExpressionNode, SSymbol> {
     nodes.add(IfInlinedLiteralNode.class);
     nodes.add(IfNilInlinedLiteralNode.class);
     nodes.add(IfNotNilInlinedLiteralNode.class);
+    nodes.add(IfNilNotNilInlinedLiteralNode.class);
+    nodes.add(IfNotNilNilInlinedLiteralNode.class);
     nodes.add(TrueIfElseLiteralNode.class);
     nodes.add(FalseIfElseLiteralNode.class);
     nodes.add(AndInlinedLiteralNode.class);

--- a/tests/trufflesom/tests/AstInliningTests.java
+++ b/tests/trufflesom/tests/AstInliningTests.java
@@ -30,6 +30,10 @@ import trufflesom.interpreter.nodes.literals.IntegerLiteralNode;
 import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.AndInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.BooleanInlinedLiteralNode.OrInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfNilInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfNilNotNilInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfNotNilInlinedLiteralNode;
+import trufflesom.interpreter.nodes.specialized.IfNotNilNilInlinedLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.FalseIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IfTrueIfFalseInlinedLiteralsNode.TrueIfElseLiteralNode;
 import trufflesom.interpreter.nodes.specialized.IntToDoInlinedLiteralsNode;
@@ -318,6 +322,29 @@ public class AstInliningTests extends AstTestSetup {
   public void testIfTrueIfFalseReturn() {
     ifTrueIfFalseReturn("ifTrue:", "ifFalse:", TrueIfElseLiteralNode.class);
     ifTrueIfFalseReturn("ifFalse:", "ifTrue:", FalseIfElseLiteralNode.class);
+  }
+
+  private void ifNil(final String sel, final Class<?> cls) {
+    SequenceNode seq = (SequenceNode) parseMethod(
+        "test: arg1 = (\n"
+            + "   #start.\n"
+            + "   ^ self method " + sel + " [ arg1 ]\n"
+            + "   )");
+
+    Node ifNode = read(seq, "expressions", 1);
+    assertThat(ifNode, instanceOf(cls));
+  }
+
+  @Test
+  public void testIfNil() {
+    ifNil("ifNil:", IfNilInlinedLiteralNode.class);
+    ifNil("ifNotNil:", IfNotNilInlinedLiteralNode.class);
+  }
+
+  @Test
+  public void testIfNilIfNotNil() {
+    ifTrueIfFalseReturn("ifNil:", "ifNotNil:", IfNilNotNilInlinedLiteralNode.class);
+    ifTrueIfFalseReturn("ifNotNil:", "ifNil:", IfNotNilNilInlinedLiteralNode.class);
   }
 
   private void whileInlining(final String whileSel, final boolean expectedBool) {

--- a/tests/trufflesom/tests/BytecodeMethodTests.java
+++ b/tests/trufflesom/tests/BytecodeMethodTests.java
@@ -2,7 +2,6 @@ package trufflesom.tests;
 
 import static org.junit.Assert.assertEquals;
 import static trufflesom.vm.SymbolTable.strSelf;
-import static trufflesom.vm.SymbolTable.symSelf;
 import static trufflesom.vm.SymbolTable.symbolFor;
 
 import org.junit.Ignore;
@@ -253,6 +252,8 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
   public void testIfArg() {
     ifArg("ifTrue:", Bytecodes.JUMP_ON_FALSE_TOP_NIL);
     ifArg("ifFalse:", Bytecodes.JUMP_ON_TRUE_TOP_NIL);
+    ifArg("ifNil:", Bytecodes.JUMP_ON_NOT_NIL_TOP_TOP);
+    ifArg("ifNotNil:", Bytecodes.JUMP_ON_NIL_TOP_TOP);
   }
 
   @Test
@@ -636,7 +637,13 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
   }
 
   @Test
-  public void testIfPushConsantSame() {
+  public void testIfNilIfNotNilReturn() {
+    ifTrueIfFalseReturn("ifNil:", "ifNotNil:", Bytecodes.JUMP_ON_NOT_NIL_POP);
+    ifTrueIfFalseReturn("ifNotNil:", "ifNil:", Bytecodes.JUMP_ON_NIL_POP);
+  }
+
+  @Test
+  public void testIfPushConstantSame() {
     byte[] bytecodes = methodToBytecodes(
         "test = (\n"
             + "  #a. #b. #c. #d.\n"

--- a/tests/trufflesom/tests/BytecodeMethodTests.java
+++ b/tests/trufflesom/tests/BytecodeMethodTests.java
@@ -883,7 +883,7 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
         Bytecodes.RETURN_SELF);
   }
 
-  @Ignore("TODO")
+  @Ignore("to:do: inlining isn't implemented yet")
   @Test
   public void testToDoBlockBlockInlinedSelf() {
     addField("field");
@@ -898,8 +898,8 @@ public class BytecodeMethodTests extends BytecodeTestSetup {
             + ")");
 
     check(bytecodes,
-        Bytecodes.PUSH_CONSTANT,
-        Bytecodes.PUSH_CONSTANT,
+        Bytecodes.PUSH_1,
+        Bytecodes.PUSH_CONSTANT_0,
         -1, // TODO: Bytecodes.DUP_SECOND, // stack: Top[1, 2, 1]
         -1, // TODO new BC(Bytecodes.jump_if_greater, 21), // consume only on jump
         Bytecodes.DUP,


### PR DESCRIPTION
This implements inlining in the AST and bytecode interpreters.