### PR TITLE
Update to Truffle of 2026-04-02 and Update Oracle GraalVM and JDK Versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,8 +6,8 @@ stages:
 variables:
   PYTHONUNBUFFERED: "true"
   JVMCI_VERSION_CHECK: ignore
-  GRAALEE_VERSION: oracle-graalvm-ea-jdk-25.0.0-ea.36
-  JAVA_VERSION: temurin-24.0.2+12
+  GRAALEE_VERSION: oracle-graalvm-ea-jdk-25e1-25.0.2-ea.20
+  JAVA_VERSION: temurin-25.0.2+10.0.LTS
 
 .shared-scripts:
   download-binaries: &DOWNLOAD_BINARIES |

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "cbb1b8c08127400cb41a48d70f1baf51bf2e21c9",
+                "version": "2a1f00ba7227ff8e2bddb1d0d5c2cf6b8fee82bf",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]


### PR DESCRIPTION
This now brings EE to the level to support the earlier Truffle changes here https://github.com/SOM-st/TruffleSOM/pull/241

And indeed also gives a good boost to the bytecode interpreter:
https://rebench.dev/TruffleSOM/compare/1456c55cbe4ed98e9c29e75ae98680a714e59dcd..b109a666d898586a76ac32c6416a063c70eafb80