### PR TITLE
Update Truffle to version of 2026-08-01 and allow perf to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ benchmark-y2:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria2
+    - rebench -f -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria2
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria2
   after_script:
@@ -194,7 +194,7 @@ benchmark-y3:
     - *DOWNLOAD_BINARIES
 
     # Profile
-    - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria3
+    - rebench -f -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf profiling t:yuria3
     # Run Benchmarks
     - rebench -c --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" rebench.conf t:yuria3
   after_script:

--- a/mx.trufflesom/suite.py
+++ b/mx.trufflesom/suite.py
@@ -16,7 +16,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "08d9647c7763f8b14fc59dc9afd93d3e305e2b3e",
+                "version": "5262f5645f86b378b7b1e006d1b367da6018b5dc",
                 "urls": [{"url": "https://github.com/oracle/graal", "kind": "git"}],
             },
         ]


### PR DESCRIPTION
Now that yuria2 and 3 are on Ubuntu 24.04, perf fails there as it does on the other machines.