### PR TITLE
Update Truffle to version of 2026-05-23

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,7 @@ benchmark-y1:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria
+    - rebench -f -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria
   after_script:

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "2f0bd1c316c776369bcf6b6feb711a6dc385eade",
+                "version": "3b5da51428289dd1ca1131427a1984e1efabd742",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]


### PR DESCRIPTION
This seems to have some performance regressions:

https://rebench.dev/TruffleSOM/compare/526a2e230f1ee09c540c4ff2e00eda67ea257ca6..4d27b73de40433ee26c155370fcb93a285bb5b5b

This also allows profiling to fail on yuria. It now seems to occasionally crash perf. Could not reproduce it directly or after recompilation though.